### PR TITLE
switch stereo channels in OKI4S decoding

### DIFF
--- a/src/coding/oki_decoder.c
+++ b/src/coding/oki_decoder.c
@@ -197,7 +197,7 @@ void decode_oki4s(VGMSTREAMCHANNEL* stream, sample_t* outbuf, int channelspacing
                 stream->offset + i :    /* stereo: one nibble per channel */
                 stream->offset + i/2;   /* mono: consecutive nibbles (assumed) */
         int nibble_shift =
-                is_stereo ? (!(channel&1) ? 0:4) : ((i&1) ? 0:4);  /* even = low, odd = high */
+                is_stereo ? ((channel&1) ? 0:4) : ((i&1) ? 0:4);  /* even = high, odd = low */
 
         oki4s_expand_nibble(stream, byte_offset,nibble_shift, &hist1, &step_index, &out_sample);
         outbuf[sample_count] = (out_sample);


### PR DESCRIPTION
(bnnm) the BMP decoder dll does mono and stereo
(bnnm) but I misread the code, so it was high nibble first