### PR TITLE
txtp snds

### DIFF
--- a/doc/TXTP.md
+++ b/doc/TXTP.md
@@ -165,7 +165,7 @@ mode = layers
 - `type`: group as `S`=segments, `L`=layers, or `R`=pseudo-random
 - `count`: number of files in group (optional, default is all)
 - `repeat`: R=repeat group of `count` files until end (optional, default is no repeat)
-- `>file`: select file in pseudo-random groups (ignored for others)
+- `>file`: select file (for pseudo-random groups)
 
 Examples:
 - `L`: take all files as layers (equivalent to `mode = layers`)
@@ -193,7 +193,7 @@ group = -S2  #segment prev 2 (will start from pos.1 = bgm1+2, makes group of bgm
 ```
 
 ### Pseudo-random groups
-Group `R` is meant to help with games that randomly select a file in a group. You can set with `>N` which file will be selected. This way you can quickly edit the TXTP and change the file (you could just comment files too, this is just for convenience in complex cases and testing). You can also set `>-`, meaning "play all", basically turning `R` into `S`. Files do need to exist and are parsed before being selected, and it can select groups too.
+Group `R` is meant to help with games that randomly select a file in a group. You can set with `>N` which file will be selected. This way you can quickly edit the TXTP and change the file (you could just comment files too, this is just for convenience in complex cases and testing). You can also set `>-`, meaning "play all", basically turning `R` into `S` (this can be ommited, but it's clearer). Files do need to exist and are parsed before being selected, and it can select groups too.
 ```
  bgm1.adx
  bgm2.adx

