### PR TITLE
Opus txth etc

### DIFF
--- a/doc/TXTH.md
+++ b/doc/TXTH.md
@@ -366,10 +366,11 @@ Sets the name of the stream, most useful when used with subsongs. TXTH will read
 
 `name_size` defaults to 0, which reads until null-terminator or a non-ascii character is found.
 
-`name_offset` can be a (number) value, but being an offset it's also adjusted by `subsong_spacing`.
+`name_offset` can be a (number) value, but being an offset it's also adjusted by `subsong_spacing`. If you need to point to some absolute offset (for example a subsong pointings to name in another table) that doesn't depend on subsong (must not be changed by `subsong_spacing`), use `name_offset_absolute`.
 ```
 name_offset = (value)
 name_size = (value)
+name_offset_absolute = (value)
 ```
 
 #### SUBFILES
@@ -853,7 +854,6 @@ JIN002.XAG: 0x168
 JIN003.XAG: 0x180
 ```
 
-
 #### Grandia (PS1) bgm.txth
 ```
 header_file       = GM1.IDX
@@ -903,7 +903,6 @@ st_s01_02b.ssd: 6*0x04
 st_s01_02c.ssd: 7*0x04
 ```
 
-
 #### Zack & Wiki (Wii) st_s01_00a.txth
 ```
 #alt from above with untouched folders
@@ -943,7 +942,7 @@ coef_endianness = BE
 # uses wildcards for full paths from plugins
 ```
 
-####  Croc (SAT) .asf.txth
+#### Croc (SAT) .asf.txth
 ```
 codec = ASF
 sample_rate = 22050
@@ -951,7 +950,7 @@ channels = 2
 num_samples = data_size
 ```
 
-####  Sega Rally 3 (SAT) ALL_SOUND.txth
+#### Sega Rally 3 (SAT) ALL_SOUND.txth
 ```
 codec             = PCM16LE
 
@@ -993,7 +992,8 @@ subsong_spacing   = 0xc8
 
 start_offset      = @0xc4 + 0xc0
 ```
-####  Sega Rally 3 (PC) EnglishStream.txth
+
+#### Sega Rally 3 (PC) EnglishStream.txth
 ```
 codec             = PCM16LE
 
@@ -1029,4 +1029,26 @@ base_offset       = @0x108
 subsong_spacing   = 0xc8
 
 start_offset      = @0xc4 + 0xc0
