### PR TITLE
xwb ww layouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,24 @@ simpler to make and cleaner: for example create a text file named `bgm01-loop.tx
 and inside write `bgm01.mp3 #I 10.0 90.0`. Open the `.txtp` to play the `.mp3`
 looping from 10 to 90 seconds.
 
+#### OS case sensitiveness
+When using OS with case sensitive filesystem (mainly Linux), a known issue with
+companion files is that vgmstream generally tries to find them using lowercase
+extension.
+
+This means that if the developer used uppercase instead (e.g. `bgm.ABK`+`bgm.AST`)
+loading will fail. It's technically complex to fix this, so for the time being
+the only option is renaming the companion extension to lowercase.
+
+A particularly nasty variation of that is that some formats load files by full
+name (e.g. `STREAM.SS0`), but sometimes the actual filename is in other case
+(`Stream.ss0`), and some files could even point to that with another case. You
+could try adding *symlinks* in various upper/lower/mixed cases to handle this.
+Currently there isn't any way to know what exact name is needed (other than
+hex-editting), though only a few formats do this, mainly *Ubisoft* banks.
+
+Regular formats without companion files should work fine in upper/lowercase.
+
 ### Decryption keys
 Certain formats have encrypted data, and need a key to decrypt. vgmstream
 will try to find the correct key from a list, but it can be provided by

--- a/doc/TXTH.md
+++ b/doc/TXTH.md
@@ -440,9 +440,13 @@ While you can put anything in the values, this feature is meant to be used to st
 
 
 #### BASE OFFSET MODIFIER
-You can set a default offset that affects next `@(offset)` reads making them `@(offset + base_offset)`, for cleaner parsing (particularly interesting when combined with the `name_table`).
+You can set a default offset that affects next `@(offset)` reads making them `@(offset + base_offset)`, for cleaner parsing.
 
-For example instead of `channels = @0x714` you could set `base_offset = 0x710, channels = @0x04`. Set to 0 when you want to disable it.
+This is particularly interesting when combined with offsets to some long value. For example instead of `channels = @0x714` you could set `base_offset = 0x710, channels = @0x04`. Or values from the `name_table`, like `base_offset = name_value, channels = @0x04`.
+ 
+It also allows parsing formats that set offsets to another offset, by "chaining" `base_offset`. With `base_offset = @0x10` (pointing to `0x40`) then `base_offset = @0x20`, it reads value at `0x60`. Set to 0 when you want to disable/reset the chain: `base_offset = @0x10` then `base_offset = 0` then `base_offset = @0x20` reads value at `0x20`
+
+
 ```
 base_offset = (value)
 ```
@@ -1051,4 +1055,44 @@ loop_flag         = auto
 
 #@0x10 is an absolute offset to another table, that shouldn't be affected by subsong_spacing
 name_offset_absolute = @0x10 + 0x270
+```
+
+#### Fatal Frame (Xbox) .mwa.txth
+```
+#00: MWAV
+#04: flags?
+#08: subsongs
+#0c: data size
+#10: null
+#14: sizes offset
+#18: offsets table
+#1c: offset to tables?
+#20: header offset
+
+subsong_count = @0x08
+
+# size table
+subsong_spacing = 0
+base_offset = 0
+base_offset = @0x14
+subsong_spacing = 0x04
+data_size = @0x00
+
+# offset table
+subsong_spacing = 0
+base_offset = 0
+base_offset = @0x18
+subsong_spacing = 0x04
+start_offset = @0x00
+
+# header (standard "fmt")
+subsong_spacing = 0
+base_offset = 0
+base_offset = @0x20
+channels = @0x02$2
+sample_rate = @0x04
+
+codec = XBOX
+num_samples = data_size
+#todo: there are dummy entries
 ```

--- a/doc/TXTP.md
+++ b/doc/TXTP.md
@@ -72,7 +72,7 @@ loop_start_segment = 2
 loop_end_segment = 3
 loop_mode = keep    # loops in 2nd file's loop_start to 3rd file's loop_end
 ```
-Mixing sample rates is ok (uses max) but channel number must be equal for all files. You can use mixing (explained later) to join segments of different channels though.
+Mixing sample rates is ok (uses max). Different number of channels is allowed, but you may need to use mixing (explained later) to improve results. 4ch + 2ch will sound ok, but 1ch + 2ch would need some upmixing first.
 
 
 ### Layers mode
@@ -242,15 +242,16 @@ group = L #h44100
 commands = #h48000 #overwrites
 ```
 
-Segments and layer settings and rules still apply when making groups, so you can't group segments of files with different total channels. To do it you could use commands to "downmix" the group first:
+Segments and layer settings and rules still apply when making groups, so you may need to adjust groups a bit with commands:
 ```
 # this doesn't need to be grouped
 intro_2ch.at3
 
-# this is grouped into a single 4ch file, then downmixed to stereo
+# this is grouped into a single 4ch file, then auto-downmixed to stereo
+# (without downmixing may sound a bit strange since channels from mainB wouldn't mix with intro)
 mainA_2ch.at3
 mainB_2ch.at3
-group = 2L2 #@layer-v 2
+group = -L2 #@layer-v
 
 # finally resulting layers are played as segments (2ch, 2ch)
 # (could set a group = S and ommit mode here, too)
@@ -489,6 +490,39 @@ Use this feature responsibly, though. If you find a format that should loop usin
 Note that a few codecs may not work with arbitrary loop values since they weren't tested with loops. Misaligned loops will cause audible "clicks" at loop point too.
 
 
+### Loop anchors
+**`#a`** (loop start segment), **`#A`** (loop end segment): mark looping parts in segmented layout.
+
+For segmented layout normally you set loop points using `loop_start_segment` and `loop_end_segment`. It's clean in simpler cases but can be a hassle when lots of files exist. To simplify those cases you can set "loop anchors":
+```
+bgm01.adx
+bgm02.adx #a  ##defines loop start
+```
+```
+bgm01.adx
+bgm02.adx #a  ##defines loop start
+bgm03.adx
+bgm04.adx #A  ##defines loop end
+bgm05.adx
+```
+You can also use `#@loop` to set loop start.
+
+This setting also works in groups, which allows loops when using multiple segmented groups (not possible with `loop_start/end_segment`).
+```
+  bgm01.adx
+  bgm02.adx #a
+ group -S2 #l 2.0
+  bgm01.adx
+  bgm02.adx #a
+  bgm03.adx
+ group -S2 #l 3.0
+group -S2
+#could use R groups to select one sub-groups that loops
+# (loop_start_segment doesn't make sense for both segments)
+```
+Loop anchors have priority over `loop_start_segment`, and are ignored in layered layouts.
+
+
 ### Force sample rate
 **`#h(sample rate)`**: changes sample rate to selected value, changing play speed.
 
