### PR TITLE
Handle The Sims 2 XA header variant

### DIFF
--- a/src/meta/maxis_xa.c
+++ b/src/meta/maxis_xa.c
@@ -12,8 +12,9 @@ VGMSTREAM * init_vgmstream_maxis_xa(STREAMFILE *streamFile) {
         goto fail;
 
     /* check header */
-    if ((read_32bitBE(0x00,streamFile) != 0x58414900) && /* "XAI\0" */
-        (read_32bitBE(0x00,streamFile) != 0x58414A00))   /* "XAJ\0" (some odd song uses this, no apparent diffs) */
+    if ((read_32bitBE(0x00,streamFile) != 0x58414900) && /* "XAI\0" (sound/speech)*/
+        (read_32bitBE(0x00,streamFile) != 0x58414A00) && /* "XAJ\0" (music, no apparent diffs) */
+        (read_32bitBE(0x00,streamFile) != 0x58410000))   /* "XA\0\0" (used in The Sims 2, no apparent diffs) */
         goto fail;
 
     loop_flag = 0;


### PR DESCRIPTION
While working on a rip of the PC version of The Sims 2 Ultimate Collection, I stumbled upon several XA files that didn't play. After some discussion on the Discord server, the format used by the game was found to be identical to the already supported XAI/XAJ file type from Sim City 3000, apart from a single byte difference in the header, which is introduced by this PR (by the way, the updated comments are based on [this documentation](http://simswiki.info/wiki.php?title=XA)). 

Since I'm not sure if this change can introduce false detections, I have [uploaded here](https://github.com/vgmstream/vgmstream/files/6442049/Sims2_XA.zip) some samples ripped straight from The Sims 2 for testing. None of those files were modified but you might notice `Misc_113.xa` has a proper XAJ header, this is an edge case since the majority of the XAs from the base game and all XAs from the expansion packs released after uses the header variant introduced by this PR instead...