--- a/src/decode.c
+++ b/src/decode.c
@@ -341,6 +341,7 @@ int get_vgmstream_samples_per_frame(VGMSTREAM* vgmstream) {
         case coding_SDX2:
         case coding_SDX2_int:
         case coding_CBD2:
+        case coding_CBD2_int:
         case coding_ACM:
         case coding_DERF:
         case coding_WADY:
@@ -540,6 +541,7 @@ int get_vgmstream_frame_size(VGMSTREAM* vgmstream) {
         case coding_SDX2:
         case coding_SDX2_int:
         case coding_CBD2:
+        case coding_CBD2_int:
         case coding_DERF:
         case coding_WADY:
         case coding_NWA:

--- a/src/layout/blocked_str_snds.c
+++ b/src/layout/blocked_str_snds.c
@@ -1,54 +1,39 @@
 #include "layout.h"
 #include "../vgmstream.h"
 
-/* set up for the block at the given offset */
-void block_update_str_snds(off_t block_offset, VGMSTREAM * vgmstream) {
-    off_t current_chunk;
-    size_t file_size;
+
+void block_update_str_snds(off_t block_offset, VGMSTREAM* vgmstream) {
+    STREAMFILE* sf = vgmstream->ch[0].streamfile;
+    uint32_t block_type, block_subtype, block_size, block_current;
     int i;
-    STREAMFILE *streamfile;
-    int FoundSSMP = 0;
-    off_t SSMP_offset = -1;
 
-    current_chunk = block_offset;
-    streamfile = vgmstream->ch[0].streamfile;
-    file_size = get_streamfile_size(streamfile);
+    /* EOF reads: signal we have nothing and let the layout fail */
+    if (block_offset >= get_streamfile_size(sf)) {
+        vgmstream->current_block_samples = -1;
+        return;
+    }
 
-    /* we may have to skip some chunks */
-    while (!FoundSSMP && current_chunk < file_size) {
-        if (current_chunk+read_32bitBE(current_chunk+4,streamfile)>=file_size)
-            break;
-        switch (read_32bitBE(current_chunk,streamfile)) {
-            case 0x534e4453:    /* SNDS */
-                /* SSMP */
-                if (read_32bitBE(current_chunk+0x10,streamfile)==0x53534d50) {
-                    FoundSSMP = 1;
-                    SSMP_offset = current_chunk;
-                }
-                break;
-            case 0x46494c4c:    /* FILL, the main culprit */
-            default:
-                break;
+
+    block_type = read_u32be(block_offset + 0x00,sf);
+    block_size = read_u32be(block_offset + 0x04,sf);
+
+    block_current = 0; /* ignore block by default (other chunks include MPVD + VHDR/FRAM and FILL) */
+    if (block_type == 0x534e4453) { /* SNDS */
+        block_subtype = read_u32be(block_offset + 0x10,sf); /* SNDS */
+        if (block_subtype == 0x53534d50) {
+            block_current = read_u32be(block_offset + 0x14, sf) / vgmstream->channels;
         }
-
-        current_chunk += read_32bitBE(current_chunk+4,streamfile);
     }
 
-    if (!FoundSSMP) {
-        /* if we couldn't find it all we can do is try playing the current
-         * block, which is going to suck */
-        vgmstream->current_block_offset = block_offset;
-    }
+    /* seen in Battle Tryst video frames */
+    if (block_size % 0x04)
+        block_size += 0x04 - (block_size % 0x04);
 
-    vgmstream->current_block_offset = SSMP_offset;
-    vgmstream->current_block_size = (read_32bitBE(
-            vgmstream->current_block_offset+4,
-            vgmstream->ch[0].streamfile) - 0x18) / vgmstream->channels;
-    vgmstream->next_block_offset = vgmstream->current_block_offset +
-            read_32bitBE(vgmstream->current_block_offset+4,
-                    vgmstream->ch[0].streamfile);
+    vgmstream->current_block_offset = block_offset;
+    vgmstream->next_block_offset = block_offset + block_size;
+    vgmstream->current_block_size = block_current;
 
     for (i = 0; i < vgmstream->channels; i++) {
-        vgmstream->ch[i].offset = vgmstream->current_block_offset + 0x18 + i * vgmstream->interleave_block_size;
+        vgmstream->ch[i].offset = block_offset + 0x18 + i * vgmstream->interleave_block_size;
     }
 }

--- a/src/meta/ngc_adpdtk.c
+++ b/src/meta/ngc_adpdtk.c
@@ -3,45 +3,54 @@
 #include "../util.h"
 
 /* DTK - headerless Nintendo GC DTK file [Harvest Moon: Another Wonderful Life (GC), XGRA (GC)] */
-VGMSTREAM * init_vgmstream_ngc_adpdtk(STREAMFILE *streamFile) {
-    VGMSTREAM * vgmstream = NULL;
+VGMSTREAM* init_vgmstream_ngc_adpdtk(STREAMFILE* sf) {
+    VGMSTREAM* vgmstream = NULL;
     off_t start_offset;
-    int channel_count, loop_flag;
+    int channels, loop_flag;
 
 
     /* checks */
-    /* .dtk: standard [XGRA (GC)], .adp: standard [Harvest Moon AWL (GC)], .wav/lwav: Alien Hominid (GC) */
-    if ( !check_extensions(streamFile,"dtk,adp,wav,lwav"))
+    /* .dtk: standard [XGRA (GC)]
+     * .adp: standard [Harvest Moon AWL (GC)]
+     * .wav/lwav: Alien Hominid (GC) */
+    if (!check_extensions(sf,"dtk,adp,wav,lwav"))
         goto fail;
 
     /* check valid frames as files have no header, and .adp/wav are common */
     {
         int i;
         for (i = 0; i < 10; i++) { /* try a bunch of frames */
-            if (read_8bit(0x00 + i*0x20,streamFile) != read_8bit(0x02 + i*0x20,streamFile) ||
-                read_8bit(0x01 + i*0x20,streamFile) != read_8bit(0x03 + i*0x20,streamFile))
-                goto fail;
             /* header 0x00/01 are repeated in 0x02/03 (for error correction?),
              * could also test header values (upper nibble should be 0..3, and lower nibble 0..C) */
+            if (read_8bit(0x00 + i*0x20,sf) != read_8bit(0x02 + i*0x20,sf) ||
+                read_8bit(0x01 + i*0x20,sf) != read_8bit(0x03 + i*0x20,sf))
+                goto fail;
+
+            /* frame headers for silent frames are 0x0C, never null */
+            if (read_8bit(0x00 + i*0x20,sf) == 0x00)
+                goto fail;
         }
     }
 
-    /* always stereo, no loop (since it's hardware-decoded and streamed) */
-    channel_count = 2;
+    /* DTK (Disc Track) are DVD hardware-decoded streams, always stereo and no loop.
+     * Some games fake looping by calling DVD commands to set position with certain timing.
+     * Though headerless, format is HW-wired to those specs. */
+    channels = 2;
     loop_flag = 0;
     start_offset = 0x00;
 
+
     /* build the VGMSTREAM */
-    vgmstream = allocate_vgmstream(channel_count, loop_flag);
+    vgmstream = allocate_vgmstream(channels, loop_flag);
     if (!vgmstream) goto fail;
 
-    vgmstream->num_samples = get_streamfile_size(streamFile) / 0x20 * 28;
+    vgmstream->num_samples = get_streamfile_size(sf) / 0x20 * 28;
     vgmstream->sample_rate = 48000; /* due to a GC hardware defect this may be closer to 48043 */
     vgmstream->coding_type = coding_NGC_DTK;
     vgmstream->layout_type = layout_none;
     vgmstream->meta_type = meta_NGC_ADPDTK;
 
-    if ( !vgmstream_open_stream(vgmstream, streamFile, start_offset) )
+    if ( !vgmstream_open_stream(vgmstream, sf, start_offset) )
         goto fail;
 
     return vgmstream;

--- a/src/meta/str_snds.c
+++ b/src/meta/str_snds.c
@@ -13,10 +13,10 @@ VGMSTREAM* init_vgmstream_str_snds(STREAMFILE* sf) {
 
     /* checks */
     /* .str: standard
+     * .stream: Battle Tryst (Arcade) movies
      * .3do: Aqua World - Umimi Monogatari (3DO) movies */
-    if (!check_extensions(sf, "str,3do"))
+    if (!check_extensions(sf, "str,stream,3do"))
         goto fail;
-
     if (read_u32be(0x00,sf) != 0x4354524c &&   /* "CTRL" */
         read_u32be(0x00,sf) != 0x534e4453 &&   /* "SNDS" */
         read_u32be(0x00,sf) != 0x53484452)     /* "SHDR" */
@@ -96,14 +96,24 @@ VGMSTREAM* init_vgmstream_str_snds(STREAMFILE* sf) {
     vgmstream->num_samples /= vgmstream->channels;
 
     switch (read_u32be(shdr_offset + 0x24,sf)) {
-        case 0x53445832:    /* "SDX2" */
+        case 0x53445832:    /* "SDX2" (common) */
             if (channels > 1) {
                 vgmstream->coding_type = coding_SDX2_int;
-                vgmstream->interleave_block_size = 1;
+                vgmstream->interleave_block_size = 0x01;
             } else {
                 vgmstream->coding_type = coding_SDX2;
             }
             break;
+
+        case 0x43424432:    /* "CBD2" (rare, Battle Tryst) */
+            if (channels > 1) {
+                vgmstream->coding_type = coding_CBD2_int;
+                vgmstream->interleave_block_size = 0x01;
+            } else {
+                vgmstream->coding_type = coding_CBD2; /* assumed */
+            }
+            break;
+
         default:
             goto fail;
     }

--- a/src/meta/txtp.c
+++ b/src/meta/txtp.c
@@ -184,7 +184,6 @@ VGMSTREAM* init_vgmstream_txtp(STREAMFILE* sf) {
 
     clean_txtp(txtp, 0);
     return vgmstream;
-
 fail:
     clean_txtp(txtp, 1);
     return NULL;
@@ -444,7 +443,7 @@ static int make_group_segment(txtp_header* txtp, txtp_group* grp, int position, 
 
 
     /* special "whole loop" settings */
-    if (grp->entry.loop_anchor_start == 1) {
+    if (grp && grp->entry.loop_anchor_start == 1) {
         grp->entry.config.config_set = 1;
         grp->entry.config.really_force_loop = 1;
     }
@@ -506,8 +505,8 @@ static int make_group_layer(txtp_header* txtp, txtp_group* grp, int position, in
 
 
     /* special "whole loop" settings (also loop if this group becomes final vgmstream) */
-    if (grp->entry.loop_anchor_start == 1
-            || (position == 0 && txtp->vgmstream_count == count && txtp->is_loop_auto)) {
+    if (grp && (grp->entry.loop_anchor_start == 1
+            || (position == 0 && txtp->vgmstream_count == count && txtp->is_loop_auto))) {
         grp->entry.config.config_set = 1;
         grp->entry.config.really_force_loop = 1;
     }
@@ -568,7 +567,7 @@ static int make_group_random(txtp_header* txtp, txtp_group* grp, int position, i
 
 
     /* special "whole loop" settings */
-    if (grp->entry.loop_anchor_start == 1) {
+    if (grp && grp->entry.loop_anchor_start == 1) {
         grp->entry.config.config_set = 1;
         grp->entry.config.really_force_loop = 1;
     }
@@ -576,7 +575,8 @@ static int make_group_random(txtp_header* txtp, txtp_group* grp, int position, i
     /* force selected vgmstream to be a segment when not a group already, and
      * group + vgmstream has config (AKA must loop/modify over the result) */
     //todo could optimize to not generate segment in some cases?
-    if (!(vgmstream->layout_type == layout_layered || vgmstream->layout_type == layout_segmented) &&
+    if (grp &&
+            !(vgmstream->layout_type == layout_layered || vgmstream->layout_type == layout_segmented) &&
             (grp->entry.config.config_set && vgmstream->config.config_set) ) {
         if (!make_group_segment(txtp, grp, position, 1))
             goto fail;

--- a/src/meta/txtp.c
+++ b/src/meta/txtp.c
@@ -1629,14 +1629,20 @@ static int add_group(txtp_header* txtp, char* line) {
 
     m = sscanf(line, " >%c%n", &c, &n);
     if (m == 1 && c == TXTP_GROUP_RANDOM_ALL) {
+        cfg.type = TXTP_GROUP_MODE_RANDOM; /* usually R>- but allows L/S>- */
         cfg.selected = cfg.count; /* special meaning */
         line += n;
     }
     else {
         m = sscanf(line, " >%d%n", &cfg.selected, &n);
         if (m == 1) {
+            cfg.type = TXTP_GROUP_MODE_RANDOM; /* usually R>1 but allows L/S>1 */
             cfg.selected--; /* externally 1=first but internally 0=first */
             line += n;
+        }
+        else if (cfg.type == TXTP_GROUP_MODE_RANDOM) {
+            /* was a random but didn't select anything, just select all */
+            cfg.selected = cfg.count;
         }
     }
 


### PR DESCRIPTION
- Improve perfomance of some de-chunked .txtp
- Tweak DTK detection
- Fix SNDS with CBD2 [Battle Tryst (Arcade)]
- Allow TXTP groups selecting subfiles like random for testing
- Fix TXTP segfault when not using groups