@@ -566,44 +600,11 @@ song#m1-3,2-4,3D
 # - drop channel 1 then 2 (now 1)
 song#m1d,1d
 ```
-Proper mixing requires some basic knowledge though, it's further explained later. Order matters and operations are applied sequentially, for extra flexibility at the cost of complexity and user-friendliness, and may result in surprising mixes. Try to stick to macros and simple combos, using later examples as a base.
+Proper mixing requires some basic knowledge though, it's further explained later. Order matters and operations are applied sequentially, for extra flexibility at the cost of complexity and user-friendliness, and may result in surprising mixes. Typical mixing operations are provided as *macros* (see below), so try to stick to macros and simple combos, using later examples as a base.
 
 This can be applied to individual layers and segments, but normally you want to use `commands` to apply mixing to the resulting file (see examples). Per-segment mixing should be reserved to specific up/downmixings.
 
-Mixing must be supported by the plugin, otherwise it's ignored (there is a negligible performance penalty per mix operation though).
-
-
-### Loop anchors
-**`#a`** (loop start segment), **`#A`** (loop end segment): mark looping parts in segmented layout.
-
-For segmented layout normally you set loop points using `loop_start_segment` and `loop_end_segment`. It's clean in simpler cases but can be a hassle when lots of files exist. To simplify those cases you can set "loop anchors":
-```
-bgm01.adx
-bgm02.adx #a  ##defines loop start
-```
-```
-bgm01.adx
-bgm02.adx #a  ##defines loop start
-bgm03.adx
-bgm04.adx #A  ##defines loop end
-bgm05.adx
-```
-You can also use `#@loop` to set loop start.
-
-This setting also works in groups, which allows loops when using multiple segmented groups (not possible with `loop_start/end_segment`).
-```
-  bgm01.adx
-  bgm02.adx #a
- group -S2 #l 2.0
-  bgm01.adx
-  bgm02.adx #a
-  bgm03.adx
- group -S2 #l 3.0
-group -S2
-#could use R groups to select one sub-groups that loops
-# (loop_start_segment doesn't make sense for both segments)
-```
-Loop anchors have priority over `loop_start_segment`, and are ignored in layered layouts.
+Mixing must be supported by the plugin, otherwise it's ignored (there is a negligible performance penalty per mix operation though, though having *a lot* will add up).
 
 
 ### Macros
@@ -613,10 +614,10 @@ Manually setting values gets old, so TXTP supports a bunch of simple macros. The
 - `volume N (channels)`: sets volume V to selected channels. N.N = percent or NdB = decibels.
   -  `1.0` or `0dB` = base volume, `2.0` or `6dB` = double volume, `0.5` or `-6dB` = half volume
   - `#v N` also works
-- `track (channels)`: makes a file of selected channels
-- `layer-v N (channels)`: mixes selected channels to N channels with default volume (for layered vocals). If N is 0 (or ommited), automatically sets highest channel count among all layers.
-- `layer-b N (channels)`: same, but adjusts volume depending on layers (for layered bgm)
-- `layer-e N (channels)`: same, but adjusts volume equally for all layers (for generic downmixing)
+- `track (channels)`: makes a file of selected channels (drops others)
+- `layer-v (N) (channels)`: for layered files, mixes selected channels to N channels with default volume (for layered vocals). If N is ommited (or 0), automatically sets highest channel count among all layers plus does some extra optimizations for (hopefully) better sounding results. May be applied to global commands or group config.
+- `layer-e (N) (channels)`: same, but adjusts volume equally for all layers (for generic downmixing)
+- `layer-b (N) (channels)`: same, but adjusts volume focusing on "main" layer (for layered bgm)
 - `remix N (channels)`: same, but mixes selected channels to N channels properly adjusting volume (for layered bgm)
 - `crosstrack N`: crossfades between Nch tracks after every loop (loop count is adjusted as needed)
 - `crosslayer-v/b/e N`: crossfades Nch layers to the main track after every loop (loop count is adjusted as needed)
@@ -731,7 +732,7 @@ Here is a rough look of how TXTP parses files, so you get a better idea of what'
 subdir name/bgm bank.fsb#s2#C1,2
 subdir name/bgm bank.fsb #s2  #C1,2 #comment
 ```
-All defined files must exist and be parseable by vgmstream, and general config like `mode` must make sense (not `mde = layers` or `mode = laye`).
+All defined files must exist and be parseable by vgmstream, and general config like `mode` must make sense (not `mde = layers` or `mode = laye`). *subdir* may even be relative paths like `../file.adx`, provided your OS supports that.
 
 Commands may add spaces as needed, but try to keep it simple. They *must* start with `#(command)`, as `#(space)(anything)` is a comment. Commands without corresponding file are ignored too (seen as comments), while incorrect commands are ignored and skip to next, though the parser may try to make something usable of them (this may be change anytime without warning):
 ```
@@ -796,7 +797,7 @@ You can also add spaces before files/commands, mainly to improve readability whe
  #segment x2
   song1
   song2
- group = 1S2 #E
+ group = -S2 #E
 ```
 
 Repeated commands overwrite previous setting, except comma-separated commands that are additive:
@@ -844,7 +845,7 @@ All this means there is no simple, standard way to mix, so you must experiment a
 
 
 ### Mixing examples
-TXTP has a few macros that help you handle most simpler cases (like `#C 1 2`, `#@layer-v 2`), that you should use when possible, but below is a full explanation of manual mixing (macros just automate these options using some standard formulas). 
+TXTP has a few macros that help you handle most simpler cases (like `#C 1 2`, `#@layer-v`), that you should use when possible, but below is a full explanation of manual mixing (macros just automate these options using some standard formulas). 
 ```
 # boost volume of all channels by 30%
 song#m0*1.3
@@ -915,19 +916,22 @@ ffxiii2-eclipse.scd#m5u,6u,5+1,6+2#@crosstrack 2
 
 Segment/layer downmixing is allowed but try to keep it simple, some mixes accomplish the same things but are a bit strange.
 ```
