### PR TITLE
fix Windows Compiler Warning C4703 on uninitialized pointer in src\meta\csb.c

### DIFF
--- a/src/meta/csb.c
+++ b/src/meta/csb.c
@@ -13,7 +13,7 @@ VGMSTREAM* init_vgmstream_csb(STREAMFILE* sf) {
     utf_context *utf_sdl = NULL;
     int total_subsongs, target_subsong = sf->stream_index;
     uint8_t fmt = 0;
-    const char* stream_name;
+    const char* stream_name = NULL;
 
 
     /* checks */


### PR DESCRIPTION
On our addon for Kodi https://github.com/xbmc/audiodecoder.vgmstream becomes your vgmstream used.
In the build systems used for Windows UWP there, a warning is automatically declared as an error.

This change sets the variable to NULL there, which removes the warning.

Error:
```
d:\a\1\audiodecoder.vgmstream\lib\vgmstream\src\meta\csb.c(142): error C4703: potentially uninitialized local pointer variable 'stream_name' used [D:\a\1\s\build\audiodecoder.vgmstream-prefix\src\audiodecoder.vgmstream-build\lib\vgmstream\src\libvgmstream.vcxproj] [D:\a\1\s\build\audiodecoder.vgmstream.vcxproj]
```

Related build log:
https://dev.azure.com/teamkodi/binary-addons/_build/results?buildId=6134&view=logs&j=cc6cffab-e95c-563d-eef4-026ebc0684ec&t=4caacdc4-d3f5-50ea-479d-35158b55a00e&l=583