+```
+
+#### Starsky & Hutch (PS2) MUSICPS2.WAD.txth
+```
+codec = PSX
+channels = 1
+sample_type = bytes
+
+header_file = MUSICPS2.WAD
+body_file   = MUSICPS2.WAD
+
+subsong_count     = 0xC
+subsong_spacing   = 0x30
+sample_rate       = 32000
+base_offset       = 0x70
+start_offset      = @0x14 + 0x380
+num_samples       = @0x18
+data_size         = num_samples
+loop_flag         = auto
+
+#@0x10 is an absolute offset to another table, that shouldn't be affected by subsong_spacing
+name_offset_absolute = @0x10 + 0x270
 ```

--- a/src/coding/coding.h
+++ b/src/coding/coding.h
@@ -540,14 +540,18 @@ typedef struct {
     int coupled_count;
     int stream_count;
     int channel_mapping[8];
+    /* frame table */
+    off_t table_offset;
+    int table_count;
 } opus_config;
 
 ffmpeg_codec_data* init_ffmpeg_switch_opus_config(STREAMFILE* sf, off_t start_offset, size_t data_size, opus_config* cfg);
 ffmpeg_codec_data* init_ffmpeg_switch_opus(STREAMFILE* sf, off_t start_offset, size_t data_size, int channels, int skip, int sample_rate);
 ffmpeg_codec_data* init_ffmpeg_ue4_opus(STREAMFILE* sf, off_t start_offset, size_t data_size, int channels, int skip, int sample_rate);
 ffmpeg_codec_data* init_ffmpeg_ea_opus(STREAMFILE* sf, off_t start_offset, size_t data_size, int channels, int skip, int sample_rate);
-ffmpeg_codec_data* init_ffmpeg_x_opus(STREAMFILE* sf, off_t start_offset, size_t data_size, int channels, int skip, int sample_rate);
+ffmpeg_codec_data* init_ffmpeg_x_opus(STREAMFILE* sf, off_t table_offset, int table_count, off_t data_offset, size_t data_size, int channels, int skip);
 ffmpeg_codec_data* init_ffmpeg_fsb_opus(STREAMFILE* sf, off_t start_offset, size_t data_size, int channels, int skip, int sample_rate);
+ffmpeg_codec_data* init_ffmpeg_wwise_opus(STREAMFILE* sf, off_t table_offset, int table_count, off_t data_offset, size_t data_size, int channels, int skip);
 
 size_t switch_opus_get_samples(off_t offset, size_t stream_size, STREAMFILE* sf);
 

--- a/src/formats.c
+++ b/src/formats.c
@@ -1314,6 +1314,7 @@ static const meta_info meta_info_list[] = {
         {meta_SDRH,                 "feelplus SDRH header"},
         {meta_WADY,                 "Marble WADY header"},
         {meta_DSP_SQEX,             "Square Enix DSP header"},
+        {meta_DSP_WIIVOICE,         "Koei Tecmo WiiVoice header"},
 };
 
 void get_vgmstream_coding_description(VGMSTREAM* vgmstream, char* out, size_t out_size) {

--- a/src/meta/awb.c
+++ b/src/meta/awb.c
@@ -180,10 +180,11 @@ static void load_awb_name(STREAMFILE* sf, STREAMFILE* sf_acb, VGMSTREAM* vgmstre
 
         /* try parsing TXTM if present */
         sf_acb = read_filemap_file(sf_acb, 0);
-        if (sf_acb) return sf_acb;
 
         /* try (name).awb + (name).awb */
-        sf_acb = open_streamfile_by_ext(sf, "acb");
+        if (!sf_acb) {
+            sf_acb = open_streamfile_by_ext(sf, "acb");
+        }
 
         /* try (name)_streamfiles.awb + (name).acb */
         if (!sf_acb) {

--- a/src/meta/ea_schl.c
+++ b/src/meta/ea_schl.c
@@ -802,11 +802,11 @@ VGMSTREAM * init_vgmstream_ea_mpf_mus(STREAMFILE* sf) {
     VGMSTREAM* vgmstream = NULL;
     STREAMFILE* sf_mus = NULL;
     segmented_layout_data *data_s = NULL;
-    uint32_t track_start, track_end, track_hash, tracks_table, samples_table, section_offset, entry_offset, eof_offset, off_mult, sound_offset;
+    uint32_t track_start, track_end = 0, track_hash = 0, tracks_table, samples_table = 0, section_offset, entry_offset = 0, eof_offset = 0, off_mult, sound_offset;
     uint16_t num_nodes;
-    uint8_t version, sub_version, num_tracks, num_sections, num_events, num_routers, num_vars, subentry_num;
-    int32_t(*read_u32)(off_t, STREAMFILE*);
-    int16_t(*read_u16)(off_t, STREAMFILE*);
+    uint8_t version, sub_version, num_tracks, num_sections, num_events, num_routers, num_vars, subentry_num = 0;
+    uint32_t(*read_u32)(off_t, STREAMFILE*);
+    uint16_t(*read_u16)(off_t, STREAMFILE*);
     int i;
     int target_stream = sf->stream_index, total_streams, big_endian, is_bnk = 0;
 
@@ -997,7 +997,7 @@ VGMSTREAM * init_vgmstream_ea_mpf_mus(STREAMFILE* sf) {
         if (version == 5 && bnk_index != 0) {
             /* HACK: open proper .mus now since open_mapfile_pair doesn't let us adjust the name */
             char filename[PATH_LIMIT], basename[PATH_LIMIT], ext[32];
-            int basename_len, fileext_len;
+            int basename_len;
 
             get_streamfile_basename(sf_mus, basename, PATH_LIMIT);
             basename_len = strlen(basename);

--- a/src/meta/meta.h
+++ b/src/meta/meta.h
@@ -887,7 +887,8 @@ VGMSTREAM* init_vgmstream_fda(STREAMFILE *sf);
 
 VGMSTREAM * init_vgmstream_tgc(STREAMFILE *streamFile);
 
-VGMSTREAM * init_vgmstream_kwb(STREAMFILE* sf);
+VGMSTREAM* init_vgmstream_kwb(STREAMFILE* sf);
+VGMSTREAM* init_vgmstream_xws(STREAMFILE* sf);
 
 VGMSTREAM * init_vgmstream_lrmd(STREAMFILE* sf);
 

--- a/src/meta/meta.h
+++ b/src/meta/meta.h
@@ -54,7 +54,8 @@ VGMSTREAM* init_vgmstream_dsp_adpy(STREAMFILE* sf);
 VGMSTREAM* init_vgmstream_dsp_adpx(STREAMFILE* sf);
 VGMSTREAM* init_vgmstream_dsp_ds2(STREAMFILE* sf);
 VGMSTREAM* init_vgmstream_dsp_itl(STREAMFILE* sf);
-VGMSTREAM* init_vgmstream_dsp_sqex(STREAMFILE *sf);
+VGMSTREAM* init_vgmstream_dsp_sqex(STREAMFILE* sf);
+VGMSTREAM* init_vgmstream_dsp_wiivoice(STREAMFILE* sf);
 
 VGMSTREAM * init_vgmstream_csmp(STREAMFILE *streamFile);
 

--- a/src/meta/ngc_dsp_std.c
+++ b/src/meta/ngc_dsp_std.c
@@ -1278,3 +1278,31 @@ VGMSTREAM* init_vgmstream_dsp_sqex(STREAMFILE* sf) {
 fail:
     return NULL;
 }
+
+/* WiiVoice - Koei Tecmo wrapper [Fatal Frame 5 (WiiU)] */
+VGMSTREAM* init_vgmstream_dsp_wiivoice(STREAMFILE* sf) {
+    dsp_meta dspm = {0};
+    /* also see g1l.c for WiiBGM weirder variation */
+
+    /* checks */
+    /* .dsp: assumed */
+    if (!check_extensions(sf, "dsp"))
+        goto fail;
+    if (read_u32be(0x00,sf) != 0x57696956 &&    /* "WiiV" */
+        read_u32be(0x04,sf) != 0x6F696365)      /* "oice" */
+        goto fail;
+
+    dspm.channel_count = 1;
+    dspm.max_channels = 1;
+
+    dspm.header_offset = read_u32be(0x08,sf);
+    /* 0x10: file size */
+    /* 0x14: data size */
+    dspm.header_spacing = 0x60;
+    dspm.start_offset = dspm.header_offset + dspm.header_spacing*dspm.channel_count;
+
+    dspm.meta_type = meta_DSP_WIIVOICE;
+    return init_vgmstream_dsp_common(sf, &dspm);
+fail:
+    return NULL;
+}

--- a/src/meta/riff.c
+++ b/src/meta/riff.c
@@ -412,6 +412,9 @@ VGMSTREAM* init_vgmstream_riff(STREAMFILE* sf) {
 
         else if (codec == 0x0011 && (riff_size / 2 / 2 == read_32bitLE(0x30,sf))) /* riff_size = pcm_size (always stereo, has fact at 0x30) */
             riff_size = file_size - 0x08; /* [Asphalt 6 (iOS)] (sfx/memory wavs have ok sizes?) */
+
+        else if (codec == 0xFFFE && riff_size + 0x08 + 0x30 == file_size)
+            riff_size += 0x30; /* [E.X. Troopers (PS3)] (adds "ver /eBIT/tIME/mrkr" empty chunks but RIFF size wasn't updated) */
     }
 
     /* check for truncated RIFF */

--- a/src/meta/txth.c
+++ b/src/meta/txth.c
@@ -1154,6 +1154,13 @@ static int parse_keyval(STREAMFILE* sf_, txth_header* txth, const char * key, ch
         if (txth->subsong_spacing)
             txth->name_offset += txth->subsong_spacing * (txth->target_subsong - 1);
     }
+    else if (is_string(key,"name_offset_absolute")) {
+        if (!parse_num(txth->sf_head,txth,val, &txth->name_offset)) goto fail;
+        txth->name_offset_set = 1;
+        /* special adjustment */
+        txth->name_offset += txth->base_offset;
+        /* unlike the above this is meant for reads that point to somewhere in the file, regardless subsong number */
+    }
     else if (is_string(key,"name_size")) {
         if (!parse_num(txth->sf_head,txth,val, &txth->name_size)) goto fail;
     }
@@ -1561,7 +1568,7 @@ static int parse_num(STREAMFILE* sf, txth_header* txth, const char * val, uint32
     uint32_t value_div = txth->value_div;
     uint32_t value_add = txth->value_add;
     uint32_t value_sub = txth->value_sub;
-    uint32_t subsong_offset = txth->subsong_spacing;
+    uint32_t subsong_spacing = txth->subsong_spacing;
 
     char op = ' ';
     int brackets = 0;
@@ -1626,8 +1633,8 @@ static int parse_num(STREAMFILE* sf, txth_header* txth, const char * val, uint32
             else if (!(ed1 == 'L' && ed2 == 'E'))
                 goto fail;
 
-            if (subsong_offset)
-                offset = offset + subsong_offset * (txth->target_subsong - 1);
+            if (subsong_spacing)
+                offset = offset + subsong_spacing * (txth->target_subsong - 1);
 
             switch(size) {
                 case 1: value = (uint8_t)read_8bit(offset,sf); break;
@@ -1658,8 +1665,8 @@ static int parse_num(STREAMFILE* sf, txth_header* txth, const char * val, uint32
             else if ((n = is_string_field(val,"loop_end_sample")))      value = txth->loop_end_sample;
             else if ((n = is_string_field(val,"loop_end")))             value = txth->loop_end_sample;
             else if ((n = is_string_field(val,"subsong_count")))        value = txth->subsong_count;
-            else if ((n = is_string_field(val,"subsong_offset")))       value = txth->subsong_spacing;
             else if ((n = is_string_field(val,"subsong_spacing")))      value = txth->subsong_spacing;
+            else if ((n = is_string_field(val,"subsong_offset")))       value = txth->subsong_spacing;
             else if ((n = is_string_field(val,"subfile_offset")))       value = txth->subfile_offset;
             else if ((n = is_string_field(val,"subfile_size")))         value = txth->subfile_size;
             else if ((n = is_string_field(val,"base_offset")))          value = txth->base_offset;

--- a/src/meta/wwise.c
+++ b/src/meta/wwise.c
@@ -16,11 +16,21 @@ typedef struct {
     int truncated;
 
     /* chunks references */
-    off_t fmt_offset;
+    off_t  fmt_offset;
     size_t fmt_size;
-    off_t data_offset;
+    off_t  data_offset;
     size_t data_size;
-    off_t chunk_offset;
+    off_t  xma2_offset;
+    size_t xma2_size;
+    off_t  vorb_offset;
+    size_t vorb_size;
+    off_t  wiih_offset;
+    size_t wiih_size;
+    off_t  smpl_offset;
+    size_t smpl_size;
+    off_t  seek_offset;
+    size_t seek_size;
+
 
     /* standard fmt stuff */
     wwise_codec codec;
@@ -39,16 +49,19 @@ typedef struct {
     int32_t loop_end_sample;
 } wwise_header;
 
+static int parse_wwise(STREAMFILE* sf, wwise_header* ww);
 static int is_dsp_full_interleave(STREAMFILE* sf, wwise_header* ww, off_t coef_offset);
 
 
 /* Wwise - Audiokinetic Wwise (Wave Works Interactive Sound Engine) middleware */
-VGMSTREAM * init_vgmstream_wwise(STREAMFILE* sf) {
-    VGMSTREAM * vgmstream = NULL;
+VGMSTREAM* init_vgmstream_wwise(STREAMFILE* sf) {
+    VGMSTREAM* vgmstream = NULL;
     wwise_header ww = {0};
-    off_t start_offset, first_offset = 0xc;
-    int32_t (*read_32bit)(off_t,STREAMFILE*) = NULL;
-    int16_t (*read_16bit)(off_t,STREAMFILE*) = NULL;
+    off_t start_offset;
+    uint32_t (*read_u32)(off_t,STREAMFILE*) = NULL;
+     int32_t (*read_s32)(off_t,STREAMFILE*) = NULL;
+    uint16_t (*read_u16)(off_t,STREAMFILE*) = NULL;
+
 
     /* checks */
     /* .wem: newer "Wwise Encoded Media" used after the 2011.2 SDK (~july 2011)
@@ -59,199 +72,27 @@ VGMSTREAM * init_vgmstream_wwise(STREAMFILE* sf) {
     if (!check_extensions(sf,"wem,wav,lwav,ogg,logg,xma,bnk"))
         goto fail;
 
-    if (read_32bitBE(0x00,sf) != 0x52494646 &&  /* "RIFF" (LE) */
-        read_32bitBE(0x00,sf) != 0x52494658)    /* "RIFX" (BE) */
-        goto fail;
-    if (read_32bitBE(0x08,sf) != 0x57415645 &&  /* "WAVE" */
-        read_32bitBE(0x08,sf) != 0x58574D41)    /* "XWMA" */
+    if (!parse_wwise(sf, &ww))
         goto fail;
 
-    ww.big_endian = read_32bitBE(0x00,sf) == 0x52494658; /* RIFX */
-    if (ww.big_endian) { /* Wwise honors machine's endianness (PC=RIFF, X360=RIFX --unlike XMA) */
-        read_32bit = read_32bitBE;
-        read_16bit = read_16bitBE;
-    } else {
-        read_32bit = read_32bitLE;
-        read_16bit = read_16bitLE;
-    }
-
-    ww.file_size = sf->get_size(sf);
-
-#if 0
-    /* Wwise's RIFF size is often wonky, seemingly depending on codec:
-     * - PCM, IMA/PTADPCM, VORBIS, AAC, OPUSNX/OPUS: correct
-     * - DSP, XWMA, ATRAC9: almost always slightly smaller (around 0x50)
-     * - HEVAG: very off
-     * - XMA2: exact file size
-     * - some RIFX have LE size
-     * (later we'll validate "data" which fortunately is correct)
-     */
-    if (read_32bit(0x04,sf)+0x04+0x04 != ww.file_size) {
-        VGM_LOG("WWISE: bad riff size (real=0x%x vs riff=0x%x)\n", read_32bit(0x04,sf)+0x04+0x04, ww.file_size);
-        goto fail;
-    }
-#endif
-
-    /* ignore LyN RIFF */
-    {
-        off_t fact_offset;
-        size_t fact_size;
-
-        if (find_chunk(sf, 0x66616374,first_offset,0, &fact_offset,&fact_size, 0, 0)) { /* "fact" */
-            if (fact_size == 0x10 && read_32bitBE(fact_offset+0x04, sf) == 0x4C794E20) /* "LyN " */
-                goto fail; /* parsed elsewhere */
-        }
-        /* Wwise doesn't use "fact", though */
-    }
-
-    /* parse format (roughly spec-compliant but some massaging is needed) */
-    {
-        off_t loop_offset;
-        size_t loop_size;
-
-        /* find basic chunks */
-        if (read_32bitBE(0x0c, sf) == 0x584D4132) { /* "XMA2" with no "fmt" [Too Human (X360)] */
-            ww.format = 0x0165; /* signal for below */
-        }
-        else {
-            if (!find_chunk(sf, 0x666d7420,first_offset,0, &ww.fmt_offset,&ww.fmt_size, ww.big_endian, 0)) /* "fmt " */
-                goto fail;
-            if (ww.fmt_size < 0x10)
-                goto fail;
-            ww.format = (uint16_t)read_16bit(ww.fmt_offset+0x00,sf);
-        }
-
-
-        if (ww.format == 0x0165) {
-            /* pseudo-XMA2WAVEFORMAT ("fmt"+"XMA2" or just "XMA2) */
-            if (!find_chunk(sf, 0x584D4132,first_offset,0, &ww.chunk_offset,NULL, ww.big_endian, 0)) /* "XMA2" */
-                goto fail;
-            xma2_parse_xma2_chunk(sf, ww.chunk_offset,&ww.channels,&ww.sample_rate, &ww.loop_flag, &ww.num_samples, &ww.loop_start_sample, &ww.loop_end_sample);
-        }
-        else {
-            /* pseudo-WAVEFORMATEX */
-            ww.channels         = read_16bit(ww.fmt_offset+0x02,sf);
-            ww.sample_rate      = read_32bit(ww.fmt_offset+0x04,sf);
-            ww.average_bps      = read_32bit(ww.fmt_offset+0x08,sf);/* bytes per sec */
-            ww.block_align      = (uint16_t)read_16bit(ww.fmt_offset+0x0c,sf);
-            ww.bits_per_sample   = (uint16_t)read_16bit(ww.fmt_offset+0x0e,sf);
-            if (ww.fmt_size > 0x10 && ww.format != 0x0165 && ww.format != 0x0166) /* ignore XMAWAVEFORMAT */
-                ww.extra_size   = (uint16_t)read_16bit(ww.fmt_offset+0x10,sf);
-            if (ww.extra_size >= 0x06) { /* always present (actual RIFFs only have it in WAVEFORMATEXTENSIBLE) */
-                /* mostly WAVEFORMATEXTENSIBLE's bitmask (see AkSpeakerConfig.h) */
-                ww.channel_layout = read_32bit(ww.fmt_offset+0x14,sf);
-                /* later games (+2018?) have a pseudo-format instead to handle more cases:
-                 * - 8b: uNumChannels
-                 * - 4b: eConfigType  (0=none, 1=standard, 2=ambisonic)
-                 * - 19b: uChannelMask */
-                if ((ww.channel_layout & 0xFF) == ww.channels) {
-                    ww.channel_layout = (ww.channel_layout >> 12);
-                }
-            }
-        }
-
-        /* find loop info ("XMA2" chunks already read them) */
-        if (ww.format == 0x0166) { /* XMA2WAVEFORMATEX in fmt */
-            ww.chunk_offset = ww.fmt_offset;
-            xma2_parse_fmt_chunk_extra(sf, ww.chunk_offset, &ww.loop_flag, &ww.num_samples, &ww.loop_start_sample, &ww.loop_end_sample, ww.big_endian);
-        }
-        else if (find_chunk(sf, 0x736D706C,first_offset,0, &loop_offset,&loop_size, ww.big_endian, 0)) { /* "smpl", common */
-            if (loop_size >= 0x34
-                    && read_32bit(loop_offset+0x1c, sf)==1        /* loop count */
-                    && read_32bit(loop_offset+0x24+4, sf)==0) {
-                ww.loop_flag = 1;
-                ww.loop_start_sample = read_32bit(loop_offset+0x24+0x8, sf);
-                ww.loop_end_sample   = read_32bit(loop_offset+0x24+0xc, sf) + 1; /* like standard RIFF */
-            }
-        }
-        //else if (find_chunk(sf, 0x4C495354,first_offset,0, &loop_offset,&loop_size, ww.big_endian, 0)) { /*"LIST", common */
-        //    /* usually contains "cue"s with sample positions for events (ex. Platinum Games) but no real looping info */
-        //}
-
-        /* other chunks:
-         * "JUNK": optional padding for aligment (0-size JUNK exists too), also in regular RIFF
-         * "akd ": seem to store extra info for Wwise editor (wave peaks/loudness/HDR envelope?)
-         */
-
-        if (!find_chunk(sf, 0x64617461,first_offset,0, &ww.data_offset,&ww.data_size, ww.big_endian, 0)) /* "data" */
-            goto fail;
-    }
-
-    /* format to codec */
-    switch(ww.format) {
-        case 0x0001: ww.codec = PCM; break; /* older Wwise */
-        case 0x0002: ww.codec = IMA; break; /* newer Wwise (conflicts with MSADPCM, probably means "platform's ADPCM") */
-        case 0x0069: ww.codec = IMA; break; /* older Wwise [Spiderman Web of Shadows (X360), LotR Conquest (PC)] */
-        case 0x0161: ww.codec = XWMA; break; /* WMAv2 */
-        case 0x0162: ww.codec = XWMA; break; /* WMAPro */
-        case 0x0165: ww.codec = XMA2; break; /* XMA2-chunk XMA (Wwise doesn't use XMA1) */
-        case 0x0166: ww.codec = XMA2; break; /* fmt-chunk XMA */
-        case 0xAAC0: ww.codec = AAC; break;
-        case 0xFFF0: ww.codec = DSP; break;
-        case 0xFFFB: ww.codec = HEVAG; break;
-        case 0xFFFC: ww.codec = ATRAC9; break;
-        case 0xFFFE: ww.codec = PCM; break; /* "PCM for Wwise Authoring" */
-        case 0xFFFF: ww.codec = VORBIS; break;
-        case 0x3039: ww.codec = OPUSNX; break; /* renamed from "OPUS" on Wwise 2018.1 */
-        case 0x3040: ww.codec = OPUS; break;
-        case 0x3041: ww.codec = OPUSWW; break; /* added on Wwise 2019.2.3, presumably replaces OPUS */
-        case 0x8311: ww.codec = PTADPCM; break; /* newer, rare [Genshin Impact (PC)] */
-        default:
-            goto fail;
-    }
-
-    /* identify system's ADPCM */
-    if (ww.format == 0x0002) {
-        if (ww.extra_size == 0x0c + ww.channels * 0x2e) {
-            /* newer Wwise DSP with coefs [Epic Mickey 2 (Wii), Batman Arkham Origins Blackgate (3DS)] */
-            ww.codec = DSP;
-        } else if (ww.extra_size == 0x0a && find_chunk(sf, 0x57696948, first_offset,0, NULL,NULL, ww.big_endian, 0)) { /* WiiH */
-            /* few older Wwise DSP with num_samples in extra_size [Tony Hawk: Shred (Wii)] */
-            ww.codec = DSP;
-        } else if (ww.block_align == 0x104 * ww.channels) {
-            ww.codec = PTADPCM; /* Bayonetta 2 (Switch) */
-        }
-    }
-
-
-    /* Some Wwise .bnk (RAM) files have truncated, prefetch mirrors of another file, that
-     * play while the rest of the real stream loads. We'll add basic support to avoid
-     * complaints of this or that .wem not playing */
-    if (ww.data_offset + ww.data_size > ww.file_size) {
-        //VGM_LOG("WWISE: truncated data size (prefetch): (real=0x%x > riff=0x%x)\n", ww.data_size, ww.file_size);
-
-        /* catch wrong rips as truncated tracks' file_size should be much smaller than data_size,
-         * but it's possible to pre-fetch small files too [Punch Out!! (Wii)] */
-        if (ww.data_offset + ww.data_size - ww.file_size < 0x5000 && ww.file_size > 0x10000) {
-            VGM_LOG("WWISE: wrong expected data_size\n");
-            goto fail;
-        }
-
-        if (ww.codec == PCM || ww.codec == IMA || ww.codec == VORBIS || ww.codec == DSP || ww.codec == XMA2 ||
-            ww.codec == OPUSNX || ww.codec == OPUS || ww.codec == OPUSWW || ww.codec == PTADPCM) {
-            ww.truncated = 1; /* only seen those, probably all exist (XWMA, AAC, HEVAG, ATRAC9?) */
-        } else {
-            VGM_LOG("WWISE: wrong size, maybe truncated\n");
-            goto fail;
-        }
-    }
-
+    read_u32 = ww.big_endian ? read_u32be : read_u32le;
+    read_s32 = ww.big_endian ? read_s32be : read_s32le;
+    read_u16 = ww.big_endian ? read_u16be : read_u16le;
 
     start_offset = ww.data_offset;
 
     /* build the VGMSTREAM */
-    vgmstream = allocate_vgmstream(ww.channels,ww.loop_flag);
+    vgmstream = allocate_vgmstream(ww.channels, ww.loop_flag);
     if (!vgmstream) goto fail;
 
+    vgmstream->meta_type = meta_WWISE_RIFF;
     vgmstream->sample_rate = ww.sample_rate;
     vgmstream->loop_start_sample = ww.loop_start_sample;
     vgmstream->loop_end_sample = ww.loop_end_sample;
     vgmstream->channel_layout = ww.channel_layout;
-    vgmstream->meta_type = meta_WWISE_RIFF;
 
     switch(ww.codec) {
         case PCM: /* common */
-VGM_LOG("1\n");
             /* normally riff.c has priority but it's needed when .wem is used */
             if (ww.fmt_size != 0x10 && ww.fmt_size != 0x18 && ww.fmt_size != 0x28) goto fail; /* old, new/Limbo (PC) */
             if (ww.bits_per_sample != 16) goto fail;
@@ -297,10 +138,10 @@ VGM_LOG("1\n");
             break;
 
 #ifdef VGM_USE_VORBIS
-        case VORBIS: {  /* common */
+        case VORBIS: { /* common */
             /* Wwise uses custom Vorbis, which changed over time (config must be detected to pass to the decoder). */
-            off_t vorb_offset, data_offsets, block_offsets;
-            size_t vorb_size, setup_offset, audio_offset;
+            off_t data_offsets, block_offsets;
+            size_t setup_offset, audio_offset;
             vorbis_custom_config cfg = {0};
 
             cfg.channels = ww.channels;
@@ -310,10 +151,10 @@ VGM_LOG("1\n");
             if (ww.block_align != 0 || ww.bits_per_sample != 0) goto fail; /* always 0 for Worbis */
 
             /* autodetect format (fields are mostly common, see the end of the file) */
-            if (find_chunk(sf, 0x766F7262,first_offset,0, &vorb_offset,&vorb_size, ww.big_endian, 0)) { /* "vorb" */
+            if (ww.vorb_offset) {
                 /* older Wwise (~<2012) */
 
-                switch(vorb_size) {
+                switch(ww.vorb_size) {
                     case 0x2C: /* earliest (~2009) [The Lord of the Rings: Conquest (PC)] */
                     case 0x28: /* early (~2009) [UFC Undisputed 2009 (PS3), some EVE Online Apocrypha (PC)] */
                         data_offsets = 0x18;
@@ -341,22 +182,22 @@ VGM_LOG("1\n");
                         break;
 
                     default:
-                        VGM_LOG("WWISE: unknown vorb size 0x%x\n", vorb_size);
+                        VGM_LOG("WWISE: unknown vorb size 0x%x\n", ww.vorb_size);
                         goto fail;
                 }
 
-                vgmstream->num_samples = read_32bit(vorb_offset + 0x00, sf);
-                setup_offset    = read_32bit(vorb_offset + data_offsets + 0x00, sf); /* within data (0 = no seek table) */
-                audio_offset    = read_32bit(vorb_offset + data_offsets + 0x04, sf); /* within data */
+                vgmstream->num_samples = read_s32(ww.vorb_offset + 0x00, sf);
+                setup_offset = read_u32(ww.vorb_offset + data_offsets + 0x00, sf); /* within data (0 = no seek table) */
+                audio_offset = read_u32(ww.vorb_offset + data_offsets + 0x04, sf); /* within data */
                 if (block_offsets) {
-                    cfg.blocksize_1_exp = read_8bit(vorb_offset + block_offsets + 0x00, sf); /* small */
-                    cfg.blocksize_0_exp = read_8bit(vorb_offset + block_offsets + 0x01, sf); /* big */
+                    cfg.blocksize_1_exp = read_u8(ww.vorb_offset + block_offsets + 0x00, sf); /* small */
+                    cfg.blocksize_0_exp = read_u8(ww.vorb_offset + block_offsets + 0x01, sf); /* big */
                 }
                 ww.data_size -= audio_offset;
 
 
                 /* detect normal packets */
-                if (vorb_size == 0x2a) {
+                if (ww.vorb_size == 0x2a) {
                     /* almost all blocksizes are 0x08+0x0B except a few with 0x0a+0x0a [Captain America: Super Soldier (X360) voices/sfx] */
                     if (cfg.blocksize_0_exp == cfg.blocksize_1_exp)
                         cfg.packet_type = WWV_STANDARD;
@@ -366,12 +207,12 @@ VGM_LOG("1\n");
                  * - full inline: ~2009, ex. The King of Fighters XII (X360), The Saboteur (PC)
                  * - trimmed inline: ~2010, ex. Army of Two: 40 days (X360) some multiplayer files
                  * - external: ~2010, ex. Assassin's Creed Brotherhood (X360), Dead Nation (X360) */
-                if (vorb_size == 0x34) {
-                    size_t setup_size = (uint16_t)read_16bit(start_offset + setup_offset, sf);
-                    uint32_t id = (uint32_t)read_32bitBE(start_offset + setup_offset + 0x06, sf);
+                if (ww.vorb_size == 0x34) {
+                    size_t setup_size = read_u16  (start_offset + setup_offset + 0x00, sf);
+                    uint32_t setup_id = read_u32be(start_offset + setup_offset + 0x06, sf);
 
                     /* if the setup after header starts with "(data)BCV" it's an inline codebook) */
-                    if ((id & 0x00FFFFFF) == 0x00424356) { /* 0"BCV" */
+                    if ((setup_id & 0x00FFFFFF) == 0x00424356) { /* 0"BCV" */
                         cfg.setup_type = WWV_FULL_SETUP;
                     }
                     /* if the setup is suspiciously big it's probably trimmed inline codebooks */
@@ -402,15 +243,15 @@ VGM_LOG("1\n");
                         break;
 
                     default:
-                        VGM_LOG("WWISE: unknown extra size 0x%x\n", vorb_size);
+                        VGM_LOG("WWISE: unknown extra size 0x%x\n", ww.vorb_size);
                         goto fail;
                 }
 
-                vgmstream->num_samples = read_32bit(extra_offset + 0x00, sf);
-                setup_offset = read_32bit(extra_offset + data_offsets + 0x00, sf); /* within data */
-                audio_offset = read_32bit(extra_offset + data_offsets + 0x04, sf); /* within data */
-                cfg.blocksize_1_exp = read_8bit(extra_offset + block_offsets + 0x00, sf); /* small */
-                cfg.blocksize_0_exp = read_8bit(extra_offset + block_offsets + 0x01, sf); /* big */
+                vgmstream->num_samples = read_s32(extra_offset + 0x00, sf);
+                setup_offset = read_u32(extra_offset + data_offsets + 0x00, sf); /* within data */
+                audio_offset = read_u32(extra_offset + data_offsets + 0x04, sf); /* within data */
+                cfg.blocksize_1_exp = read_u8(extra_offset + block_offsets + 0x00, sf); /* small */
+                cfg.blocksize_0_exp = read_u8(extra_offset + block_offsets + 0x01, sf); /* big */
                 ww.data_size -= audio_offset;
 
                 /* detect normal packets */
@@ -445,10 +286,7 @@ VGM_LOG("1\n");
         }
 #endif
 
-        case DSP: {     /* Wii/3DS/WiiU */
-            off_t wiih_offset;
-            size_t wiih_size;
-
+        case DSP: { /* Wii/3DS/WiiU */
             //if (ww.fmt_size != 0x28 && ww.fmt_size != ?) goto fail; /* old, new */
             if (ww.bits_per_sample != 4) goto fail;
 
@@ -457,17 +295,17 @@ VGM_LOG("1\n");
             vgmstream->interleave_block_size = 0x08; /* ww.block_align = 0x8 in older Wwise, samples per block in newer Wwise */
 
             /* find coef position */
-            if (find_chunk(sf, 0x57696948,first_offset,0, &wiih_offset,&wiih_size, ww.big_endian, 0)) { /*"WiiH", older Wwise */
+            if (ww.wiih_offset) { /* older */
                 vgmstream->num_samples = dsp_bytes_to_samples(ww.data_size, ww.channels);
-                if (wiih_size != 0x2e * ww.channels) goto fail;
+                if (ww.wiih_size != 0x2e * ww.channels) goto fail;
 
-                if (is_dsp_full_interleave(sf, &ww, wiih_offset))
+                if (is_dsp_full_interleave(sf, &ww, ww.wiih_offset))
                     vgmstream->interleave_block_size = ww.data_size / 2;
             }
-            else if (ww.extra_size == 0x0c + ww.channels * 0x2e) { /* newer Wwise */
-                vgmstream->num_samples = read_32bit(ww.fmt_offset + 0x18, sf);
-                wiih_offset = ww.fmt_offset + 0x1c;
-                wiih_size = 0x2e * ww.channels;
+            else if (ww.extra_size == 0x0c + ww.channels * 0x2e) { /* newer */
+                vgmstream->num_samples = read_s32(ww.fmt_offset + 0x18, sf);
+                ww.wiih_offset = ww.fmt_offset + 0x1c;
+                ww.wiih_size = 0x2e * ww.channels;
             }
             else {
                 goto fail;
@@ -485,18 +323,16 @@ VGM_LOG("1\n");
                 vgmstream->loop_flag = 0;
             }
 
-            dsp_read_coefs(vgmstream,sf,wiih_offset + 0x00, 0x2e, ww.big_endian);
-            dsp_read_hist (vgmstream,sf,wiih_offset + 0x24, 0x2e, ww.big_endian);
+            dsp_read_coefs(vgmstream, sf, ww.wiih_offset + 0x00, 0x2e, ww.big_endian);
+            dsp_read_hist (vgmstream, sf, ww.wiih_offset + 0x24, 0x2e, ww.big_endian);
 
             break;
         }
 
 #ifdef VGM_USE_FFMPEG
-        case XMA2: {    /* X360/XBone */
+        case XMA2: { /* X360/XBone */
             uint8_t buf[0x100];
             int bytes;
-            off_t xma2_offset;
-            size_t xma2_size;
 
             /* endian check should be enough */
             //if (ww.fmt_size != ...) goto fail; /* XMA1 0x20, XMA2old: 0x34, XMA2new: 0x40, XMA2 Guitar Hero Live/padded: 0x64, etc */
@@ -505,10 +341,11 @@ VGM_LOG("1\n");
             if (!(ww.big_endian || (!ww.big_endian && check_extensions(sf,"wem,bnk"))))
                 goto fail;
 
-            if (find_chunk(sf, 0x584D4132,first_offset,0, &xma2_offset,&xma2_size, ww.big_endian, 0)) { /*"XMA2"*/ /* older Wwise */
-                bytes = ffmpeg_make_riff_xma2_from_xma2_chunk(buf,0x100, xma2_offset, xma2_size, ww.data_size, sf);
-            } else { /* newer Wwise */
-                bytes = ffmpeg_make_riff_xma_from_fmt_chunk(buf,0x100, ww.fmt_offset, ww.fmt_size, ww.data_size, sf, ww.big_endian);
+            if (ww.xma2_offset) { /* older */
+                bytes = ffmpeg_make_riff_xma2_from_xma2_chunk(buf, sizeof(buf), ww.xma2_offset, ww.xma2_size, ww.data_size, sf);
+            }
+            else { /* newer */
+                bytes = ffmpeg_make_riff_xma_from_fmt_chunk(buf, sizeof(buf), ww.fmt_offset, ww.fmt_size, ww.data_size, sf, ww.big_endian);
             }
 
             vgmstream->codec_data = init_ffmpeg_header_offset(sf, buf,bytes, ww.data_offset,ww.data_size);
@@ -519,12 +356,7 @@ VGM_LOG("1\n");
             vgmstream->num_samples = ww.num_samples; /* set while parsing XMAWAVEFORMATs */
 
             /* Wwise loops are always pre-adjusted (old or new) and only num_samples is off */
-            xma_fix_raw_samples(vgmstream, sf, ww.data_offset,ww.data_size, ww.chunk_offset, 1,0);
-
-            /* "XMAc": rare Wwise extension, XMA2 physical loop regions (loop_start_b, loop_end_b, loop_subframe_data)
-             * Can appear even in the file doesn't loop, maybe it's meant to be the playable physical region */
-            //VGM_ASSERT(find_chunk(sf, 0x584D4163,first_offset,0, NULL,NULL, ww.big_endian, 0), "WWISE: XMAc chunk found\n");
-            /* other chunks: "seek", regular XMA2 seek table */
+            xma_fix_raw_samples(vgmstream, sf, ww.data_offset, ww.data_size, ww.xma2_offset ? ww.xma2_offset : ww.fmt_offset, 1,0);
 
             /* XMA is VBR so this is very approximate percent, meh */
             if (ww.truncated) {
@@ -536,7 +368,7 @@ VGM_LOG("1\n");
             break;
         }
 
-        case XWMA: {    /* X360 */
+        case XWMA: { /* X360 */
             ffmpeg_codec_data *ffmpeg_data = NULL;
             uint8_t buf[0x100];
             int bytes;
@@ -544,8 +376,8 @@ VGM_LOG("1\n");
             if (ww.fmt_size != 0x18) goto fail;
             if (!ww.big_endian) goto fail; /* must be from Wwise X360 (PC LE XWMA is parsed elsewhere) */
 
-            bytes = ffmpeg_make_riff_xwma(buf,0x100, ww.format, ww.data_size, vgmstream->channels, vgmstream->sample_rate, ww.average_bps, ww.block_align);
-            ffmpeg_data = init_ffmpeg_header_offset(sf, buf,bytes, ww.data_offset,ww.data_size);
+            bytes = ffmpeg_make_riff_xwma(buf, sizeof(buf), ww.format, ww.data_size, ww.channels, ww.sample_rate, ww.average_bps, ww.block_align);
+            ffmpeg_data = init_ffmpeg_header_offset(sf, buf,bytes, ww.data_offset, ww.data_size);
             if ( !ffmpeg_data ) goto fail;
             vgmstream->codec_data = ffmpeg_data;
             vgmstream->coding_type = coding_FFmpeg;
@@ -561,9 +393,9 @@ VGM_LOG("1\n");
                 msd.data_size = ww.data_size;
 
                 if (ww.format == 0x0162)
-                    wmapro_get_samples(&msd, sf, ww.block_align, ww.sample_rate,0x00E0);
+                    wmapro_get_samples(&msd, sf, ww.block_align, ww.sample_rate, 0x00E0);
                 else
-                    wma_get_samples(&msd, sf, ww.block_align, ww.sample_rate,0x001F);
+                    wma_get_samples(&msd, sf, ww.block_align, ww.sample_rate, 0x001F);
 
                 vgmstream->num_samples = msd.num_samples;
                 if (!vgmstream->num_samples)
@@ -594,21 +426,18 @@ VGM_LOG("1\n");
 
         case OPUSNX: {  /* Switch */
             size_t skip;
+            size_t seek_size;
 
+            if (ww.fmt_size != 0x28) goto fail;
             /* values up to 0x14 seem fixed and similar to HEVAG's (block_align 0x02/04, bits_per_sample 0x10) */
-            if (ww.fmt_size == 0x28) {
-                size_t seek_size;
 
-                vgmstream->num_samples = read_32bit(ww.fmt_offset + 0x18, sf);
-                /* 0x1c: null? 0x20: data_size without seek_size */
-                seek_size = read_32bit(ww.fmt_offset + 0x24, sf);
+            vgmstream->num_samples = read_s32(ww.fmt_offset + 0x18, sf);
+            /* 0x1c: null?
+             * 0x20: data_size without seek_size */
+            seek_size = read_u32(ww.fmt_offset + 0x24, sf);
 
-                start_offset += seek_size;
-                ww.data_size -= seek_size;
-            }
-            else {
-                goto fail;
-            }
+            start_offset += seek_size;
+            ww.data_size -= seek_size;
 
             skip = switch_opus_get_encoder_delay(start_offset, sf); /* should be 120 */
 
@@ -626,18 +455,18 @@ VGM_LOG("1\n");
                 ww.data_size = ww.file_size - start_offset;
             }
 
-            vgmstream->codec_data = init_ffmpeg_switch_opus(sf, start_offset,ww.data_size, vgmstream->channels, skip, vgmstream->sample_rate);
+            vgmstream->codec_data = init_ffmpeg_switch_opus(sf, start_offset,ww.data_size, ww.channels, skip, vgmstream->sample_rate);
             if (!vgmstream->codec_data) goto fail;
             vgmstream->coding_type = coding_FFmpeg;
             vgmstream->layout_type = layout_none;
             break;
         }
 
-        case OPUS: {     /* PC/mobile/etc, rare (most games still use Vorbis) [Girl Cafe Gun (Mobile)] */
+        case OPUS: { /* alt to Vorbis [Girl Cafe Gun (Mobile)] */
             if (ww.block_align != 0 || ww.bits_per_sample != 0) goto fail;
 
             /* extra: size 0x12 */
-            vgmstream->num_samples = read_32bit(ww.fmt_offset + 0x18, sf);
+            vgmstream->num_samples = read_s32(ww.fmt_offset + 0x18, sf);
             /* 0x1c: stream size without OggS? */
             /* 0x20: full samples (without encoder delay) */
 
@@ -654,21 +483,19 @@ VGM_LOG("1\n");
             vgmstream->layout_type = layout_none;
             break;
         }
+
 #if 0   // disabled until more files/tests
-        case OPUSWW: {   /* updated Opus added in Wwise 2019.2.3 [Assassin's Creed Valhalla (PC)] */
+        case OPUSWW: {   /* updated Opus [Assassin's Creed Valhalla (PC)] */
             int skip, table_count;
-            off_t seek_offset;
         
             if (ww.block_align != 0 || ww.bits_per_sample != 0) goto fail;
-
-            if (!find_chunk(sf, 0x7365656B,first_offset,0, &seek_offset, NULL, ww.big_endian, 0)) /* "seek" */
-                goto fail;
+            if (!ww.seek_offset)) goto fail;
 
             /* extra: size 0x10 */
             /* 0x12: samples per frame */
-            vgmstream->num_samples = read_32bit(ww.fmt_offset + 0x18, sf);
-            table_count = read_32bit(ww.fmt_offset + 0x1c, sf); /* same as seek size / 2 */
-            skip = read_16bit(ww.fmt_offset + 0x20, sf);
+            vgmstream->num_samples = read_s32(ww.fmt_offset + 0x18, sf);
+            table_count = read_u32(ww.fmt_offset + 0x1c, sf); /* same as seek size / 2 */
+            skip = read_u16(ww.fmt_offset + 0x20, sf);
             /* 0x22: 1? (though extra size is declared as 0x10 so this is outsize, AK plz */
 
             /* OPUS is VBR so this is very approximate percent, meh */
@@ -679,7 +506,7 @@ VGM_LOG("1\n");
             }
 
             /* Wwise Opus saves all frame sizes in the seek table */
-            vgmstream->codec_data = init_ffmpeg_wwise_opus(sf, seek_offset, table_count, ww.data_offset, ww.data_size, ww.channels, skip);
+            vgmstream->codec_data = init_ffmpeg_wwise_opus(sf, ww.seek_offset, table_count, ww.data_offset, ww.data_size, ww.channels, skip);
             if (!vgmstream->codec_data) goto fail;
             vgmstream->coding_type = coding_FFmpeg;
             vgmstream->layout_type = layout_none;
@@ -688,7 +515,7 @@ VGM_LOG("1\n");
 #endif
 
 #endif
-        case HEVAG:     /* PSV */
+        case HEVAG: /* PSV */
             /* changed values, another bizarre Wwise quirk */
             //ww.block_align /* unknown (1ch=2, 2ch=4) */
             //ww.bits_per_sample; /* unknown (0x10) */
@@ -697,7 +524,9 @@ VGM_LOG("1\n");
             if (ww.fmt_size != 0x18) goto fail;
             if (ww.big_endian) goto fail;
 
-            /* extra_data: size 0x06, @0x00: samples per block (0x1c), @0x04: channel config */
+            /* extra_data (size 0x06)
+             * 0x00: samples per block (0x1c)
+             * 0x04: channel config (again?) */
 
             vgmstream->coding_type = coding_HEVAG;
             vgmstream->layout_type = layout_interleave;
@@ -713,20 +542,20 @@ VGM_LOG("1\n");
             if (ww.fmt_size != 0x24) goto fail;
             if (ww.extra_size != 0x12) goto fail;
 
-            cfg.channels = vgmstream->channels;
-            cfg.config_data = read_32bitBE(ww.fmt_offset+0x18,sf);
-            cfg.encoder_delay = read_32bit(ww.fmt_offset+0x20,sf);
+            cfg.channels = ww.channels;
+            cfg.config_data = read_u32be(ww.fmt_offset + 0x18,sf);
+            cfg.encoder_delay = read_u32(ww.fmt_offset + 0x20,sf);
 
             vgmstream->codec_data = init_atrac9(&cfg);
             if (!vgmstream->codec_data) goto fail;
             vgmstream->coding_type = coding_ATRAC9;
             vgmstream->layout_type = layout_none;
 
-            vgmstream->num_samples = read_32bit(ww.fmt_offset+0x1c,sf);
+            vgmstream->num_samples = read_s32(ww.fmt_offset + 0x1c, sf);
             break;
         }
 #endif
-        case PTADPCM: /* substitutes IMA as default ADPCM codec */
+        case PTADPCM: /* newer ADPCM [Bayonetta 2 (Switch), Genshin Impact (PC)]  */
             if (ww.bits_per_sample != 4) goto fail;
             if (ww.block_align != 0x24 * ww.channels && ww.block_align != 0x104 * ww.channels) goto fail;
 
@@ -747,8 +576,7 @@ VGM_LOG("1\n");
     }
 
 
-
-    if ( !vgmstream_open_stream(vgmstream,sf,start_offset) )
+    if (!vgmstream_open_stream(vgmstream, sf, start_offset) )
         goto fail;
     return vgmstream;
 
@@ -792,6 +620,219 @@ static int is_dsp_full_interleave(STREAMFILE* sf, wwise_header* ww, off_t coef_o
     return 0;
 }
 
+
+static int parse_wwise(STREAMFILE* sf, wwise_header* ww) {
+    uint32_t (*read_u32)(off_t,STREAMFILE*) = NULL;
+    uint16_t (*read_u16)(off_t,STREAMFILE*) = NULL;
+
+    if (read_u32be(0x00,sf) != 0x52494646 &&  /* "RIFF" (LE) */
+        read_u32be(0x00,sf) != 0x52494658)    /* "RIFX" (BE) */
+        goto fail;
+    if (read_u32be(0x08,sf) != 0x57415645 &&  /* "WAVE" */
+        read_u32be(0x08,sf) != 0x58574D41)    /* "XWMA" */
+        goto fail;
+
+    ww->big_endian = read_u32be(0x00,sf) == 0x52494658; /* RIFX */
+    if (ww->big_endian) { /* Wwise honors machine's endianness (PC=RIFF, X360=RIFX --unlike XMA) */
+        read_u32 = read_u32be;
+        read_u16 = read_u16be;
+    } else {
+        read_u32 = read_u32le;
+        read_u16 = read_u16le;
+    }
+
+    ww->file_size = get_streamfile_size(sf);
+
+#if 0
+    /* Wwise's RIFF size is often wonky, seemingly depending on codec:
+     * - PCM, IMA/PTADPCM, VORBIS, AAC, OPUSNX/OPUS: correct
+     * - DSP, XWMA, ATRAC9: almost always slightly smaller (around 0x50)
+     * - HEVAG: very off
+     * - XMA2: exact file size
+     * - some RIFX have LE size
+     * (later we'll validate "data" which fortunately is correct)
+     */
+    if (read_u32(0x04,sf) + 0x04 + 0x04 != ww->file_size) {
+        VGM_LOG("WWISE: bad riff size\n");
+        goto fail;
+    }
+#endif
+
+    /* parse chunks (reads once linearly) */
+    {
+        off_t offset = 0x0c;
+        while (offset < ww->file_size) {
+            uint32_t type = read_u32be(offset + 0x00,sf);
+            uint32_t size = read_u32  (offset + 0x04,sf);
+            offset += 0x08;
+
+            switch(type) {
+                case 0x666d7420: /* "fmt " */
+                    ww->fmt_offset = offset;
+                    ww->fmt_size = size;
+                    break;
+                case 0x584D4132: /* "XMA2" */
+                    ww->xma2_offset = offset;
+                    ww->xma2_size = size;
+                    break;
+                case 0x64617461: /* "data" */
+                    ww->data_offset = offset;
+                    ww->data_size = size;
+                    break;
+                case 0x766F7262: /* "vorb" */
+                    ww->vorb_offset = offset;
+                    ww->vorb_size = size;
+                    break;
+                case 0x57696948: /* "WiiH" */
+                    ww->wiih_offset = offset;
+                    ww->wiih_size = size;
+                    break;
+                case 0x7365656B: /* "seek" */
+                    ww->seek_offset = offset;
+                    ww->seek_size = size;
+                    break;
+                case 0x736D706C: /* "smpl" */
+                    ww->smpl_offset = offset;
+                    ww->smpl_size = size;
+                    break;
+
+                case 0x66616374: /* "fact" */
+                    /* Wwise shouldn't use fact, but if somehow some file does uncomment the following: */
+                    //if (size == 0x10 && read_u32be(offset + 0x04, sf) == 0x4C794E20) /* "LyN " */
+                    //    goto fail; /* ignore LyN RIFF */
+                    goto fail;
+
+                /* "XMAc": rare XMA2 physical loop regions (loop_start_b, loop_end_b, loop_subframe_data)
+                 *         Can appear even in the file doesn't loop, maybe it's meant to be the playable physical region */
+                /* "LIST": leftover 'cue' info from OG .wavs (ex. loop starts in Platinum Games) */
+                /* "JUNK": optional padding for aligment (0-size JUNK exists too) */
+                /* "akd ": extra info for Wwise? (wave peaks/loudness/HDR envelope?) */
+                default:
+                    break;
+            }
+
+            /* chunks are even-aligned and don't need to add padding byte, unlike real RIFFs */
+            offset += size;
+        }
+    }
+
+
+    /* parse format (roughly spec-compliant but some massaging is needed) */
+    if (ww->xma2_offset) {
+        /* pseudo-XMA2WAVEFORMAT, "fmt"+"XMA2" (common) or only "XMA2" [Too Human (X360)] */
+        ww->format = 0x0165; /* signal for below */
+        xma2_parse_xma2_chunk(sf,
+                ww->xma2_offset, &ww->channels, &ww->sample_rate, &ww->loop_flag,
+                &ww->num_samples, &ww->loop_start_sample, &ww->loop_end_sample);
+    }
+    else {
+        /* pseudo-WAVEFORMATEX */
+        if (ww->fmt_size < 0x10)
+            goto fail;
+        ww->format           = read_u16(ww->fmt_offset + 0x00,sf);
+        ww->channels         = read_u16(ww->fmt_offset + 0x02,sf);
+        ww->sample_rate      = read_u32(ww->fmt_offset + 0x04,sf);
+        ww->average_bps      = read_u32(ww->fmt_offset + 0x08,sf);
+        ww->block_align      = read_u16(ww->fmt_offset + 0x0c,sf);
+        ww->bits_per_sample  = read_u16(ww->fmt_offset + 0x0e,sf);
+        if (ww->fmt_size > 0x10 && ww->format != 0x0165 && ww->format != 0x0166) /* ignore XMAWAVEFORMAT */
+            ww->extra_size   = read_u16(ww->fmt_offset + 0x10,sf);
+        if (ww->extra_size >= 0x06) { /* always present (actual RIFFs only have it in WAVEFORMATEXTENSIBLE) */
+            /* mostly WAVEFORMATEXTENSIBLE's bitmask (see AkSpeakerConfig.h) */
+            ww->channel_layout = read_u32(ww->fmt_offset + 0x14,sf);
+            /* later games (+2018?) have a pseudo-format instead to handle more cases:
+             * - 8b: uNumChannels
+             * - 4b: eConfigType  (0=none, 1=standard, 2=ambisonic)
+             * - 19b: uChannelMask */
+            if ((ww->channel_layout & 0xFF) == ww->channels) {
+                ww->channel_layout = (ww->channel_layout >> 12);
+            }
+        }
+
+        if (ww->format == 0x0166) { /* XMA2WAVEFORMATEX in fmt */
+            xma2_parse_fmt_chunk_extra(sf, ww->fmt_offset, &ww->loop_flag,
+                    &ww->num_samples, &ww->loop_start_sample, &ww->loop_end_sample, ww->big_endian);
+        }
+    }
+
+    /* common loops ("XMA2" chunks already read them) */
+    if (ww->smpl_offset) {
+        if (ww->smpl_size >= 0x34
+                && read_u32(ww->smpl_offset + 0x1c, sf) == 1           /* loop count */
+                && read_u32(ww->smpl_offset + 0x24 + 0x04, sf) == 0) { /* loop type */
+            ww->loop_flag = 1;
+            ww->loop_start_sample = read_u32(ww->smpl_offset + 0x24 + 0x8, sf);
+            ww->loop_end_sample   = read_u32(ww->smpl_offset + 0x24 + 0xc, sf) + 1; /* +1 like standard RIFF */
+        }
+    }
+
+    if (!ww->data_offset)
+        goto fail;
+
+
+    /* format to codec */
+    switch(ww->format) {
+        case 0x0001: ww->codec = PCM; break; /* older Wwise */
+        case 0x0002: ww->codec = IMA; break; /* newer Wwise (conflicts with MSADPCM, probably means "platform's ADPCM") */
+        case 0x0069: ww->codec = IMA; break; /* older Wwise [Spiderman Web of Shadows (X360), LotR Conquest (PC)] */
+        case 0x0161: ww->codec = XWMA; break; /* WMAv2 */
+        case 0x0162: ww->codec = XWMA; break; /* WMAPro */
+        case 0x0165: ww->codec = XMA2; break; /* XMA2-chunk XMA (Wwise doesn't use XMA1) */
+        case 0x0166: ww->codec = XMA2; break; /* fmt-chunk XMA */
+        case 0xAAC0: ww->codec = AAC; break;
+        case 0xFFF0: ww->codec = DSP; break;
+        case 0xFFFB: ww->codec = HEVAG; break;
+        case 0xFFFC: ww->codec = ATRAC9; break;
+        case 0xFFFE: ww->codec = PCM; break; /* "PCM for Wwise Authoring" */
+        case 0xFFFF: ww->codec = VORBIS; break;
+        case 0x3039: ww->codec = OPUSNX; break; /* renamed from "OPUS" on Wwise 2018.1 */
+        case 0x3040: ww->codec = OPUS; break;
+        case 0x3041: ww->codec = OPUSWW; break; /* added on Wwise 2019.2.3, presumably replaces OPUS */
+        case 0x8311: ww->codec = PTADPCM; break; /* added on Wwise 2019.1, replaces IMA */
+        default:
+            goto fail;
+    }
+
+    /* identify system's ADPCM */
+    if (ww->format == 0x0002) {
+        if (ww->extra_size == 0x0c + ww->channels * 0x2e) {
+            /* newer Wwise DSP with coefs [Epic Mickey 2 (Wii), Batman Arkham Origins Blackgate (3DS)] */
+            ww->codec = DSP;
+        } else if (ww->extra_size == 0x0a && ww->wiih_offset) { /* WiiH */
+            /* few older Wwise DSP with num_samples in extra_size [Tony Hawk: Shred (Wii)] */
+            ww->codec = DSP;
+        } else if (ww->block_align == 0x104 * ww->channels) {
+            ww->codec = PTADPCM; /* Bayonetta 2 (Switch) */
+        }
+    }
+
+
+    /* Some Wwise .bnk (RAM) files have truncated, prefetch mirrors of another file, that
+     * play while the rest of the real stream loads. We'll add basic support to avoid
+     * complaints of this or that .wem not playing */
+    if (ww->data_offset + ww->data_size > ww->file_size) {
+        //;VGM_LOG("WWISE: truncated data size (prefetch): (real=0x%x > riff=0x%x)\n", ww->data_size, ww->file_size);
+
+        /* catch wrong rips as truncated tracks' file_size should be much smaller than data_size,
+         * but it's possible to pre-fetch small files too [Punch Out!! (Wii)] */
+        if (ww->data_offset + ww->data_size - ww->file_size < 0x5000 && ww->file_size > 0x10000) {
+            VGM_LOG("WWISE: wrong expected data_size\n");
+            goto fail;
+        }
+
+        if (ww->codec == PCM || ww->codec == IMA || ww->codec == VORBIS || ww->codec == DSP || ww->codec == XMA2 ||
+            ww->codec == OPUSNX || ww->codec == OPUS || ww->codec == OPUSWW || ww->codec == PTADPCM) {
+            ww->truncated = 1; /* only seen those, probably all exist (XWMA, AAC, HEVAG, ATRAC9?) */
+        } else {
+            VGM_LOG("WWISE: wrong size, maybe truncated\n");
+            goto fail;
+        }
+    }
+
+    return 1;
+fail:
+    return 0;
+}
 
 
 /* VORBIS FORMAT RESEARCH */

--- a/src/meta/xopus.c
+++ b/src/meta/xopus.c
@@ -3,39 +3,40 @@
 
 
 /* XOPUS - from Exient games [Angry Birds: Transformers (Android), Angry Birds: Go (Android)] */
-VGMSTREAM * init_vgmstream_xopus(STREAMFILE *streamFile) {
-    VGMSTREAM * vgmstream = NULL;
-    off_t start_offset;
-    int loop_flag = 0, channel_count, sample_rate, num_samples, skip;
+VGMSTREAM* init_vgmstream_xopus(STREAMFILE* sf) {
+    VGMSTREAM* vgmstream = NULL;
+    off_t start_offset, table_offset;
+    int loop_flag = 0, channels, sample_rate, num_samples, skip;
     size_t data_size;
     int entries;
 
 
     /* checks*/
-    if (!check_extensions(streamFile, "xopus"))
+    if (!check_extensions(sf, "xopus"))
         goto fail;
-    if (read_32bitBE(0x00, streamFile) != 0x584F7075)    /* "XOpu" */
+    if (read_u32be(0x00, sf) != 0x584F7075) /* "XOpu" */
         goto fail;
 
     /* 0x04: always 0x01? */
-    channel_count = read_8bit(0x05, streamFile);
+    channels = read_u8(0x05, sf);
     /* 0x06: always 0x30? */
     /* 0x08: always 0xc8? max allowed packet size? */
-    num_samples = read_32bitLE(0x0c, streamFile);
-    skip = read_32bitLE(0x10, streamFile);
-    entries = read_32bitLE(0x14, streamFile);
-    data_size = read_32bitLE(0x18, streamFile);
+    num_samples = read_s32le(0x0c, sf);
+    skip = read_s32le(0x10, sf);
+    entries = read_u32le(0x14, sf);
+    data_size = read_u32le(0x18, sf);
     /* 0x1c: unused */
     /* 0x20+: packet sizes table */
 
     sample_rate = 48000;
     loop_flag = 0;
 
-    start_offset = 0x20 + 0x02*entries;
+    table_offset = 0x20;
+    start_offset = table_offset + 0x02*entries;
 
 
     /* build the VGMSTREAM */
-    vgmstream = allocate_vgmstream(channel_count, loop_flag);
+    vgmstream = allocate_vgmstream(channels, loop_flag);
     if (!vgmstream) goto fail;
 
     vgmstream->meta_type = meta_XOPUS;
@@ -44,7 +45,7 @@ VGMSTREAM * init_vgmstream_xopus(STREAMFILE *streamFile) {
 
 #ifdef VGM_USE_FFMPEG
     {
-        vgmstream->codec_data = init_ffmpeg_x_opus(streamFile, start_offset,data_size, vgmstream->channels, skip, vgmstream->sample_rate);
+        vgmstream->codec_data = init_ffmpeg_x_opus(sf, table_offset, entries, start_offset, data_size, vgmstream->channels, skip);
         if (!vgmstream->codec_data) goto fail;
         vgmstream->coding_type = coding_FFmpeg;
         vgmstream->layout_type = layout_none;
@@ -53,7 +54,7 @@ VGMSTREAM * init_vgmstream_xopus(STREAMFILE *streamFile) {
     goto fail;
 #endif
 
-    if (!vgmstream_open_stream(vgmstream, streamFile, start_offset))
+    if (!vgmstream_open_stream(vgmstream, sf, start_offset))
         goto fail;
     return vgmstream;
 

--- a/src/render.c
+++ b/src/render.c
@@ -404,13 +404,21 @@ static int render_fade(VGMSTREAM* vgmstream, sample_t* buf, int samples_done) {
     }
 }
 
-static int render_pad_end(VGMSTREAM* vgmstream, sample_t* buf, int samples_to_do) {
+static int render_pad_end(VGMSTREAM* vgmstream, sample_t* buf, int samples_done) {
+    play_state_t* ps = &vgmstream->pstate;
     int channels = vgmstream->pstate.output_channels;
+    int start = 0;
 
-    /* since anything beyond pad end is silence no need to check ranges */
+    /* since anything beyond pad end is silence no need to check end */
+    if (ps->play_position < ps->pad_end_start) {
+        start = samples_done - (ps->play_position + samples_done - ps->pad_end_start);
+    }
+    else {
+        start = 0;
+    }
 
-    memset(buf, 0, samples_to_do * sizeof(sample_t) * channels);
-    return samples_to_do;
+    memset(buf + (start * channels), 0, (samples_done - start) * sizeof(sample_t) * channels);
+    return samples_done;
 }
 
 
@@ -445,7 +453,7 @@ int render_vgmstream(sample_t* buf, int32_t sample_count, VGMSTREAM* vgmstream) 
         tmpbuf += done * vgmstream->pstate.output_channels; /* as if mixed */
     }
 
-    /* end padding (done before to avoid decoding if possible) */
+    /* end padding (done before to avoid decoding if possible, samples_to_do becomes 0) */
     if (!vgmstream->config.play_forever /* && ps->pad_end_left */
             && ps->play_position + samples_done >= ps->pad_end_start) {
         done = render_pad_end(vgmstream, tmpbuf, samples_to_do);
@@ -462,10 +470,16 @@ int render_vgmstream(sample_t* buf, int32_t sample_count, VGMSTREAM* vgmstream) 
 
         samples_done += done;
 
-        /* simple fadeout */
-        if (!vgmstream->config.play_forever && ps->fade_left
-                && ps->play_position + done >= ps->fade_start) {
-            render_fade(vgmstream, tmpbuf, done);
+        if (!vgmstream->config.play_forever) {
+            /* simple fadeout */
+            if (ps->fade_left && ps->play_position + done >= ps->fade_start) {
+                render_fade(vgmstream, tmpbuf, done);
+            }
+
+            /* silence leftover buf samples (rarely used when no fade is set) */
+            if (ps->play_position + done >= ps->pad_end_start) {
+                render_pad_end(vgmstream, tmpbuf, done);
+            }
         }
 
         tmpbuf += done * vgmstream->pstate.output_channels;

--- a/src/vgmstream.c
+++ b/src/vgmstream.c
@@ -508,6 +508,7 @@ VGMSTREAM* (*init_vgmstream_functions[])(STREAMFILE* sf) = {
     init_vgmstream_xse_old,
     init_vgmstream_wady,
     init_vgmstream_dsp_sqex,
+    init_vgmstream_dsp_wiivoice,
 
     /* lowest priority metas (should go after all metas, and TXTH should go before raw formats) */
     init_vgmstream_txth,            /* proper parsers should supersede TXTH, once added */

--- a/src/vgmstream.c
+++ b/src/vgmstream.c
@@ -509,6 +509,7 @@ VGMSTREAM* (*init_vgmstream_functions[])(STREAMFILE* sf) = {
     init_vgmstream_wady,
     init_vgmstream_dsp_sqex,
     init_vgmstream_dsp_wiivoice,
+    init_vgmstream_xws,
 
     /* lowest priority metas (should go after all metas, and TXTH should go before raw formats) */
     init_vgmstream_txth,            /* proper parsers should supersede TXTH, once added */

--- a/src/vgmstream.h
+++ b/src/vgmstream.h
@@ -739,6 +739,7 @@ typedef enum {
     meta_SDRH,
     meta_WADY,
     meta_DSP_SQEX,
+    meta_DSP_WIIVOICE,
 } meta_t;
 
 /* standard WAVEFORMATEXTENSIBLE speaker positions */


### PR DESCRIPTION
- Improve XOpus handling + prepare Wwise Opus
- Add Wwise Opus (disabled)
- Fix buggy .at3 [E.X. Troopers (PS3)]
- Fix trailing samples not being cut when using pad end
- Rename TXTH subsong_offset to subsong_spacing for clarity
- Add TXTH name_offset_absolute for some subsong cases pointing to offset
- Fix some .sed [Fatal Frame 5 (WiiU)]
- Add WiiVoice dsp [Fatal Frame 5 (WiiU)]
- Add partial support for Koie Tecmo .xws with MSF
- Clean Wwise meta
