### PR TITLE
Add G.719 support on Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,11 @@ Release
 # cmake stuff
 /build
 /cmake-build*
+CMakeCache.txt
+CMakeFiles
+/lib
+/cli/vgmstream_cli
+/cli/vgmstream123
+/audacious/vgmstream.so
+/audacious/Makefile
+cmake_install.cmake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,9 +49,12 @@ set_ffmpeg(ON FALSE)
 option(USE_MAIATRAC3PLUS "Use MAIATRAC3+ for support of ATRAC3+" OFF)
 set(MAIATRAC3PLUS_PATH CACHE PATH "Path to MAIATRAC3+")
 option(USE_G7221 "Use G7221 for support of ITU-T G.722.1 annex C" ON)
+option(USE_G719 "Use libg719_decode for support ITU-T G.719" ON)
+if(NOT WIN32)
+	set(G719_PATH CACHE PATH "Path to G.719 decoder")
+endif()
 if(WIN32)
 	# May need to see if it is possible to get these to work on non-Windows systems too
-	option(USE_G719 "Use libg719_decode for support ITU-T G.719" ON)
 	option(USE_ATRAC9 "Use LibAtrac9 for support of ATRAC9" ON)
     option(USE_CELT "Use libcelt for support of FSB CELT versions 0.6.1 and 0.11.0" ON)
     option(USE_SPEEX "Use libspeex for support of SPEEX" ON)
@@ -221,6 +224,26 @@ if(USE_MAIATRAC3PLUS)
 		message(FATAL_ERROR "Path to MAIATRAC3+ must be set. (Use MAIATRAC3PLUS_PATH)")
 	endif()
 endif()
+if(NOT WIN32 AND USE_G719)
+	if(G719_PATH)
+		configure_file(
+			${VGM_SOURCE_DIR}/ext_libs/libg719_decode/CMakeLists.txt
+			${G719_PATH}/CMakeLists.txt
+		COPYONLY)
+		add_subdirectory(${G719_PATH})
+	else()
+		include(FetchContent)
+		FetchContent_Populate(libg719_decode
+			GIT_REPOSITORY https://github.com/kode54/libg719_decode.git
+			SOURCE_DIR ${VGM_SOURCE_DIR}/dependencies/libg719_decode
+		)
+		configure_file(
+			${VGM_SOURCE_DIR}/ext_libs/libg719_decode/CMakeLists.txt
+			${VGM_SOURCE_DIR}/dependencies/libg719_decode/CMakeLists.txt
+		COPYONLY)
+		add_subdirectory(${libg719_decode_SOURCE_DIR})
+	endif()
+endif()
 add_subdirectory(src)
 if(WIN32)
 	add_subdirectory(ext_libs)
@@ -273,8 +296,8 @@ message(STATUS "      Vorbis: ${USE_VORBIS}")
 message(STATUS "      FFmpeg: ${USE_FFMPEG}")
 message(STATUS "  MAIATRAC3+: ${USE_MAIATRAC3PLUS}")
 message(STATUS "     G.722.1: ${USE_G7221}")
+message(STATUS "       G.719: ${USE_G719}")
 if(WIN32)
-	message(STATUS "       G.719: ${USE_G719}")
 	message(STATUS "      ATRAC9: ${USE_ATRAC9}")
     message(STATUS "    FSB CELT: ${USE_CELT}")
     message(STATUS "       SPEEX: ${USE_SPEEX}")

--- a/cmake/vgmstream.cmake
+++ b/cmake/vgmstream.cmake
@@ -79,9 +79,12 @@ macro(setup_target TARGET)
 
 	if(USE_G719)
 		target_compile_definitions(${TARGET} PRIVATE VGM_USE_G719)
-		if(LINK)
+		if(WIN32 AND LINK)
 			add_dependencies(${TARGET} libg719_decode)
 			target_link_libraries(${TARGET} ${VGM_BINARY_DIR}/ext_libs/libg719_decode.lib)
+		endif()
+		if(NOT WIN32 AND LINK)
+			target_link_libraries(${TARGET} g719_decode)
 		endif()
 	endif()
 

--- a/ext_libs/libg719_decode/CMakeLists.txt
+++ b/ext_libs/libg719_decode/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.18)
+project(libg719_decode)
+
+file(GLOB_RECURSE SOURCES "reference_code/*.c")
+
+add_library(g719_decode STATIC g719.c ${SOURCES})
+
+target_include_directories(g719_decode PRIVATE reference_code/include)
+
+set_property(TARGET g719_decode PROPERTY POSITION_INDEPENDENT_CODE ON)
+target_compile_definitions(g719_decode PRIVATE VAR_ARRAYS)


### PR DESCRIPTION
Running cmake on Linux will fetch the code from the [libg719_decode repository](https://github.com/kode54/libg719_decode) by default