### PR TITLE
xnb acx etc

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Available commands are printed when run with no flags. Note that you can also
 achieve similar results for other plugins using TXTP, described later.
 
 With files multiple subsongs you need to specify manually subsong (by design, to avoid
-massive data dumps since some formats have hundred of subsongs), but you could do
+massive data dumps since some formats have hundreds of subsongs), but you could do
 some command line tricks:
 ```
 : REM extracts from subsong 5 to 10 in file.fsb
@@ -259,6 +259,7 @@ which are hardcoded instead of being listed in the header file (e.g. `.mpf+.mus`
 In these cases, you can use *TXTM* format to specify associated companion files.
 See *Artificial files* below for more information.
 
+#### Dual stereo
 A special case of the above is "dual file stereo", where 2 similarly named mono
 files are fused together to make 1 stereo song.
 - `(file)_L.dsp`+`(file)_R.dsp`
@@ -267,16 +268,12 @@ files are fused together to make 1 stereo song.
 - `(file)_0.dsp`+`(file)_1.dsp`
 - `(file)_Left.dsp`+`(file)_Right.dsp`
 - `(file).v0`+`(file).v1`
-This is only allowed in a few formats (mainly `.dsp` and `.vag`). In those cases
-you can open either `L` or `R` and you'll get the same stereo song. If you rename
-one of the files the "pair" won't be found, and both will be played as mono.
 
-`.pos` is a small file with 32 bit little endian values: loop start sample and
-loop end sample. This is a real format, but is sometimes reused to force loops.
-If you want to force looping files consider using *TXTP* instead, as it's much
-simpler to make and cleaner: for example create a text file named `bgm01-loop.txtp`
-and inside write `bgm01.mp3 #I 10.0 90.0`. Open the `.txtp` to play the `.mp3`
-looping from 10 to 90 seconds.
+vgmstream automatically detects these pairs and makes a stereo song from `L` + `R`.
+You can open either `L` or `R` and you'll get the same stereo. If you rename one
+of the files the "pair" won't be found, and both will be played as mono. This
+is only done for a few choice formats (mainly `.dsp` and `.vag`) that commonly
+split audio like that, though.
 
 #### OS case sensitiveness
 When using OS with case sensitive filesystem (mainly Linux), a known issue with
@@ -295,6 +292,16 @@ Currently there isn't any way to know what exact name is needed (other than
 hex-editting), though only a few formats do this, mainly *Ubisoft* banks.
 
 Regular formats without companion files should work fine in upper/lowercase.
+
+#### .pos looping
+`.pos` is a small file with 32 bit little endian values: loop start sample and
+loop end sample. This is a real format, but is sometimes reused to force loops.
+
+If you want to force looping consider using *TXTP* instead, as it's much simpler
+to make and cleaner (plus doesn't hijack a real format). For example, make a text
+file named `bgm01-loop.txtp` and inside write `bgm01.mp3 #I 10.0 90.0`. Open the
+`.txtp` and vgmstream will loop that `.mp3` from 10 to 90 seconds.
+
 
 ### Decryption keys
 Certain formats have encrypted data, and need a key to decrypt. vgmstream
@@ -317,7 +324,7 @@ sample rate, channels, etc) is stored in the .exe or other hard to locate places
 Those can be played using an artificial header with info vgmstream needs.
 
 **GENH**: a byte header placed right before the original data, modyfing it.
-The resulting file must be (name).genh. Contains static header data.
+The resulting file must be `(name).genh`. Contains static header data.
 Programs like VGMToolbox can help to create *GENH*.
 
 **TXTH**: a text header placed in an external file. The TXTH must be named
@@ -325,7 +332,7 @@ Programs like VGMToolbox can help to create *GENH*.
 single file). Contains dynamic text commands to read data from the original
 file, or static values.
 
-*TXTH* is recomended over *GENH* as it's far easier to create and has many
+*TXTH* is recommended over *GENH* as it's far easier to create and has many
 more functions.
 
 For files that already play, sometimes they are used by the game in various

