### PR TITLE
nus msadpcm

### DIFF
--- a/cli/txtp_maker.py
+++ b/cli/txtp_maker.py
@@ -147,6 +147,7 @@ class TxtpMaker(object):
         self.stream_count = self._get_value("stream count: ")
         self.stream_index = self._get_value("stream index: ")
         self.stream_name = self._get_text("stream name: ")
+        self.encoding = self._get_text("encoding: ")
 
         if self.channels <= 0 or self.sample_rate <= 0:
             raise ValueError('Incorrect command result')
@@ -204,6 +205,8 @@ class TxtpMaker(object):
             p = re.compile(cfg.include_regex)
             if p.match(self.stream_name) is None:
                 return True
+        if self.encoding.lower() == 'silence':
+            return True
         return False
 
     def _get_stream_mask(self, layer):

--- a/src/coding/coding.h
+++ b/src/coding/coding.h
@@ -156,6 +156,8 @@ void free_nwa(nwa_codec_data* data);
 STREAMFILE* nwa_get_streamfile(nwa_codec_data* data);
 
 /* msadpcm_decoder */
+#define MSADPCM_MAX_BLOCK_SIZE  0x800 /* known max and RIFF spec seems to concur, while MS's encoders may be lower (typical stereo: 0x8c, 0x2C, 0x48, 0x400) */
+
 void decode_msadpcm_stereo(VGMSTREAM* vgmstream, sample_t* outbuf, int32_t first_sample, int32_t samples_to_do);
 void decode_msadpcm_mono(VGMSTREAM* vgmstream, sample_t* outbuf, int channelspacing, int32_t first_sample, int32_t samples_to_do, int channel);
 void decode_msadpcm_ck(VGMSTREAM* vgmstream, sample_t* outbuf, int channelspacing, int32_t first_sample, int32_t samples_to_do, int channel);

--- a/src/meta/riff.c
+++ b/src/meta/riff.c
@@ -333,7 +333,7 @@ VGMSTREAM* init_vgmstream_riff(STREAMFILE* sf) {
      * .adx: Remember11 (PC) sfx
      * .adp: Headhunter (DC)
      * .xss: Spider-Man The Movie (Xbox)
-     * .xsew: Mega Man X Legacy Collections (PC)
+     * .xsew: Mega Man X Legacy Collection (PC)
      * .adpcm: Angry Birds Transformers (Android)
      * .adw: Dead Rising 2 (PC)
      * .wd: Genma Onimusha (Xbox) voices
@@ -416,6 +416,9 @@ VGMSTREAM* init_vgmstream_riff(STREAMFILE* sf) {
 
         else if (codec == 0xFFFE && riff_size + 0x08 + 0x30 == file_size)
             riff_size += 0x30; /* [E.X. Troopers (PS3)] (adds "ver /eBIT/tIME/mrkr" empty chunks but RIFF size wasn't updated) */
+
+        else if (codec == 0x0002 && riff_size + 0x08 + 0x1c == file_size)
+            riff_size += 0x1c; /* [Mega Man X Legacy Collection (PC)] (adds "ver /tIME/ver " chunks but RIFF size wasn't updated) */
     }
 
     /* check for truncated RIFF */

--- a/src/meta/str_wav.c
+++ b/src/meta/str_wav.c
@@ -362,6 +362,29 @@ static int parse_header(STREAMFILE* sf_h, strwav_header* strwav) {
         return 1;
     }
 
+    /* Zapper: One Wicked Cricket! Beta (PS2)[2005] */
+    if ( read_u32be(0x04,sf_h) == 0x00000900 &&
+         read_u32le(0x2c,sf_h) == 44100 && /* sample rate */
+         read_u32le(0x70,sf_h) == 0 && /* sample rate repeat? */
+         header_size == 0x78
+         ) {
+        strwav->num_samples = read_u32le(0x5c,sf_h);
+        strwav->sample_rate = read_u32le(0x2c,sf_h);
+        strwav->flags       = read_u32le(0x34,sf_h);
+        strwav->loop_start  = 0;
+        strwav->loop_end    = 0;
+
+        strwav->channels    = read_u32le(0x60,sf_h) * (strwav->flags & 0x02 ? 2 : 1); /* tracks of 2/1ch */
+        strwav->loop_flag   = strwav->flags & 0x01;
+        strwav->interleave  = strwav->channels > 2 ? 0x8000 : 0x8000;
+        //todo: tracks are stereo blocks of size 0x20000*tracks, containing 4 interleaves of 0x8000:
+        // | 1 2 1 2 | 3 4 3 4 | 5 6 5 6 | 1 2 1 2 | 3 4 3 4 | 5 6 5 6 | ...
+
+        strwav->codec = PSX;
+        ;VGM_LOG("STR+WAV: header Zapper Beta (PS2)\n");
+        return 1;
+    }
+
     /* Zapper: One Wicked Cricket! (PS2)[2005] */
     if ( read_32bitBE(0x04,sf_h) == 0x00000900 &&
          read_32bitLE(0x24,sf_h) == read_32bitLE(0x70,sf_h) && /* sample rate repeat */

--- a/src/vgmstream.c
+++ b/src/vgmstream.c
@@ -1530,6 +1530,14 @@ int vgmstream_open_stream_bf(VGMSTREAM* vgmstream, STREAMFILE* sf, off_t start_o
         vgmstream->frame_size = vgmstream->interleave_block_size;
     }
 
+    if ((vgmstream->coding_type == coding_MSADPCM ||
+            vgmstream->coding_type == coding_MSADPCM_ck ||
+            vgmstream->coding_type == coding_MSADPCM_int) &&
+            (vgmstream->frame_size > MSADPCM_MAX_BLOCK_SIZE)) {
+        VGM_LOG("VGMSTREAM: MSADPCM decoder with wrong frame size %x\n", vgmstream->frame_size);
+        goto fail;
+    }
+
     /* big interleaved values for non-interleaved data may result in incorrect behavior,
      * quick fix for now since layouts are finicky, with 'interleave' left for meta info
      * (certain layouts+codecs combos results in funny output too, should rework the whole thing) */


### PR DESCRIPTION
- Fix .nus3audio with dummy entries [Gundam Extreme Vs Maxi Boost ON (PS4)]
- Fix .xsew [Mega Man X Legacy Collection (PC)]
- Improve MSADPCM performance (~50%) + doc spec diffs
- Add partial .str+wav support for Zapper Beta (PS2)
