### PR TITLE
Fix cmake for emscripten and add emscripten build to actions

### DIFF
--- a/.github/workflows/cmake-em.yml
+++ b/.github/workflows/cmake-em.yml
@@ -1,0 +1,50 @@
+# github workflow to automate builds
+
+name: Emscripten build
+
+on: [push, pull_request]
+
+env:
+  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
+  BUILD_TYPE: Release
+  EM_VERSION: 2.0.29
+  EM_CACHE_FOLDER: 'emsdk-cache'
+
+jobs:
+  build:
+    name: CMake, Emscripten
+    runs-on: ubuntu-18.04
+
+    steps:
+    - uses: actions/checkout@v2
+    
+    - name: Fetch Git tags
+      run: |
+        git fetch --prune --unshallow --tags
+
+    - name: Setup emsdk
+      uses: mymindstorm/setup-emsdk@v10
+      with:
+          version: ${{env.EM_VERSION}}
+          actions-cache-folder: ${{env.EM_CACHE_FOLDER}}
+
+    - name: Create build environment
+      run: cmake -E make_directory ${{runner.workspace}}/embuild
+
+    - name: Configure CMake
+      shell: bash
+      working-directory: ${{runner.workspace}}/embuild
+      run: emcmake cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE
+
+    - name: Build
+      working-directory: ${{runner.workspace}}/embuild
+      shell: bash
+      run: emmake make
+
+    - name: Upload emscripten artifact
+      uses: actions/upload-artifact@v2
+      with:
+          path: |
+            ${{runner.workspace}}/embuild/cli/vgmstream-cli.js
+            ${{runner.workspace}}/embuild/cli/vgmstream-cli.wasm
+          name: vgmstream-wasm

--- a/.github/workflows/cmake-wasm.yml
+++ b/.github/workflows/cmake-wasm.yml
@@ -1,6 +1,6 @@
 # github workflow to automate builds
 
-name: Emscripten build
+name: WebAssembly build
 
 on: [push, pull_request]
 
@@ -12,7 +12,7 @@ env:
 
 jobs:
   build:
-    name: CMake, Emscripten
+    name: CMake, WebAssembly
     runs-on: ubuntu-18.04
 
     steps:
@@ -41,7 +41,7 @@ jobs:
       shell: bash
       run: emmake make
 
-    - name: Upload emscripten artifact
+    - name: Upload WebAssembly artifact
       uses: actions/upload-artifact@v2
       with:
           path: |

--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ Release
 
 # cmake stuff
 /build
+/embuild
 /cmake-build*
 CMakeCache.txt
 CMakeFiles

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,6 +107,8 @@ if(EMSCRIPTEN)
 	set(USE_MPEG OFF)
 	set(USE_FFMPEG OFF)
 	set(USE_JANSSON OFF)
+	set(BUILD_V123 OFF)
+	set(BUILD_AUDACIOUS OFF)
 endif()
 
 # Static builds will link all libraries statically

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,24 +90,35 @@ if(WIN32)
 	option(BUILD_XMPLAY "Build XMPlay plugin" ON)
 	set(XMPLAY_INSTALL_PREFIX CACHE PATH "Path to XMPlay installation directory")
 else()
-	option(BUILD_STATIC "Build statically linked binary" OFF)
-	if(BUILD_STATIC)
-		option(BUILD_V123 "Build vgmstream123 player" OFF)
+	if(EMSCRIPTEN)
+		set(BUILD_STATIC ON)
 	else()
-		option(BUILD_V123 "Build vgmstream123 player" ON)
+		option(BUILD_STATIC "Build statically linked binary" OFF)
+		if(BUILD_STATIC)
+			option(BUILD_V123 "Build vgmstream123 player" OFF)
+		else()
+			option(BUILD_V123 "Build vgmstream123 player" ON)
+		endif()
+		option(BUILD_AUDACIOUS "Build Audacious plugin" ON)
 	endif()
-	option(BUILD_AUDACIOUS "Build Audacious plugin" ON)
+endif()
+
+if(EMSCRIPTEN)
+	set(USE_MPEG OFF)
+	set(USE_FFMPEG OFF)
+	set(USE_JANSSON OFF)
 endif()
 
 # Static builds will link all libraries statically
 if(BUILD_STATIC)
 	set(BUILD_SHARED_LIBS OFF)
 	set(CMAKE_EXE_LINKER_FLAGS "-static-libgcc -static-libstdc++ -static")
-
-	#  it is already kind of obvious when you do not have it, and just prevents you from building without ffmpeg
-	#find_package(PkgConfig REQUIRED)
-	#pkg_check_modules(PC_OPUS REQUIRED opus>=1.1)
-
+	
+	if(USE_FFMPEG)
+		find_package(PkgConfig REQUIRED)
+		pkg_check_modules(PC_OPUS REQUIRED opus>=1.1)
+	endif()
+	
 	# Incompatible with static builds
 	set(BUILD_AUDACIOUS OFF)
 endif()
@@ -417,15 +428,27 @@ if(NOT WIN32)
 			endif()
 		endif()
 		if(ATRAC9_PATH)
-			if(NOT EXISTS ${ATRAC9_PATH}/C/bin/libatrac9.a)
-				add_custom_target(ATRAC9_MAKE ALL
-					COMMAND make static CFLAGS="-fPIC"
-					WORKING_DIRECTORY ${ATRAC9_PATH}/C
-				)
+			if(EMSCRIPTEN)
+				set(ATRAC9_LINK_PATH ${ATRAC9_PATH}/C/embin/libatrac9.a)
+			else()
+				set(ATRAC9_LINK_PATH ${ATRAC9_PATH}/C/bin/libatrac9.a)
+			endif()
+			if(NOT EXISTS ${ATRAC9_LINK_PATH})
+				if(EMSCRIPTEN)
+					add_custom_target(ATRAC9_MAKE ALL
+						COMMAND emmake make static CFLAGS="-fPIC" CC=emcc AR=emar BINDIR=embin
+						WORKING_DIRECTORY ${ATRAC9_PATH}/C
+					)
+				else()
+					add_custom_target(ATRAC9_MAKE ALL
+						COMMAND make static CFLAGS="-fPIC"
+						WORKING_DIRECTORY ${ATRAC9_PATH}/C
+					)
+				endif()
 			endif()
 			add_library(atrac9 STATIC IMPORTED)
 			set_target_properties(atrac9 PROPERTIES
-				IMPORTED_LOCATION ${ATRAC9_PATH}/C/bin/libatrac9.a
+				IMPORTED_LOCATION ${ATRAC9_LINK_PATH}
 			)
 		endif()
 	endif()

--- a/cli/CMakeLists.txt
+++ b/cli/CMakeLists.txt
@@ -17,7 +17,7 @@ endif()
 target_link_libraries(vgmstream_cli libvgmstream)
 
 # Link to Jansson, if we have it
-if (JANSSON_FOUND)
+if (USE_JANSSON AND JANSSON_FOUND)
     target_compile_definitions(vgmstream_cli PRIVATE HAVE_JSON)
 	target_link_libraries(vgmstream_cli jansson)
 endif()


### PR DESCRIPTION
Emscripten builds currently do not use mpg123, vorbis, ffmpeg, celt, or speex