-# mix one stereo segment with a mono segment
+# mix one stereo segment with a mono segment upmixed to stereo
 intro-stereo.hca
-loop-mono.hca#m2u
-
-# this makes mono file
-intro-stereo.hca#m2u
-loop-stereo.hca#m2u
-
-# but you normally should do this instead as it's more natural
+loop-mono.hca#m2u,2+1
+```
+```
+# this makes mono file from each stereo song
+intro-stereo.hca#m2d
+loop-stereo.hca#m2d
+```
+```
+# but you normally should do it on the final result as it's more natural
 intro-stereo.hca
 loop-stereo.hca
-commands = #m2u
-
+commands = #m2d
+```
+```
 # fading segments work rather unexpectedly
 # fades out 1 minute into the _segment_  (could be 2 minutes into the resulting file)
 segment1.hca#m0{0:10+10.0

--- a/src/coding/coding.h
+++ b/src/coding/coding.h
@@ -551,7 +551,7 @@ ffmpeg_codec_data* init_ffmpeg_ue4_opus(STREAMFILE* sf, off_t start_offset, size
 ffmpeg_codec_data* init_ffmpeg_ea_opus(STREAMFILE* sf, off_t start_offset, size_t data_size, int channels, int skip, int sample_rate);
 ffmpeg_codec_data* init_ffmpeg_x_opus(STREAMFILE* sf, off_t table_offset, int table_count, off_t data_offset, size_t data_size, int channels, int skip);
 ffmpeg_codec_data* init_ffmpeg_fsb_opus(STREAMFILE* sf, off_t start_offset, size_t data_size, int channels, int skip, int sample_rate);
-ffmpeg_codec_data* init_ffmpeg_wwise_opus(STREAMFILE* sf, off_t table_offset, int table_count, off_t data_offset, size_t data_size, int channels, int skip);
+ffmpeg_codec_data* init_ffmpeg_wwise_opus(STREAMFILE* sf, off_t data_offset, size_t data_size, opus_config* cfg);
 
 size_t switch_opus_get_samples(off_t offset, size_t stream_size, STREAMFILE* sf);
 

--- a/src/coding/ffmpeg_decoder_custom_opus.c
+++ b/src/coding/ffmpeg_decoder_custom_opus.c
@@ -490,11 +490,11 @@ static size_t make_opus_header(uint8_t* buf, int buf_size, opus_config *cfg) {
     if (mapping_family > 0) {
         int i;
 
-        /* internal mono/stereo streams (N mono/stereo streams form M channels) */
+        /* internal mono/stereo streams (N mono/stereo streams that make M channels) */
         put_u8(buf+0x13, cfg->stream_count);
-        /* joint stereo streams (rest would be mono, so 6ch can be 2ch+2ch+1ch+1ch = 2 coupled */
+        /* joint stereo streams (rest would be mono, so 6ch can be 2ch+2ch+1ch+1ch = 2 coupled in 4 streams */
         put_u8(buf+0x14, cfg->coupled_count);
-        /* mapping bits per channel? */
+        /* mapping per channel (order of channels, ex: 0x000104050203) */
         for (i = 0; i < cfg->channels; i++) {
             put_u8(buf+0x15+i, cfg->channel_mapping[i]);
         }
@@ -753,8 +753,8 @@ ffmpeg_codec_data* init_ffmpeg_x_opus(STREAMFILE* sf, off_t table_offset, int ta
 ffmpeg_codec_data* init_ffmpeg_fsb_opus(STREAMFILE* sf, off_t start_offset, size_t data_size, int channels, int skip, int sample_rate) {
     return init_ffmpeg_custom_opus(sf, start_offset, data_size, channels, skip, sample_rate, OPUS_FSB);
 }
-ffmpeg_codec_data* init_ffmpeg_wwise_opus(STREAMFILE* sf, off_t table_offset, int table_count, off_t data_offset, size_t data_size, int channels, int skip) {
-    return init_ffmpeg_custom_table_opus(sf, table_offset, table_count, data_offset, data_size, channels, skip, 0, OPUS_WWISE);
+ffmpeg_codec_data* init_ffmpeg_wwise_opus(STREAMFILE* sf, off_t data_offset, size_t data_size, opus_config* cfg) {
+    return init_ffmpeg_custom_opus_config(sf, data_offset, data_size, cfg, OPUS_WWISE);
 }
 
 static opus_type_t get_ue4opus_version(STREAMFILE* sf, off_t offset) {

--- a/src/formats.c
+++ b/src/formats.c
@@ -333,6 +333,7 @@ static const char* extension_list[] = {
     "musc",
     "musx",
     "mvb", //txth/reserved [Porsche Challenge (PS1)]
+    "mwa", //txth/reserved [Fatal Frame (Xbox)]
     "mwv",
     "mxst",
     "myspd",

--- a/src/layout/layered.c
+++ b/src/layout/layered.c
@@ -76,6 +76,18 @@ decode_fail:
 }
 
 
+void seek_layout_layered(VGMSTREAM* vgmstream, int32_t seek_sample) {
+    int layer;
+    layered_layout_data* data = vgmstream->layout_data;
+
+    for (layer = 0; layer < data->layer_count; layer++) {
+        seek_vgmstream(data->layers[layer], seek_sample);
+    }
+
+    vgmstream->current_sample = seek_sample;
+    vgmstream->samples_into_block = seek_sample;
+}
+
 void loop_layout_layered(VGMSTREAM* vgmstream, int32_t loop_sample) {
     int layer;
     layered_layout_data* data = vgmstream->layout_data;

--- a/src/layout/layout.h
+++ b/src/layout/layout.h
@@ -59,7 +59,8 @@ segmented_layout_data* init_layout_segmented(int segment_count);
 int setup_layout_segmented(segmented_layout_data* data);
 void free_layout_segmented(segmented_layout_data* data);
 void reset_layout_segmented(segmented_layout_data* data);
-void loop_layout_segmented(VGMSTREAM* vgmstream, int32_t seek_sample);
+void seek_layout_segmented(VGMSTREAM* vgmstream, int32_t seek_sample);
+void loop_layout_segmented(VGMSTREAM* vgmstream, int32_t loop_sample);
 VGMSTREAM *allocate_segmented_vgmstream(segmented_layout_data* data, int loop_flag, int loop_start_segment, int loop_end_segment);
 
 void render_vgmstream_layered(sample_t* buffer, int32_t sample_count, VGMSTREAM* vgmstream);
@@ -67,7 +68,8 @@ layered_layout_data* init_layout_layered(int layer_count);
 int setup_layout_layered(layered_layout_data* data);
 void free_layout_layered(layered_layout_data* data);
 void reset_layout_layered(layered_layout_data* data);
-void loop_layout_layered(VGMSTREAM* vgmstream, int32_t seek_sample);
+void seek_layout_layered(VGMSTREAM* vgmstream, int32_t seek_sample);
+void loop_layout_layered(VGMSTREAM* vgmstream, int32_t loop_sample);
 VGMSTREAM *allocate_layered_vgmstream(layered_layout_data* data);
 
 #endif

--- a/src/layout/segmented.c
+++ b/src/layout/segmented.c
@@ -115,7 +115,7 @@ static inline void copy_samples(sample_t* outbuf, segmented_layout_data* data, i
 }
 
 
-void loop_layout_segmented(VGMSTREAM* vgmstream, int32_t loop_sample) {
+void seek_layout_segmented(VGMSTREAM* vgmstream, int32_t seek_sample) {
     int segment, total_samples;
     segmented_layout_data* data = vgmstream->layout_data;
 
@@ -124,13 +124,13 @@ void loop_layout_segmented(VGMSTREAM* vgmstream, int32_t loop_sample) {
     while (total_samples < vgmstream->num_samples) {
         int32_t segment_samples = vgmstream_get_samples(data->segments[segment]);
 
-        /* find if loop falls within segment's samples */
-        if (loop_sample >= total_samples && loop_sample < total_samples + segment_samples) {
-            int32_t loop_relative = loop_sample - total_samples;
+        /* find if sample falls within segment's samples */
+        if (seek_sample >= total_samples && seek_sample < total_samples + segment_samples) {
+            int32_t seek_relative = seek_sample - total_samples;
 
-            seek_vgmstream(data->segments[segment], loop_relative);
+            seek_vgmstream(data->segments[segment], seek_relative);
             data->current_segment = segment;
-            vgmstream->samples_into_block = loop_relative;
+            vgmstream->samples_into_block = seek_relative;
             break;
         }
         total_samples += segment_samples;
@@ -138,8 +138,12 @@ void loop_layout_segmented(VGMSTREAM* vgmstream, int32_t loop_sample) {
     }
 
     if (segment == data->segment_count) {
-        VGM_LOG("SEGMENTED: can't find loop segment\n");
+        VGM_LOG("SEGMENTED: can't find seek segment\n");
     }
+}
+
+void loop_layout_segmented(VGMSTREAM* vgmstream, int32_t loop_sample) {
+    loop_layout_segmented(vgmstream, loop_sample);
 }
 
 

--- a/src/meta/aax.c
+++ b/src/meta/aax.c
@@ -105,7 +105,7 @@ VGMSTREAM * init_vgmstream_aax(STREAMFILE *streamFile) {
         }
     }
 
-    channel_count = data->segments[0]->channels;
+    channel_count = data->output_channels;
 
 
     /* build the VGMSTREAM */

--- a/src/meta/mus_acm.c
+++ b/src/meta/mus_acm.c
@@ -78,7 +78,7 @@ VGMSTREAM * init_vgmstream_mus_acm(STREAMFILE *streamFile) {
         goto fail;
 
 
-    channel_count = data->segments[0]->channels;
+    channel_count = data->output_channels;
 
 
     /* build the VGMSTREAM */

--- a/src/meta/riff.c
+++ b/src/meta/riff.c
@@ -347,8 +347,9 @@ VGMSTREAM* init_vgmstream_riff(STREAMFILE* sf) {
      * .at9: standard ATRAC9
      * .saf: Whacked! (Xbox)
      * .mwv: Level-5 games [Dragon Quest VIII (PS2), Rogue Galaxy (PS2)]
+     * .ima: Baja: Edge of Control (PS3/X360)
      */
-    if ( check_extensions(sf, "wav,lwav,xwav,da,dax,cd,med,snd,adx,adp,xss,xsew,adpcm,adw,wd,,sbv,wvx,str,at3,rws,aud,at9,saf") ) {
+    if ( check_extensions(sf, "wav,lwav,xwav,da,dax,cd,med,snd,adx,adp,xss,xsew,adpcm,adw,wd,,sbv,wvx,str,at3,rws,aud,at9,saf,ima") ) {
         ;
     }
     else if ( check_extensions(sf, "mwv") ) {

--- a/src/meta/sadl.c
+++ b/src/meta/sadl.c
@@ -1,59 +1,92 @@
 #include "meta.h"
+#include "../coding/coding.h"
+
 
 /* sadl - from DS games with Procyon Studio audio driver [Professor Layton (DS), Soma Bringer (DS)] */
 VGMSTREAM* init_vgmstream_sadl(STREAMFILE* sf) {
     VGMSTREAM* vgmstream = NULL;
-    int channel_count, loop_flag;
+    int channels, loop_flag;
     off_t start_offset;
+    uint8_t flags;
+    uint32_t loop_start, data_size;
 
 
     /* checks */
     if (!check_extensions(sf, "sad"))
         goto fail;
 
-    if (read_32bitBE(0x00,sf) != 0x7361646c) /* "sadl" */
+    if (read_u32be(0x00,sf) != 0x7361646c) /* "sadl" */
         goto fail;
-    if (read_32bitLE(0x40,sf) != get_streamfile_size(sf))
-        goto fail;
+    /* 04: null */
+    /* 08: data size, or null in later files */
+    /* 0c: version? (x0410=Luminous Arc, 0x0411=Layton, 0x0415=rest) */
+    /* 0e: file id (for .sad packed in .spd) */
+    /* 14: name related? */
+    /* 20: short filename (may be null or nor match full filename) */
 
-    loop_flag = read_8bit(0x31,sf);
-    channel_count = read_8bit(0x32,sf);
-    start_offset = 0x100;
-    
+    /* 30: flags? (0/1/2) */
+    loop_flag = read_u8(0x31,sf);
+    channels = read_u8(0x32,sf);
+    flags = read_u8(0x33,sf);
+    /* 34: flags? */
+    /* 38: flags? */
+    /* 3c: null? */
+    data_size = read_u32le(0x40,sf); //?
+    start_offset = read_u32le(0x48,sf); /* usually 0x100, 0xc0 in LA */
+    /* 4c: start offset again or 0x40 in LA */
+    /* 50: size or samples? */
+    loop_start = read_u32le(0x54,sf); //?
+    /* others: sizes/samples/flags? */
+
+    data_size -= start_offset;
+    loop_start -= start_offset;
+
+
     /* build the VGMSTREAM */
-    vgmstream = allocate_vgmstream(channel_count,loop_flag);
+    vgmstream = allocate_vgmstream(channels, loop_flag);
     if (!vgmstream) goto fail;
 
-    switch (read_8bit(0x33,sf) & 6) {
+    vgmstream->meta_type = meta_SADL;
+
+    switch (flags & 6) { /* possibly > 1? (0/1/2) */
         case 4:
             vgmstream->sample_rate = 32728;
             break;
-        case 2:
+        case 2: /* Layton */
+        case 0: /* Luminous Arc (DS) */
             vgmstream->sample_rate = 16364;
             break;
         default:
             goto fail;
     }
 
-    vgmstream->meta_type = meta_SADL;
-
     vgmstream->layout_type = layout_interleave;
     vgmstream->interleave_block_size = 0x10;
 
-    switch(read_8bit(0x33,sf) & 0xf0) {
+    switch(flags & 0xf0) { /* possibly >> 6? (0/1/2) */
+        case 0x00: /* Luminous Arc (DS) (non-int IMA? all files are mono though) */
         case 0x70: /* Ni no Kuni (DS), Professor Layton and the Curious Village (DS), Soma Bringer (DS) */
             vgmstream->coding_type = coding_IMA_int;
 
-            vgmstream->num_samples = (read_32bitLE(0x40,sf)-start_offset)/channel_count*2;
-            vgmstream->loop_start_sample = (read_32bitLE(0x54,sf)-start_offset)/channel_count*2;
+            vgmstream->num_samples = ima_bytes_to_samples(data_size, channels);
+            vgmstream->loop_start_sample = ima_bytes_to_samples(loop_start, channels);
             vgmstream->loop_end_sample = vgmstream->num_samples;
+
+            {
+                int i;
+                for (i = 0; i < channels; i++) {
+                    vgmstream->ch[i].adpcm_history1_32 = read_s16le(0x80 + i*0x04 + 0x00, sf);
+                    vgmstream->ch[i].adpcm_step_index = read_s16le(0x80 + i*0x04 + 0x02, sf);
+                }
+            }
             break;
 
+        //TODO: Luminous Arc 2 uses a variation of this, but value 0x70
         case 0xb0: /* Soma Bringer (DS), Rekishi Taisen Gettenka (DS) */
             vgmstream->coding_type = coding_NDS_PROCYON;
 
-            vgmstream->num_samples = (read_32bitLE(0x40,sf)-start_offset)/channel_count/16*30;
-            vgmstream->loop_start_sample = (read_32bitLE(0x54,sf)-start_offset)/channel_count/16*30;
+            vgmstream->num_samples = data_size / channels / 16 * 30;
+            vgmstream->loop_start_sample = loop_start / channels / 16 *30;
             vgmstream->loop_end_sample = vgmstream->num_samples;
             break;
 

--- a/src/meta/ubi_bao.c
+++ b/src/meta/ubi_bao.c
@@ -570,7 +570,7 @@ static VGMSTREAM* init_vgmstream_ubi_bao_sequence(ubi_bao_header* bao, STREAMFIL
 
 
     /* build the base VGMSTREAM */
-    vgmstream = allocate_vgmstream(data->segments[0]->channels, !bao->sequence_single);
+    vgmstream = allocate_vgmstream(data->output_channels, !bao->sequence_single);
     if (!vgmstream) goto fail;
 
     vgmstream->meta_type = meta_UBI_BAO;

--- a/src/meta/ubi_sb.c
+++ b/src/meta/ubi_sb.c
@@ -1477,7 +1477,7 @@ static VGMSTREAM* init_vgmstream_ubi_sb_sequence(ubi_sb_header* sb, STREAMFILE* 
         goto fail;
 
     /* build the base VGMSTREAM */
-    vgmstream = allocate_vgmstream(data->segments[0]->channels, !sb->sequence_single);
+    vgmstream = allocate_vgmstream(data->output_channels, !sb->sequence_single);
     if (!vgmstream) goto fail;
 
     vgmstream->meta_type = meta_UBI_SB;

--- a/src/meta/wwise.c
+++ b/src/meta/wwise.c
@@ -40,6 +40,7 @@ typedef struct {
     int block_align;
     int average_bps;
     int bits_per_sample;
+    uint8_t channel_type;
     uint32_t channel_layout;
     size_t extra_size;
 
@@ -462,7 +463,7 @@ VGMSTREAM* init_vgmstream_wwise(STREAMFILE* sf) {
             break;
         }
 
-        case OPUS: { /* alt to Vorbis [Girl Cafe Gun (Mobile)] */
+        case OPUS: { /* fully standard Ogg Opus [Girl Cafe Gun (Mobile)] */
             if (ww.block_align != 0 || ww.bits_per_sample != 0) goto fail;
 
             /* extra: size 0x12 */
@@ -484,18 +485,26 @@ VGMSTREAM* init_vgmstream_wwise(STREAMFILE* sf) {
             break;
         }
 
-        case OPUSWW: {   /* updated Opus [Assassin's Creed Valhalla (PC)] */
-            int skip, table_count;
-        
+        case OPUSWW: { /* updated Opus [Assassin's Creed Valhalla (PC)] */
+            int mapping;
+            opus_config cfg = {0};
+
             if (ww.block_align != 0 || ww.bits_per_sample != 0) goto fail;
             if (!ww.seek_offset) goto fail;
 
-            /* extra: size 0x10 */
+            cfg.channels = ww.channels;
+            cfg.table_offset = ww.seek_offset;
+
+            /* extra: size 0x10 (though last 2 fields are beyond, AK plz) */
             /* 0x12: samples per frame */
             vgmstream->num_samples = read_s32(ww.fmt_offset + 0x18, sf);
-            table_count = read_u32(ww.fmt_offset + 0x1c, sf); /* same as seek size / 2 */
-            skip = read_u16(ww.fmt_offset + 0x20, sf);
-            /* 0x22: 1? (though extra size is declared as 0x10 so this is outsize, AK plz */
+            cfg.table_count = read_u32(ww.fmt_offset + 0x1c, sf); /* same as seek size / 2 */
+            cfg.skip = read_u16(ww.fmt_offset + 0x20, sf);
+            /* 0x22: codec version */
+            mapping = read_u8(ww.fmt_offset + 0x23, sf);
+
+            if (read_u8(ww.fmt_offset + 0x22, sf) != 1)
+                goto fail;
 
             /* OPUS is VBR so this is very approximate percent, meh */
             if (ww.truncated) {
@@ -504,8 +513,42 @@ VGMSTREAM* init_vgmstream_wwise(STREAMFILE* sf) {
                 ww.data_size = ww.file_size - start_offset;
             }
 
+            /* AK does some wonky implicit config for multichannel */
+            if (mapping == 1 && ww.channel_type == 1) { /* only allowed values ATM, set when >2ch */
+                static const int8_t mapping_matrix[8][8] = {
+                    { 0, 0, 0, 0, 0, 0, 0, 0, },
+                    { 0, 1, 0, 0, 0, 0, 0, 0, },
+                    { 0, 2, 1, 0, 0, 0, 0, 0, },
+                    { 0, 1, 2, 3, 0, 0, 0, 0, },
+                    { 0, 4, 1, 2, 3, 0, 0, 0, },
+                    { 0, 4, 1, 2, 3, 5, 0, 0, },
+                    { 0, 6, 1, 2, 3, 4, 5, 0, },
+                    { 0, 6, 1, 2, 3, 4, 5, 7, },
+                };
+                int i;
+
+                /* find coupled OPUS streams (internal streams using 2ch) */
+                switch(ww.channel_layout) {
+                    case mapping_7POINT1_surround:  cfg.coupled_count = 3; break;   /* 2ch+2ch+2ch+1ch+1ch, 5 streams */
+                    case mapping_5POINT1_surround:                                  /* 2ch+2ch+1ch+1ch, 4 streams */
+                    case mapping_QUAD_side:         cfg.coupled_count = 2; break;   /* 2ch+2ch, 2 streams */
+                    case mapping_2POINT1_xiph:                                      /* 2ch+1ch, 2 streams */
+                    case mapping_STEREO:            cfg.coupled_count = 1; break;   /* 2ch, 1 stream */
+                    default:                        cfg.coupled_count = 0; break;   /* 1ch, 1 stream */
+                    //TODO: AK OPUS doesn't seem to handles others mappings, though AK's .h imply they exist (uses 0 coupleds?)
+                }
+
+                /* total number internal OPUS streams (should be >0) */
+                cfg.stream_count = ww.channels - cfg.coupled_count;
+
+                /* channel assignments */
+                for (i = 0; i < ww.channels; i++) {
+                    cfg.channel_mapping[i] = mapping_matrix[ww.channels - 1][i];
+                }
+            }
+
             /* Wwise Opus saves all frame sizes in the seek table */
-            vgmstream->codec_data = init_ffmpeg_wwise_opus(sf, ww.seek_offset, table_count, ww.data_offset, ww.data_size, ww.channels, skip);
+            vgmstream->codec_data = init_ffmpeg_wwise_opus(sf, ww.data_offset, ww.data_size, &cfg);
             if (!vgmstream->codec_data) goto fail;
             vgmstream->coding_type = coding_FFmpeg;
             vgmstream->layout_type = layout_none;
@@ -648,6 +691,7 @@ static int parse_wwise(STREAMFILE* sf, wwise_header* ww) {
      * - HEVAG: very off
      * - XMA2: exact file size
      * - some RIFX have LE size
+     * Value is ignored by AK's parser (set to -1).
      * (later we'll validate "data" which fortunately is correct)
      */
     if (read_u32(0x04,sf) + 0x04 + 0x04 != ww->file_size) {
@@ -743,6 +787,7 @@ static int parse_wwise(STREAMFILE* sf, wwise_header* ww) {
              * - 4b: eConfigType  (0=none, 1=standard, 2=ambisonic)
              * - 19b: uChannelMask */
             if ((ww->channel_layout & 0xFF) == ww->channels) {
+                ww->channel_type = (ww->channel_layout >> 8) & 0x0F;
                 ww->channel_layout = (ww->channel_layout >> 12);
             }
         }

--- a/src/meta/wwise.c
+++ b/src/meta/wwise.c
@@ -484,12 +484,11 @@ VGMSTREAM* init_vgmstream_wwise(STREAMFILE* sf) {
             break;
         }
 
-#if 0   // disabled until more files/tests
         case OPUSWW: {   /* updated Opus [Assassin's Creed Valhalla (PC)] */
             int skip, table_count;
         
             if (ww.block_align != 0 || ww.bits_per_sample != 0) goto fail;
-            if (!ww.seek_offset)) goto fail;
+            if (!ww.seek_offset) goto fail;
 
             /* extra: size 0x10 */
             /* 0x12: samples per frame */
@@ -512,7 +511,6 @@ VGMSTREAM* init_vgmstream_wwise(STREAMFILE* sf) {
             vgmstream->layout_type = layout_none;
             break;
         }
-#endif
 
 #endif
         case HEVAG: /* PSV */
@@ -781,13 +779,13 @@ static int parse_wwise(STREAMFILE* sf, wwise_header* ww) {
         case 0x0166: ww->codec = XMA2; break; /* fmt-chunk XMA */
         case 0xAAC0: ww->codec = AAC; break;
         case 0xFFF0: ww->codec = DSP; break;
-        case 0xFFFB: ww->codec = HEVAG; break;
+        case 0xFFFB: ww->codec = HEVAG; break; /* "VAG" */
         case 0xFFFC: ww->codec = ATRAC9; break;
         case 0xFFFE: ww->codec = PCM; break; /* "PCM for Wwise Authoring" */
         case 0xFFFF: ww->codec = VORBIS; break;
         case 0x3039: ww->codec = OPUSNX; break; /* renamed from "OPUS" on Wwise 2018.1 */
         case 0x3040: ww->codec = OPUS; break;
-        case 0x3041: ww->codec = OPUSWW; break; /* added on Wwise 2019.2.3, presumably replaces OPUS */
+        case 0x3041: ww->codec = OPUSWW; break; /* "OPUS_WEM", added on Wwise 2019.2.3, replaces OPUS */
         case 0x8311: ww->codec = PTADPCM; break; /* added on Wwise 2019.1, replaces IMA */
         default:
             goto fail;

--- a/src/meta/xwb.c
+++ b/src/meta/xwb.c
@@ -9,7 +9,7 @@
 #define WAVEBANKENTRY_FLAGS_IGNORELOOP      0x00000008  // Used internally when the loop region can't be used (no idea...)
 
 /* the x.x version is just to make it clearer, MS only classifies XACT as 1/2/3 */
-#define XACT1_0_MAX     1           /* Project Gotham Racing 2 (v1), Silent Hill 4 (v1) */
+#define XACT1_0_MAX     1           /* Project Gotham Racing 2 (v1), Silent Hill 4 (v1), Shin Megami Tensei NINE (v1) */
 #define XACT1_1_MAX     3           /* Unreal Championship (v2), The King of Fighters 2003 (v3) */
 #define XACT2_0_MAX     34          /* Dead or Alive 4 (v17), Kameo (v23), Table Tennis (v34) */ // v35/36/37 too?
 #define XACT2_1_MAX     38          /* Prey (v38) */ // v39 too?
@@ -471,12 +471,12 @@ VGMSTREAM* init_vgmstream_xwb(STREAMFILE* sf) {
             break;
 
 #ifdef VGM_USE_FFMPEG
-        case XMA1: { /* Kameo (X360) */
+        case XMA1: { /* Kameo (X360), Table Tennis (X360) */
             uint8_t buf[0x100];
             int bytes;
 
-            bytes = ffmpeg_make_riff_xma1(buf,0x100, vgmstream->num_samples, xwb.stream_size, vgmstream->channels, vgmstream->sample_rate, 0);
-            vgmstream->codec_data = init_ffmpeg_header_offset(sf, buf,bytes, xwb.stream_offset,xwb.stream_size);
+            bytes = ffmpeg_make_riff_xma1(buf, sizeof(buf), vgmstream->num_samples, xwb.stream_size, vgmstream->channels, vgmstream->sample_rate, 0);
+            vgmstream->codec_data = init_ffmpeg_header_offset(sf, buf, bytes, xwb.stream_offset,xwb.stream_size);
             if (!vgmstream->codec_data) goto fail;
             vgmstream->coding_type = coding_FFmpeg;
             vgmstream->layout_type = layout_none;
@@ -499,8 +499,8 @@ VGMSTREAM* init_vgmstream_xwb(STREAMFILE* sf) {
             block_size = 0x10000; /* XACT default */
             block_count = xwb.stream_size / block_size + (xwb.stream_size % block_size ? 1 : 0);
 
-            bytes = ffmpeg_make_riff_xma2(buf,0x100, vgmstream->num_samples, xwb.stream_size, vgmstream->channels, vgmstream->sample_rate, block_count, block_size);
-            vgmstream->codec_data = init_ffmpeg_header_offset(sf, buf,bytes, xwb.stream_offset,xwb.stream_size);
+            bytes = ffmpeg_make_riff_xma2(buf, sizeof(buf), vgmstream->num_samples, xwb.stream_size, vgmstream->channels, vgmstream->sample_rate, block_count, block_size);
+            vgmstream->codec_data = init_ffmpeg_header_offset(sf, buf, bytes, xwb.stream_offset,xwb.stream_size);
             if (!vgmstream->codec_data) goto fail;
             vgmstream->coding_type = coding_FFmpeg;
             vgmstream->layout_type = layout_none;
@@ -537,8 +537,8 @@ VGMSTREAM* init_vgmstream_xwb(STREAMFILE* sf) {
             block_align = wma_block_align_index[block_index];
             wma_codec = xwb.bits_per_sample ? 0x162 : 0x161; /* 0=WMAudio2, 1=WMAudio3 */
 
-            bytes = ffmpeg_make_riff_xwma(buf,0x100, wma_codec, xwb.stream_size, vgmstream->channels, vgmstream->sample_rate, avg_bps, block_align);
-            vgmstream->codec_data = init_ffmpeg_header_offset(sf, buf,bytes, xwb.stream_offset,xwb.stream_size);
+            bytes = ffmpeg_make_riff_xwma(buf, sizeof(buf), wma_codec, xwb.stream_size, vgmstream->channels, vgmstream->sample_rate, avg_bps, block_align);
+            vgmstream->codec_data = init_ffmpeg_header_offset(sf, buf, bytes, xwb.stream_offset,xwb.stream_size);
             if (!vgmstream->codec_data) goto fail;
             vgmstream->coding_type = coding_FFmpeg;
             vgmstream->layout_type = layout_none;
@@ -646,7 +646,7 @@ static int get_xsb_name(char* buf, size_t maxsize, int target_subsong, xwb_heade
         goto fail;
 
     if ((xwb->version <= XACT1_1_MAX && xsb.version > XSB_XACT1_2_MAX) ||
-        (xwb->version <= XACT2_2_MAX && xsb.version > XSB_XACT2_MAX)) {
+        (xwb->version <= XACT2_2_MAX && xsb.version > XSB_XACT2_2_MAX)) {
         VGM_LOG("XSB: mismatched XACT versions: xsb v%i vs xwb v%i\n", xsb.version, xwb->version);
         goto fail;
     }

--- a/src/render.c
+++ b/src/render.c
@@ -361,7 +361,7 @@ static int render_pad_begin(VGMSTREAM* vgmstream, sample_t* buf, int samples_to_
     return to_do;
 }
 
-static int render_fade(VGMSTREAM* vgmstream, sample_t* buf, int samples_done) {
+static int render_fade(VGMSTREAM* vgmstream, sample_t* buf, int samples_left) {
     play_state_t* ps = &vgmstream->pstate;
     //play_config_t* pc = &vgmstream->config;
 
@@ -376,7 +376,7 @@ static int render_fade(VGMSTREAM* vgmstream, sample_t* buf, int samples_done) {
         int32_t to_do = ps->fade_left;
 
         if (ps->play_position < ps->fade_start) {
-            start = samples_done - (ps->play_position + samples_done - ps->fade_start);
+            start = samples_left - (ps->play_position + samples_left - ps->fade_start);
             fade_pos = 0;
         }
         else {
@@ -384,8 +384,8 @@ static int render_fade(VGMSTREAM* vgmstream, sample_t* buf, int samples_done) {
             fade_pos = ps->play_position - ps->fade_start;
         }
 
-        if (to_do > samples_done - start)
-            to_do = samples_done - start;
+        if (to_do > samples_left - start)
+            to_do = samples_left - start;
 
         //TODO: use delta fadedness to improve performance?
         for (s = start; s < start + to_do; s++, fade_pos++) {
@@ -398,27 +398,31 @@ static int render_fade(VGMSTREAM* vgmstream, sample_t* buf, int samples_done) {
         ps->fade_left -= to_do;
 
         /* next samples after fade end would be pad end/silence, so we can just memset */
-        memset(buf + (start + to_do) * channels, 0, (samples_done - to_do - start) * sizeof(sample_t) * channels);
-
-        return samples_done;
+        memset(buf + (start + to_do) * channels, 0, (samples_left - to_do - start) * sizeof(sample_t) * channels);
+        return samples_left; //start + to_do;
     }
 }
 
-static int render_pad_end(VGMSTREAM* vgmstream, sample_t* buf, int samples_done) {
+static int render_pad_end(VGMSTREAM* vgmstream, sample_t* buf, int samples_left) {
     play_state_t* ps = &vgmstream->pstate;
     int channels = vgmstream->pstate.output_channels;
     int start = 0;
+    int32_t to_do = samples_left;
 
-    /* since anything beyond pad end is silence no need to check end */
+    /* pad end works like fades, where part of buf done it may be valid data and part padding (silent),
+     * so needs positions (since anything beyond pad end start is silence no need to check end) */
     if (ps->play_position < ps->pad_end_start) {
-        start = samples_done - (ps->play_position + samples_done - ps->pad_end_start);
+        start = samples_left - (ps->play_position + samples_left - ps->pad_end_start);
     }
     else {
         start = 0;
     }
 
-    memset(buf + (start * channels), 0, (samples_done - start) * channels * sizeof(sample_t));
-    return samples_done;
+    if (to_do > samples_left - start)
+        to_do = samples_left - start;
+
+    memset(buf + (start * channels), 0, to_do * sizeof(sample_t) * channels);
+    return samples_left; //start + to_do;
 }
 
 
@@ -455,7 +459,7 @@ int render_vgmstream(sample_t* buf, int32_t sample_count, VGMSTREAM* vgmstream) 
 
     /* end padding (done before to avoid decoding if possible, samples_to_do becomes 0) */
     if (!vgmstream->config.play_forever /* && ps->pad_end_left */
-            && ps->play_position + samples_done >= ps->pad_end_start
+            && ps->play_position + samples_to_do >= ps->pad_end_start
             && samples_to_do) {
         done = render_pad_end(vgmstream, tmpbuf, samples_to_do);
         samples_done += done;

--- a/src/vgmstream.h
+++ b/src/vgmstream.h
@@ -767,16 +767,19 @@ typedef enum {
 } speaker_t;
 
 /* typical mappings that metas may use to set channel_layout (but plugin must actually use it)
- * (in order, so 3ch file could be mapped to FL FR FC or FL FR LFE but not LFE FL FR) */
+ * (in order, so 3ch file could be mapped to FL FR FC or FL FR LFE but not LFE FL FR)
+ * not too sure about names but no clear standards */
 typedef enum {
     mapping_MONO             = speaker_FC,
     mapping_STEREO           = speaker_FL | speaker_FR,
     mapping_2POINT1          = speaker_FL | speaker_FR | speaker_LFE,
-    mapping_2POINT1_xiph     = speaker_FL | speaker_FR | speaker_FC,
+    mapping_2POINT1_xiph     = speaker_FL | speaker_FR | speaker_FC, /* aka 3STEREO? */
     mapping_QUAD             = speaker_FL | speaker_FR | speaker_BL  | speaker_BR,
     mapping_QUAD_surround    = speaker_FL | speaker_FR | speaker_FC  | speaker_BC,
+    mapping_QUAD_side        = speaker_FL | speaker_FR | speaker_SL  | speaker_SR,
     mapping_5POINT0          = speaker_FL | speaker_FR | speaker_LFE | speaker_BL | speaker_BR,
     mapping_5POINT0_xiph     = speaker_FL | speaker_FR | speaker_FC  | speaker_BL | speaker_BR,
+    mapping_5POINT0_surround = speaker_FL | speaker_FR | speaker_FC  | speaker_SL | speaker_SR,
     mapping_5POINT1          = speaker_FL | speaker_FR | speaker_FC  | speaker_LFE | speaker_BL | speaker_BR,
     mapping_5POINT1_surround = speaker_FL | speaker_FR | speaker_FC  | speaker_LFE | speaker_SL | speaker_SR,
     mapping_7POINT0          = speaker_FL | speaker_FR | speaker_FC  | speaker_LFE | speaker_BC | speaker_FLC | speaker_FRC,
@@ -998,6 +1001,7 @@ typedef struct {
     sample_t* buffer;
     int input_channels;     /* internal buffer channels */
     int output_channels;    /* resulting channels (after mixing, if applied) */
+    int mixed_channels;     /* segments have different number of channels */
 } segmented_layout_data;
 
 /* for files made of "parallel" layers, one per group of channels (using a complete sub-VGMSTREAM) */


### PR DESCRIPTION
- Add .mwa extension [Fatal Frame (Xbox)]
- Fix some .xwb+xsb name issues [LocoCycle (X360)]
- Enable Wwise OPUS [Assassin's Creed Valhalla (PC)]
- Fix some .sad [Luminous Arc (DS)]
- Tweak layer-v mixing in some cases and improve performance
- Fix segfault when using pad end in some cases
- Fix some pad end issues with segmented layout
- Allow segments of different number of channels
- Fix multichannel Wwise Opus
- Add RIFF .ima [Baja: Edge of Control (PS3/X360)]
- Improve seeking speed in layered/segmented layout in some cases