--- a/src/formats.c
+++ b/src/formats.c
@@ -39,6 +39,7 @@ static const char* extension_list[] = {
     //"ac3", //common, FFmpeg/not parsed (AC3)
     "acb",
     "acm",
+    "acx",
     "ad", //txth/reserved [Xenosaga Freaks (PS2)]
     "adc", //txth/reserved [Tomb Raider The Last Revelation (DC), Tomb Raider Chronicles (DC)]
     "adm",

--- a/src/libvgmstream.vcproj
+++ b/src/libvgmstream.vcproj
@@ -501,6 +501,10 @@
                     >
                 </File>
                 <File
+                    RelativePath=".\meta\acx.c"
+                    >
+                </File>
+                <File
                     RelativePath=".\meta\adp_konami.c"
                     >
                 </File>

--- a/src/libvgmstream.vcxproj
+++ b/src/libvgmstream.vcxproj
@@ -282,6 +282,7 @@
     <ClCompile Include="meta\aax.c" />
     <ClCompile Include="meta\acb.c" />
     <ClCompile Include="meta\acm.c" />
+    <ClCompile Include="meta\acx.c" />
     <ClCompile Include="meta\adp_konami.c" />
     <ClCompile Include="meta\adpcm_capcom.c" />
     <ClCompile Include="meta\ads.c" />

--- a/src/libvgmstream.vcxproj.filters
+++ b/src/libvgmstream.vcxproj.filters
@@ -364,6 +364,9 @@
     <ClCompile Include="meta\acm.c">
       <Filter>meta\Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="meta\acx.c">
+      <Filter>meta\Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="meta\adp_konami.c">
       <Filter>meta\Source Files</Filter>
     </ClCompile>

--- a/src/meta/acx.c
+++ b/src/meta/acx.c
@@ -1,0 +1,43 @@
+#include "meta.h"
+#include "../coding/coding.h"
+
+/* .acx - CRI container [Baroque (SAT), Persona 3 (PS2), THE iDOLM@STER: Live For You (X360)] */
+VGMSTREAM* init_vgmstream_acx(STREAMFILE* sf) {
+    VGMSTREAM* vgmstream = NULL;
+    STREAMFILE* temp_sf = NULL;
+    off_t subfile_offset;
+    size_t subfile_size;
+    int total_subsongs, target_subsong = sf->stream_index;
+
+
+    /* checks */
+    if (!check_extensions(sf,"acx"))
+        goto fail;
+    if (read_u32be(0x00,sf) != 0x00000000)
+        goto fail;
+
+    /* simple container for sfx and rarely music [Burning Rangers (SAT)],
+     * mainly used until .csb was introduced */
+
+    total_subsongs = read_u32be(0x04,sf);
+    if (target_subsong == 0) target_subsong = 1;
+    if (target_subsong < 0 || target_subsong > total_subsongs || total_subsongs < 1) goto fail;
+
+    subfile_offset = read_u32be(0x08 + (target_subsong-1) * 0x08 + 0x00,sf);
+    subfile_size   = read_u32be(0x08 + (target_subsong-1) * 0x08 + 0x04,sf);
+
+    temp_sf = setup_subfile_streamfile(sf, subfile_offset, subfile_size, "adx");
+    if (!temp_sf) goto fail;
+
+    vgmstream = init_vgmstream_adx(temp_sf);
+    if (!vgmstream) goto fail;
+
+    vgmstream->num_streams = total_subsongs;
+    close_streamfile(temp_sf);
+    return vgmstream;
+
+fail:
+    close_streamfile(temp_sf);
+    close_vgmstream(vgmstream);
+    return NULL;
+}

--- a/src/meta/adx_keys.h
+++ b/src/meta/adx_keys.h
@@ -20,7 +20,7 @@ static const adxkey_info adxkey8_list[] = {
         {0x49e1,0x4a57,0x553d, "karaage",0},
 
         /* Blood+ (PS2) [Grasshopper Manufacture] */
-        {0x5f5d,0x58bd,0x55ed, NULL,0},     // keystring not in ELF?
+        {0x5f5d,0x58bd,0x55ed, "LOVELOVE",0},   // obfuscated keystring is "KNUDKNUD", adds +1 to chars to get final key
 
         /* Killer7 (PS2) [Grasshopper Manufacture] */
         {0x50fb,0x5803,0x5701, "GHM",0},
@@ -34,14 +34,14 @@ static const adxkey_info adxkey8_list[] = {
         /* Phantasy Star Universe (PC), Phantasy Star Universe: Ambition of the Illuminus (PS2) [Sonic Team] */
         {0x5deb,0x5f27,0x673f, "3x5k62bg9ptbwy",0},
 
-        /* Senko no Ronde [G.rev] */
+        /* Senko no Ronde Rev.X (X360) [G.rev] */
         {0x46d3,0x5ced,0x474d, "ranatus",0},
 
         /* NiGHTS: Journey of Dreams (Wii) [Sonic Team] */
         {0x440b,0x6539,0x5723, "sakakit4649",0},
 
-        /* unknown source */
-        {0x586d,0x5d65,0x63eb, NULL,0},     // from guessadx (unique?)
+        /* The iDOLM@STER: Live For You (X360) [Bandai Namco] (.aix) */
+        {0x586d,0x5d65,0x63eb, "75_501NO_003B",0},
 
         /* Shuffle! On the Stage (PS2) [Navel] */
         {0x4969,0x5deb,0x467f, "SHUF",0},
@@ -64,8 +64,8 @@ static const adxkey_info adxkey8_list[] = {
         /* Soulcalibur IV (PS3) [Namco] */
         {0x59ed,0x4679,0x46c9, "SC4Test",0},
 
-        /* Senko no Ronde DUO (X360) [G.rev] */
-        {0x6157,0x6809,0x4045, NULL,0},     // from guessadx
+        /* Senko no Ronde DUO (X360/AC) [G.rev] */
+        {0x6157,0x6809,0x4045, "yomesokushitsu",0},
 
         /* Nogizaka Haruka no Himitsu: Cosplay Hajimemashita (PS2) [Vridge] */
         {0x45af,0x5f27,0x52b1, "SKFHSIA",0},
@@ -100,16 +100,16 @@ static const adxkey_info adxkey8_list[] = {
         /* Soshite Kono Uchuu ni Kirameku Kimi no Shi XXX (PS2) [Datam Polystar] */
         {0x5f5d,0x552b,0x5507, "DATAM-KK2",0},
 
-        /* Sakura Taisen: Atsuki Chishio Ni (PS2) [Sega] */
-        {0x645d,0x6011,0x5c29, NULL,0},     // confirmed unique with guessadx
+        /* Sakura Taisen: Atsuki Chishio ni (PS2) [Sega] */
+        {0x645d,0x6011,0x5c29, NULL,0},     // possible key: "[Seq][ADX] illegal cri or libsd status."
 
-        /* Sakura Taisen 3 ~Paris wa Moeteiru ka~ (PS2) [Sega] */
-        {0x62ad,0x4b13,0x5957, NULL,0},     // confirmed unique with guessadx
+        /* Sakura Taisen Monogatari: Mysterious Paris (PS2) [Sega] */
+        {0x62ad,0x4b13,0x5957, "inoue4126",0},
 
         /* Sotsugyou 2nd Generation (PS2) [Jinx] */
         {0x6305,0x509f,0x4c01, NULL,0},     // First guess from guessadx, other was {0x6307,0x509f,0x2ac5}
 
-        /* La Corda d'Oro (PSP) [Koei] */
+        /* Kin'iro no Corda -La Corda d'Oro- (PSP) [Koei] */
         {0x55b7,0x67e5,0x5387, NULL,0},     // keystring not in ELF?
 
         /* Nanatsuiro * Drops Pure!! (PS2) [Media Works] */
@@ -127,7 +127,7 @@ static const adxkey_info adxkey8_list[] = {
         /* Sora no Otoshimono: DokiDoki Summer Vacation (PSP) [Kadokawa Shoten] */
         {0x5e75,0x4a89,0x4c61, "funen-gomi",0},
 
-        /* Boku wa Koukuu Kanseikan: Airport Hero Naha (PSP) [Sonic Powered] */
+        /* Boku wa Koukuu Kanseikan: Airport Hero Naha/Narita/Shinchitose/Haneda/Kankuu (PSP) [Sonic Powered] */
         {0x64ab,0x5297,0x632f, "sonic",0},
 
         /* Lucky Star: Net Idol Meister (PSP) [Vridge, Kadokawa Shoten] */

--- a/src/meta/awc.c
+++ b/src/meta/awc.c
@@ -162,7 +162,7 @@ VGMSTREAM* init_vgmstream_awc(STREAMFILE* sf) {
                 vgmstream->layout_data = build_layered_awc(sf, &awc);
                 if (!vgmstream->layout_data) goto fail;
                 vgmstream->layout_type = layout_layered;
-                vgmstream->coding_type = coding_FFmpeg;
+                vgmstream->coding_type = coding_VORBIS_custom;
             }
             else {
                 vorbis_custom_config cfg = {0};

--- a/src/meta/fsb_keys.h
+++ b/src/meta/fsb_keys.h
@@ -80,6 +80,9 @@ static const uint8_t key_ghm[] = { 0x8C,0xFA,0xF3,0x14,0xB1,0x53,0xDA,0xAB,0x2B,
 /* Worms Rumble Beta (PC) */ //"FXnTffGJ9LS855Gc"
 static const uint8_t key_wrb[] = { 0x46,0x58,0x6E,0x54,0x66,0x66,0x47,0x4A,0x39,0x4C,0x53,0x38,0x35,0x35,0x47,0x63 };
 
+/* Bubble Fighter (PC) */ //"qjvkeoqkrdhkdckd"
+static const uint8_t key_bbf[] = { 0x71,0x6A,0x76,0x6B,0x65,0x6F,0x71,0x6B,0x72,0x64,0x68,0x6B,0x64,0x63,0x6B,0x64 };
+
 // Unknown:
 // - Battle: Los Angeles
 // - Guitar Hero: Warriors of Rock, DJ hero FSB
@@ -90,7 +93,7 @@ typedef struct {
     int is_fsb5; /* FSB5 or FSB4/3*/
     int is_alt; /* alt XOR mode (seemingly not tied to FSB version or anything) */
     size_t fsbkey_size;
-    const uint8_t *fsbkey;
+    const uint8_t* fsbkey;
 } fsbkey_info;
 
 static const fsbkey_info fsbkey_list[] = {
@@ -153,6 +156,7 @@ static const fsbkey_info fsbkey_list[] = {
         { 1,0, sizeof(key_scp),key_scp },// FSB5
         { 0,1, sizeof(key_ghm),key_ghm },// FSB4
         { 1,0, sizeof(key_wrb),key_wrb },// FSB5
+        { 0,0, sizeof(key_bbf),key_bbf },// FSB4
 };
 static const int fsbkey_list_count = sizeof(fsbkey_list) / sizeof(fsbkey_list[0]);
 

--- a/src/meta/kwb.c
+++ b/src/meta/kwb.c
@@ -7,6 +7,7 @@ typedef struct {
     int big_endian;
     int total_subsongs;
     int target_subsong;
+    int found;
     kwb_codec codec;
 
     int channels;
@@ -26,6 +27,7 @@ typedef struct {
 
 static int parse_kwb(kwb_header* kwb, STREAMFILE* sf_h, STREAMFILE* sf_b);
 static int parse_xws(kwb_header* kwb, STREAMFILE* sf);
+static VGMSTREAM* init_vgmstream_koei_wavebank(kwb_header* kwb, STREAMFILE* sf_h, STREAMFILE* sf_b);
 
 
 /* KWB - WaveBank from Koei games */
@@ -33,7 +35,6 @@ VGMSTREAM* init_vgmstream_kwb(STREAMFILE* sf) {
     VGMSTREAM* vgmstream = NULL;
     STREAMFILE *sf_h = NULL, *sf_b = NULL;
     kwb_header kwb = {0};
-    int32_t (*read_s32)(off_t,STREAMFILE*) = NULL;
     int target_subsong = sf->stream_index;
 
 
@@ -70,89 +71,11 @@ VGMSTREAM* init_vgmstream_kwb(STREAMFILE* sf) {
 
     if (!parse_kwb(&kwb, sf_h, sf_b))
         goto fail;
-    read_s32 = kwb.big_endian ? read_s32be : read_s32le;
 
-
-    /* build the VGMSTREAM */
-    vgmstream = allocate_vgmstream(kwb.channels, kwb.loop_flag);
+    vgmstream = init_vgmstream_koei_wavebank(&kwb, sf_h, sf_b);
     if (!vgmstream) goto fail;
 
-    vgmstream->meta_type = meta_KWB;
-    vgmstream->sample_rate = kwb.sample_rate;
-    vgmstream->num_samples = kwb.num_samples;
-    vgmstream->stream_size = kwb.stream_size;
-    vgmstream->num_streams = kwb.total_subsongs;
-
-    switch(kwb.codec) {
-        case PCM16: /* PCM */
-            vgmstream->coding_type = coding_PCM16LE;
-            vgmstream->layout_type = layout_interleave;
-            vgmstream->interleave_block_size = 0x02;
-            break;
-
-        case MSADPCM:
-            vgmstream->coding_type = coding_MSADPCM;
-            vgmstream->layout_type = layout_none;
-            vgmstream->frame_size = kwb.block_size;
-            break;
-
-        case DSP_HEAD:
-        case DSP_BODY:
-            if (kwb.channels > 1) goto fail;
-            vgmstream->coding_type = coding_NGC_DSP; /* subinterleave? */
-            vgmstream->layout_type = layout_interleave;
-            vgmstream->interleave_block_size = 0x08;
-            if (kwb.codec == DSP_HEAD) {
-                dsp_read_coefs(vgmstream, sf_h, kwb.dsp_offset + 0x1c, 0x60, kwb.big_endian);
-                dsp_read_hist (vgmstream, sf_h, kwb.dsp_offset + 0x40, 0x60, kwb.big_endian);
-            }
-            else {
-                /* typical DSP header + data */
-                vgmstream->num_samples = read_s32(kwb.stream_offset + 0x00, sf_b);
-                dsp_read_coefs(vgmstream, sf_b, kwb.stream_offset + 0x1c, 0x60, kwb.big_endian);
-                dsp_read_hist (vgmstream, sf_b, kwb.stream_offset + 0x40, 0x60, kwb.big_endian);
-                kwb.stream_offset += 0x60;
-            }
-
-            break;
-
-#ifdef VGM_USE_ATRAC9
-        case AT9: {
-            atrac9_config cfg = {0};
-
-            {
-                size_t extra_size = read_u32le(kwb.stream_offset + 0x00, sf_b);
-                uint32_t config_data = read_u32be(kwb.stream_offset + 0x04, sf_b);
-                /* 0x0c: encoder delay? */
-                /* 0x0e: encoder padding? */
-                /* 0x10: samples per frame */
-                /* 0x12: frame size */
-
-                cfg.channels = vgmstream->channels;
-                cfg.config_data = config_data;
-
-                kwb.stream_offset += extra_size;
-                kwb.stream_size -= extra_size;
-            }
-
-            vgmstream->codec_data = init_atrac9(&cfg);
-            if (!vgmstream->codec_data) goto fail;
-            vgmstream->coding_type = coding_ATRAC9;
-            vgmstream->layout_type = layout_none;
-
-            //TODO: check encoder delay
-            vgmstream->num_samples = atrac9_bytes_to_samples_cfg(kwb.stream_size, cfg.config_data);
-            break;
-        }
-#endif
-        default:
-            goto fail;
-    }
-
     if (sf_h != sf) close_streamfile(sf_h);
-
-    if (!vgmstream_open_stream(vgmstream, sf_b, kwb.stream_offset))
-        goto fail;
     return vgmstream;
 
 fail:
@@ -164,7 +87,6 @@ fail:
 /* XWS - WaveStream? from Koei games */
 VGMSTREAM* init_vgmstream_xws(STREAMFILE* sf) {
     VGMSTREAM* vgmstream = NULL;
-    STREAMFILE* temp_sf = NULL;
     kwb_header kwb = {0};
     int target_subsong = sf->stream_index;
 
@@ -179,37 +101,138 @@ VGMSTREAM* init_vgmstream_xws(STREAMFILE* sf) {
     if (!parse_xws(&kwb, sf))
         goto fail;
 
-    if (kwb.codec == MSF) {
-        if (kwb.stream_offset == 0) {
-            vgmstream = init_vgmstream_silence(0,0,0); /* dummy, whatevs */
-            if (!vgmstream) goto fail;
-        }
-        else {
-            kwb.stream_size = read_u32be(kwb.stream_offset + 0x0c, sf) + 0x40;
+    vgmstream = init_vgmstream_koei_wavebank(&kwb, sf, sf);
+    if (!vgmstream) goto fail;
 
-            temp_sf = setup_subfile_streamfile(sf, kwb.stream_offset, kwb.stream_size, "msf");
-            if (!temp_sf) goto fail;
-
-            vgmstream = init_vgmstream_msf(temp_sf);
-            if (!vgmstream) goto fail;
-        }
-
-        vgmstream->num_streams = kwb.total_subsongs;
-    }
-    else {
-        goto fail;
-    }
-
-    close_streamfile(temp_sf);
     return vgmstream;
 fail:
-    close_streamfile(temp_sf);
+    close_vgmstream(vgmstream);
     return NULL;
 }
 
 
+static VGMSTREAM* init_vgmstream_koei_wavebank(kwb_header* kwb, STREAMFILE* sf_h, STREAMFILE* sf_b) {
+    VGMSTREAM* vgmstream = NULL;
+    uint32_t (*read_u32)(off_t,STREAMFILE*) = NULL;
+    int32_t  (*read_s32)(off_t,STREAMFILE*) = NULL;
 
-static int parse_type_kwb2(kwb_header* kwb, off_t offset, STREAMFILE* sf_h) {
+
+    read_u32 = kwb->big_endian ? read_u32be : read_u32le;
+    read_s32 = kwb->big_endian ? read_s32be : read_s32le;
+
+    /* container */
+    if (kwb->codec == MSF) {
+        if (kwb->stream_offset == 0) {
+            vgmstream = init_vgmstream_silence(0,0,0); /* dummy, whatevs */
+            if (!vgmstream) goto fail;
+        }
+        else {
+            STREAMFILE* temp_sf = NULL;
+
+            kwb->stream_size = read_u32(kwb->stream_offset + 0x0c, sf_h) + 0x40;
+
+            temp_sf = setup_subfile_streamfile(sf_h, kwb->stream_offset, kwb->stream_size, "msf");
+            if (!temp_sf) goto fail;
+
+            vgmstream = init_vgmstream_msf(temp_sf);
+            close_streamfile(temp_sf);
+            if (!vgmstream) goto fail;
+        }
+
+        vgmstream->num_streams = kwb->total_subsongs;
+        return vgmstream;
+    }
+
+
+    /* build the VGMSTREAM */
+    vgmstream = allocate_vgmstream(kwb->channels, kwb->loop_flag);
+    if (!vgmstream) goto fail;
+
+    vgmstream->meta_type = meta_KWB;
+    vgmstream->sample_rate = kwb->sample_rate;
+    vgmstream->num_samples = kwb->num_samples;
+    vgmstream->stream_size = kwb->stream_size;
+    vgmstream->num_streams = kwb->total_subsongs;
+
+    switch(kwb->codec) {
+        case PCM16: /* PCM */
+            vgmstream->coding_type = coding_PCM16LE;
+            vgmstream->layout_type = layout_interleave;
+            vgmstream->interleave_block_size = 0x02;
+            break;
+
+        case MSADPCM:
+            vgmstream->coding_type = coding_MSADPCM;
+            vgmstream->layout_type = layout_none;
+            vgmstream->frame_size = kwb->block_size;
+            break;
+
+        case DSP_HEAD:
+        case DSP_BODY:
+            if (kwb->channels > 1) goto fail;
+            vgmstream->coding_type = coding_NGC_DSP; /* subinterleave? */
+            vgmstream->layout_type = layout_interleave;
+            vgmstream->interleave_block_size = 0x08;
+            if (kwb->codec == DSP_HEAD) {
+                dsp_read_coefs(vgmstream, sf_h, kwb->dsp_offset + 0x1c, 0x60, kwb->big_endian);
+                dsp_read_hist (vgmstream, sf_h, kwb->dsp_offset + 0x40, 0x60, kwb->big_endian);
+            }
+            else {
+                /* typical DSP header + data */
+                vgmstream->num_samples = read_s32(kwb->stream_offset + 0x00, sf_b);
+                dsp_read_coefs(vgmstream, sf_b, kwb->stream_offset + 0x1c, 0x60, kwb->big_endian);
+                dsp_read_hist (vgmstream, sf_b, kwb->stream_offset + 0x40, 0x60, kwb->big_endian);
+                kwb->stream_offset += 0x60;
+            }
+
+            break;
+
+#ifdef VGM_USE_ATRAC9
+        case AT9: {
+            atrac9_config cfg = {0};
+
+            {
+                size_t extra_size = read_u32le(kwb->stream_offset + 0x00, sf_b);
+                uint32_t config_data = read_u32be(kwb->stream_offset + 0x04, sf_b);
+                /* 0x0c: encoder delay? */
+                /* 0x0e: encoder padding? */
+                /* 0x10: samples per frame */
+                /* 0x12: frame size */
+
+                cfg.channels = vgmstream->channels;
+                cfg.config_data = config_data;
+
+                kwb->stream_offset += extra_size;
+                kwb->stream_size -= extra_size;
+            }
+
+            vgmstream->codec_data = init_atrac9(&cfg);
+            if (!vgmstream->codec_data) goto fail;
+            vgmstream->coding_type = coding_ATRAC9;
+            vgmstream->layout_type = layout_none;
+
+            //TODO: check encoder delay
+            vgmstream->num_samples = atrac9_bytes_to_samples_cfg(kwb->stream_size, cfg.config_data);
+            break;
+        }
+#endif
+        default:
+            goto fail;
+    }
+
+
+    if (!vgmstream_open_stream(vgmstream, sf_b, kwb->stream_offset))
+        goto fail;
+    return vgmstream;
+
+fail:
+    close_vgmstream(vgmstream);
+    return NULL;
+}
+
+/* ************************************************************************* */
+
+static int parse_type_kwb2(kwb_header* kwb, off_t offset, off_t body_offset, STREAMFILE* sf_h) {
     int i, j, sounds;
 
     /* 00: KWB2/KWBN id */
@@ -220,12 +243,15 @@ static int parse_type_kwb2(kwb_header* kwb, off_t offset, STREAMFILE* sf_h) {
     /* 10: null or 1 */
     /* 14: offset to HDDB table (from type), can be null */
 
+    //;VGM_LOG("KWB2: sounds %i, o=%lx\n", sounds, offset);
+
     /* offset table to entries */
     for (i = 0; i < sounds; i++) {
         off_t sound_offset = read_u32le(offset + 0x18 + i*0x04, sf_h);
         int subsounds, subsound_start, subsound_size;
         uint16_t version;
 
+        //;VGM_LOG("KWB2: entry %i, o=%lx, so=%lx\n", i, offset + 0x18 + i*0x04, sound_offset);
 
         if (sound_offset == 0) /* common... */
             continue;
@@ -258,6 +284,8 @@ static int parse_type_kwb2(kwb_header* kwb, off_t offset, STREAMFILE* sf_h) {
             kwb->total_subsongs++;
             if (kwb->total_subsongs != kwb->target_subsong)
                 continue;
+            kwb->found = 1;
+
             subsound_offset = subsound_start + j*subsound_size;
 
             kwb->sample_rate    = read_u16le(subsound_offset + 0x00, sf_h);
@@ -272,6 +300,8 @@ static int parse_type_kwb2(kwb_header* kwb, off_t offset, STREAMFILE* sf_h) {
             /* when size > 0x48 */
             /* 0x48: subsound entry size */
             /* rest: reserved per codec? (usually null) */
+            
+            kwb->stream_offset += body_offset;
 
             switch(codec) {
                 case 0x00:
@@ -304,16 +334,14 @@ static int parse_type_kwb2(kwb_header* kwb, off_t offset, STREAMFILE* sf_h) {
     then name table (null terminated and one after other)
     */
 
-    if (kwb->target_subsong < 0 || kwb->target_subsong > kwb->total_subsongs || kwb->total_subsongs < 1) goto fail;
-
     return 1;
 fail:
     return 0;
 }
 
-static int parse_type_k4hd(kwb_header* kwb, off_t offset, STREAMFILE* sf_h) {
+static int parse_type_k4hd(kwb_header* kwb, off_t offset, off_t body_offset, STREAMFILE* sf_h) {
     off_t ppva_offset, header_offset;
-    int entries;
+    int entries, current_subsongs, relative_subsong;
     size_t entry_size;
 
 
@@ -344,10 +372,14 @@ static int parse_type_k4hd(kwb_header* kwb, off_t offset, STREAMFILE* sf_h) {
         goto fail;
     }
 
-    kwb->total_subsongs = entries;
-    if (kwb->target_subsong < 0 || kwb->target_subsong > kwb->total_subsongs || kwb->total_subsongs < 1) goto fail;
+    current_subsongs = kwb->total_subsongs;
+    kwb->total_subsongs += entries;
+    if (kwb->target_subsong - 1 < current_subsongs || kwb->target_subsong > kwb->total_subsongs)
+        return 1;
+    kwb->found = 1;
 
-    header_offset = ppva_offset + 0x20 + (kwb->target_subsong-1) * entry_size;
+    relative_subsong = kwb->target_subsong - current_subsongs;
+    header_offset = ppva_offset + 0x20 + (relative_subsong-1) * entry_size;
 
     kwb->stream_offset  = read_u32le(header_offset + 0x00, sf_h);
     kwb->sample_rate    = read_u32le(header_offset + 0x04, sf_h);
@@ -363,21 +395,22 @@ static int parse_type_k4hd(kwb_header* kwb, off_t offset, STREAMFILE* sf_h) {
     kwb->codec = AT9;
     kwb->channels = 1; /* always, devs use dual subsongs to fake stereo (like as hd3+bd3) */
 
+    kwb->stream_offset += body_offset;
 
     return 1;
 fail:
     return 0;
 }
 
-static int parse_type_sdsd(kwb_header* kwb, off_t offset, STREAMFILE* sf_h) {
+static int parse_type_sdsd(kwb_header* kwb, off_t offset, off_t body_offset, STREAMFILE* sf_h) {
     /* has Vers, Head, Prog, Smpl sections (like Sony VABs)
     unknown codec, blocked with some common start, variable sized */
     return 0;
 }
 
-static int parse_type_sdwi(kwb_header* kwb, off_t offset, STREAMFILE* sf_h) {
+static int parse_type_sdwi(kwb_header* kwb, off_t offset, off_t body_offset, STREAMFILE* sf_h) {
     off_t smpl_offset, header_offset;
-    int entries;
+    int entries, current_subsongs, relative_subsong;
     size_t entry_size;
 
 
@@ -404,10 +437,14 @@ static int parse_type_sdwi(kwb_header* kwb, off_t offset, STREAMFILE* sf_h) {
     entries = read_u32le(smpl_offset + 0x0c, sf_h); /* LE! */
     entry_size = 0x40;
 
-    kwb->total_subsongs = entries;
-    if (kwb->target_subsong < 0 || kwb->target_subsong > kwb->total_subsongs || kwb->total_subsongs < 1) goto fail;
+    current_subsongs = kwb->total_subsongs;
+    kwb->total_subsongs += entries;
+    if (kwb->target_subsong - 1 < current_subsongs || kwb->target_subsong > kwb->total_subsongs)
+        return 1;
+    kwb->found = 1;
 
-    header_offset = smpl_offset + 0x10 + (kwb->target_subsong-1) * entry_size;
+    relative_subsong = kwb->target_subsong - current_subsongs;
+    header_offset = smpl_offset + 0x10 + (relative_subsong-1) * entry_size;
 
     /* 00: "SS" + ID (0..N) */
     kwb->stream_offset  = read_u32be(header_offset + 0x04, sf_h);
@@ -427,10 +464,13 @@ static int parse_type_sdwi(kwb_header* kwb, off_t offset, STREAMFILE* sf_h) {
     kwb->codec = DSP_BODY;
     kwb->channels = 1;
 
+    kwb->stream_offset += body_offset;
+
     return 1;
 fail:
     return 0;
 }
+
 
 static int parse_kwb(kwb_header* kwb, STREAMFILE* sf_h, STREAMFILE* sf_b) {
     off_t head_offset, body_offset, start;
@@ -485,22 +525,22 @@ static int parse_kwb(kwb_header* kwb, STREAMFILE* sf_h, STREAMFILE* sf_b) {
     switch(type) {
         case 0x4B574232: /* "KWB2" [Bladestorm Nightmare (PC), Dissidia NT (PC)] */
         case 0x4B57424E: /* "KWBN" [Fire Emblem Warriors (Switch)] */
-            if (!parse_type_kwb2(kwb, head_offset, sf_h))
+            if (!parse_type_kwb2(kwb, head_offset, body_offset, sf_h))
                 goto fail;
             break;
 
         case 0x4B344844: /* "K4HD" [Dissidia NT (PS4), (Vita) */
-            if (!parse_type_k4hd(kwb, head_offset, sf_h))
+            if (!parse_type_k4hd(kwb, head_offset, body_offset, sf_h))
                 goto fail;
             break;
 
         case 0x53447364: /* "SDsd" (PS3? leftover files) */
-            if (!parse_type_sdsd(kwb, head_offset, sf_h))
+            if (!parse_type_sdsd(kwb, head_offset, body_offset, sf_h))
                 goto fail;
             break;
 
         case 0x53445769: /* "SDWi" [Fatal Frame 5 (WiiU)] */
-            if (!parse_type_sdwi(kwb, head_offset, sf_h))
+            if (!parse_type_sdwi(kwb, head_offset, body_offset, sf_h))
                 goto fail;
             break;
 
@@ -508,7 +548,8 @@ static int parse_kwb(kwb_header* kwb, STREAMFILE* sf_h, STREAMFILE* sf_b) {
             goto fail;
     }
 
-    kwb->stream_offset += body_offset;
+    if (!kwb->found)
+        goto fail;
 
     return 1;
 fail:
@@ -517,16 +558,111 @@ fail:
 
 static int parse_type_msfbank(kwb_header* kwb, off_t offset, STREAMFILE* sf) {
     /* this is just like XWSF, abridged: */
+    int entries, current_subsongs, relative_subsong;
     off_t header_offset;
+    
+    entries = read_u32be(offset + 0x14, sf);
 
-    kwb->total_subsongs = read_u32be(offset + 0x14, sf);
-    if (kwb->target_subsong < 0 || kwb->target_subsong > kwb->total_subsongs || kwb->total_subsongs < 1) goto fail;
+    current_subsongs = kwb->total_subsongs;
+    kwb->total_subsongs += entries;
+    if (kwb->target_subsong - 1 < current_subsongs || kwb->target_subsong > kwb->total_subsongs)
+        return 1;
+    kwb->found = 1;
 
-    header_offset = offset + 0x30 + (kwb->target_subsong-1) * 0x04;
+    relative_subsong = kwb->target_subsong - current_subsongs;
+    header_offset = offset + 0x30 + (relative_subsong-1) * 0x04;
 
     /* just a dumb table pointing to MSF, entries can be dummy */
-    kwb->stream_offset  = read_u32be(header_offset, sf);
+    kwb->stream_offset = read_u32be(header_offset, sf);
     kwb->codec = MSF;
+
+    kwb->stream_offset += offset;
+
+    return 1;
+//fail:
+//    return 0;
+}
+
+static int parse_type_xwsfile(kwb_header* kwb, off_t offset, STREAMFILE* sf) {
+    off_t table1_offset, table2_offset;
+    int i, chunks, chunks2;
+    uint32_t (*read_u32)(off_t,STREAMFILE*) = NULL;
+
+
+    if (!(is_id32be(offset + 0x00, sf, "XWSF") && is_id32be(offset + 0x04, sf, "ILE\0")) &&
+        !(is_id32be(offset + 0x00, sf, "tdpa") && is_id32be(offset + 0x04, sf, "ck\0\0")))
+        goto fail;
+
+    kwb->big_endian = read_u8(offset + 0x08, sf) == 0xFF;
+    /* 0x0a: version? (0100: NG2/NG3 PS3, 0101: DoA LR PC) */
+
+    read_u32 = kwb->big_endian ? read_u32be : read_u32le;
+
+    /* 0x0c: tables start  */
+    /* 0x10: file size */
+    chunks  = read_u32(offset + 0x14, sf);
+    chunks2 = read_u32(offset + 0x18, sf);
+    /* 0x1c: null */
+    if (chunks != chunks2)
+        goto fail;
+
+    table1_offset = read_u32(offset + 0x20, sf); /* offsets */
+    table2_offset = read_u32(offset + 0x24, sf); /* sizes */
+    /* 0x28: null */
+    /* 0x2c: null */
+
+
+    i = 0;
+    while (i < chunks) {
+        uint32_t entry_type, head_offset, body_offset, head_size;
+        //;VGM_LOG("XWS: entry %i/%i\n", i, chunks);
+
+        /* NG2/NG3 PS3 have table1+2, DoA LR PC removes table2 and includes body offset in entries */
+        if (table2_offset) {
+            head_offset = read_u32(offset + table1_offset + i * 0x04 + 0x00, sf);
+            head_size   = read_u32(offset + table2_offset + i * 0x04 + 0x00, sf);
+            body_offset = head_offset;
+            i += 1;
+
+            /* sometimes has file end offset as entry with no size*/
+            if (!head_size)
+                continue;
+        }
+        else {
+            head_offset = read_u32(offset + table1_offset + i * 0x04 + 0x00, sf);
+            body_offset = read_u32(offset + table1_offset + i * 0x04 + 0x04, sf);
+            i += 2;
+        }
+
+        if (!head_offset) /* just in case */
+            continue;
+
+
+        head_offset += offset;
+        body_offset += offset;
+        entry_type = read_u32be(head_offset + 0x00, sf);
+        //;VGM_LOG("XWS: head=%x, body=%x\n", head_offset, body_offset);
+
+        if (entry_type == get_id32be("XWSF")) { /* + "ILE\0" */
+            if (!parse_type_xwsfile(kwb, head_offset, sf))
+                goto fail;
+        }
+        else if (entry_type == get_id32be("CUEB") || entry_type < 0x100) {
+            ; /* CUE-like info (may start with 0 or a low number instead) */
+        }
+        else if (entry_type == get_id32be("MSFB")) { /* + "ANK\0" */
+            if (!parse_type_msfbank(kwb, head_offset, sf))
+                goto fail;
+        }
+        else if (entry_type == get_id32be("KWB2")) {
+            if (!parse_type_kwb2(kwb, head_offset, body_offset, sf))
+                goto fail;
+        }
+        else {
+            VGM_LOG("XWS: unknown type %x at head=%x, body=%x\n", entry_type, head_offset, body_offset);
+            goto fail;
+        }
+    }
 
     return 1;
 fail:
@@ -535,58 +671,22 @@ fail:
 
 
 static int parse_xws(kwb_header* kwb, STREAMFILE* sf) {
-    off_t head_offset, body_offset, start;
-    uint32_t (*read_u32)(off_t,STREAMFILE*) = NULL;
-    int chunks, chunks2;
-    off_t msfb_offset;
 
-    /* format is similar to WHD1 with some annoyances of its own
-     * variations:
-     * - tdpack: points to N XWSFILE
-     * - XWSFILE w/ 4 chunks: CUEBANK offset, ? offset, MSFBANK offset, end offset (PS3)
+    /* Format is similar to WHD1 with some annoyances of its own. Variations:
+     * - XWSFILE w/ N chunks: CUE offsets + 1 MSFBANK offset
      *   [Ninja Gaiden Sigma 2 (PS3), Ninja Gaiden 3 Razor's Edge (PS3)]
      * - XWSFILE w/ 2*N chunks: KWB2 offset + data offset * N (ex. 3 pairs = 6 chunks)
      *   [Dead or Alive 5 Last Round (PC)]
+     * - tdpack: same but points to N XWSFILE
+     *   [Ninja Gaiden 3 Razor's Edge (PS3)]
      *
-     * for now basic support for the second case, others we'd have to map subsong N to internal bank M
+     * Needs to call sub-parts multiple times to fill total subsongs when parsing xwsfile.
      */
-
-    if (read_u32be(0x00, sf) != 0x58575346 ||   /* "XWSF" */
-        read_u32be(0x04, sf) != 0x494C4500)     /* "ILE\0" */
+    if (!parse_type_xwsfile(kwb, 0x00, sf))
         goto fail;
 
-    kwb->big_endian = read_u8(0x08, sf) == 0xFF;
-    /* 0x0a: version? */
-
-    read_u32 = kwb->big_endian ? read_u32be : read_u32le;
-
-    start = read_u32(0x0c, sf);
-    /* 0x10: file size */
-    chunks  = read_u32(0x14, sf);
-    chunks2 = read_u32(0x18, sf);
-    /* 0x1c: null */
-    /* 0x20: some size? */
-    /* 0x24: some size? */
-    if (chunks != chunks2)
+    if (!kwb->found)
         goto fail;
-
-    if (chunks != 4)
-        goto fail;
-
-    msfb_offset = read_u32(start + 0x08, sf);
-    if (read_u32be(msfb_offset, sf) == 0x4D534642) { /* "MSFB" + "ANK\0" */
-        head_offset = msfb_offset;
-        body_offset = msfb_offset; /* relative to start */
-
-        if (!parse_type_msfbank(kwb, head_offset, sf))
-            goto fail;
-    }
-    else {
-        goto fail;
-    }
-
-
-    kwb->stream_offset += body_offset;
 
     return 1;
 fail:

--- a/src/meta/meta.h
+++ b/src/meta/meta.h
@@ -934,4 +934,6 @@ VGMSTREAM *init_vgmstream_sbk(STREAMFILE *sf);
 
 VGMSTREAM* init_vgmstream_ifs(STREAMFILE* sf);
 
+VGMSTREAM* init_vgmstream_acx(STREAMFILE* sf);
+
 #endif /*_META_H*/

--- a/src/meta/ngc_dsp_std.c
+++ b/src/meta/ngc_dsp_std.c
@@ -660,6 +660,8 @@ VGMSTREAM* init_vgmstream_sadb(STREAMFILE* sf) {
     dspm.start_offset = read_32bitBE(0x48,sf);
     dspm.interleave = 0x10;
 
+    dspm.ignore_loop_ps = 1; /* does something strange with offsets/etc, ignore */
+
     dspm.meta_type = meta_DSP_SADB;
     return init_vgmstream_dsp_common(sf, &dspm);
 fail:

--- a/src/meta/ps2_exst.c
+++ b/src/meta/ps2_exst.c
@@ -3,66 +3,71 @@
 
 
 /* EXST - from Sony games [Shadow of the Colossus (PS2), Gacha Mecha Stadium Saru Battle (PS2)] */
-VGMSTREAM * init_vgmstream_ps2_exst(STREAMFILE *streamFile) {
-    VGMSTREAM * vgmstream = NULL;
-    STREAMFILE * streamBody = NULL;
+VGMSTREAM* init_vgmstream_ps2_exst(STREAMFILE* sf) {
+    VGMSTREAM* vgmstream = NULL;
+    STREAMFILE* sf_body = NULL;
     off_t start_offset;
-    int loop_flag, channel_count;
+    int loop_flag, channels, sample_rate;
     size_t block_size, num_blocks, loop_start_block;
 
 
     /* checks */
-    /* .sts+int: main [Shadow of the Colossus (PS2)] (some .sts have manually joined header+body)
+    /* .sts+int: standard [Shadow of the Colossus (PS2)] (some fake .sts have manually joined header+body)
      * .x: header+body [Ape Escape 3 (PS2)] */
-    if (!check_extensions(streamFile, "sts,x"))
+    if (!check_extensions(sf, "sts,x"))
         goto fail;
-    if (read_32bitBE(0x00,streamFile) != 0x45585354) /* "EXST" */
+    if (!is_id32be(0x00,sf, "EXST"))
         goto fail;
 
-    streamBody = open_streamfile_by_ext(streamFile,"int");
-    if (!streamBody) {
-        /* data+body joined */
-        start_offset = 0x78;
-        if (get_streamfile_size(streamFile) < start_offset)
-            goto fail;
-    }
-    else {
-        /* body is separate */
+    sf_body = open_streamfile_by_ext(sf,"int");
+    if (sf_body) {
+        /* separate header+body (header is 0x78) */
         start_offset = 0x00;
     }
+    else {
+        /* joint header+body */
+        start_offset = 0x78;
+        /* Gacharoku 2 has header+data but padded header (ELF has pointers + size to SOUND.PCK, and
+         * treats them as single files, no extension but there are Sg2ExStAdpcm* calls in the ELF) */
+        if ((get_streamfile_size(sf) % 0x10) == 0)
+            start_offset = 0x80;
 
+        if (get_streamfile_size(sf) < start_offset)
+            goto fail;
+    }
 
-    channel_count = read_16bitLE(0x06,streamFile);
-    loop_flag = read_32bitLE(0x0C,streamFile) == 1;
-    loop_start_block = read_32bitLE(0x10,streamFile);
-    num_blocks = read_32bitLE(0x14,streamFile);
+    channels = read_u16le(0x06,sf);
+    sample_rate = read_u32le(0x08,sf);
+    loop_flag = read_u32le(0x0C,sf) == 1;
+    loop_start_block = read_u32le(0x10,sf);
+    num_blocks = read_u32le(0x14,sf);
+    /* 0x18: 0x24 config per channel? (volume+panning+etc?) */
+    /* rest is padding up to 0x78 */
 
 
     /* build the VGMSTREAM */
-    vgmstream = allocate_vgmstream(channel_count,loop_flag);
+    vgmstream = allocate_vgmstream(channels, loop_flag);
     if (!vgmstream) goto fail;
 
-    vgmstream->sample_rate = read_32bitLE(0x08,streamFile);
     vgmstream->meta_type = meta_PS2_EXST;
+    vgmstream->sample_rate = sample_rate;
 
     vgmstream->coding_type = coding_PSX;
     vgmstream->layout_type = layout_interleave;
     vgmstream->interleave_block_size = 0x400;
 
     block_size = vgmstream->interleave_block_size * vgmstream->channels;
-    vgmstream->num_samples = ps_bytes_to_samples(num_blocks*block_size, channel_count);
-    if (vgmstream->loop_flag) {
-        vgmstream->loop_start_sample = ps_bytes_to_samples(loop_start_block*block_size, channel_count);;
-        vgmstream->loop_end_sample = vgmstream->num_samples;
-    }
+    vgmstream->num_samples = ps_bytes_to_samples(num_blocks * block_size, channels);
+    vgmstream->loop_start_sample = ps_bytes_to_samples(loop_start_block * block_size, channels);
+    vgmstream->loop_end_sample = vgmstream->num_samples;
 
-    if (!vgmstream_open_stream(vgmstream,streamBody ? streamBody : streamFile,start_offset))
+    if (!vgmstream_open_stream(vgmstream, sf_body ? sf_body : sf, start_offset))
         goto fail;
-    close_streamfile(streamBody);
+    close_streamfile(sf_body);
     return vgmstream;
 
 fail:
-    close_streamfile(streamBody);
+    close_streamfile(sf_body);
     close_vgmstream(vgmstream);
     return NULL;
 }

--- a/src/meta/ubi_sb.c
+++ b/src/meta/ubi_sb.c
@@ -3988,9 +3988,11 @@ static int config_sb_version(ubi_sb_header* sb, STREAMFILE* sf) {
         return 1;
     }
 
+    /* Naruto: Rise of a Ninja (2007)(X360)-bank */
     /* Rainbow Six Vegas 2 (2008)(PS3)-bank */
     /* Rainbow Six Vegas 2 (2008)(X360)-bank */
-    if ((sb->version == 0x001C0000 && sb->platform == UBI_PS3) ||
+    if ((sb->version == 0x001B0001 && sb->platform == UBI_X360) ||
+        (sb->version == 0x001C0000 && sb->platform == UBI_PS3) ||
         (sb->version == 0x001C0000 && sb->platform == UBI_X360)) {
         config_sb_entry(sb, 0x64, 0x7c);
 

--- a/src/meta/wwise.c
+++ b/src/meta/wwise.c
@@ -96,7 +96,8 @@ VGMSTREAM* init_vgmstream_wwise(STREAMFILE* sf) {
     switch(ww.codec) {
         case PCM: /* common */
             /* normally riff.c has priority but it's needed when .wem is used */
-            if (ww.fmt_size != 0x10 && ww.fmt_size != 0x18 && ww.fmt_size != 0x28) goto fail; /* old, new/Limbo (PC) */
+            /* old=0x10, 0x12=Army of Two: the 40th Day (PS3), new/Limbo (PC) */
+            if (ww.fmt_size != 0x10 && ww.fmt_size != 0x12 && ww.fmt_size != 0x18 && ww.fmt_size != 0x28) goto fail;
             if (ww.bits_per_sample != 16) goto fail;
 
             vgmstream->coding_type = (ww.big_endian ? coding_PCM16BE : coding_PCM16LE);

--- a/src/vgmstream.c
+++ b/src/vgmstream.c
@@ -516,6 +516,7 @@ VGMSTREAM* (*init_vgmstream_functions[])(STREAMFILE* sf) = {
     init_vgmstream_dsp_wiiadpcm,
     init_vgmstream_dsp_cwac,
     init_vgmstream_ifs,
+    init_vgmstream_acx,
 
     /* lowest priority metas (should go after all metas, and TXTH should go before raw formats) */
     init_vgmstream_txth,            /* proper parsers should supersede TXTH, once added */


### PR DESCRIPTION
- Add streamed .xnb [Clan N (Switch), Guncraft: Blocked and Loaded (X360)]
- Fix some Wwise PCM [Army of Two: the 40th Day (PS3)]
- Fix broken sadb .sad
- Fix some .sts [Gacharoku 2 (PS2)]
- Fix some .csb [Nights: Journey of Dreams (Wii)]
- Fix compilation issue in .awc
- Fix .xws with multibanks [Ninja Gaiden 3 RE (PS3), DOA 5 Last Round (PC)]
- Add Ubi SB variation [Naruto: Rise of a Ninja (X360)]
- Add Ubi BAO variation [Beowulf (X360/PS3)]
- Fix issues when getting extension affecting .mpf + cleanup
- Add fsb key [Bubble Fighter (PC)]
- Add .acx ADX container [Baroque (SAT), Persona 3 (PS2)]
