### PR TITLE
Fixes compile error if VGM_USE_MP4V2 and VGM_USE_FDKAAC are not defined

### DIFF
--- a/src/coding/coding.h
+++ b/src/coding/coding.h
@@ -71,7 +71,9 @@ void decode_maxis_adpcm(VGMSTREAM * vgmstream, sample * outbuf, int channelspaci
 void decode_ogg_vorbis(ogg_vorbis_codec_data * data, sample * outbuf, int32_t samples_to_do, int channels);
 #endif
 
+#if defined(VGM_USE_MP4V2) && defined(VGM_USE_FDKAAC)
 void decode_mp4_aac(mp4_aac_codec_data * data, sample * outbuf, int32_t samples_to_do, int channels);
+#endif 
 
 void decode_sdx2(VGMSTREAMCHANNEL * stream, sample * outbuf, int channelspacing, int32_t first_sample, int32_t samples_to_do);
 void decode_sdx2_int(VGMSTREAMCHANNEL * stream, sample * outbuf, int channelspacing, int32_t first_sample, int32_t samples_to_do);


### PR DESCRIPTION
Hi, when compiling on linux I noticed a compiler error for any file that included the header below.  
