### PR TITLE
Add .nsa extension as RIFF WAWE [Hajimete no Otetsudai (PC)]

### DIFF
--- a/src/formats.c
+++ b/src/formats.c
@@ -362,6 +362,7 @@ static const char* extension_list[] = {
     "nop",
     "nps",
     "npsf", //fake extension/header id for .nps (in bigfiles)
+    "nsa",
     "nsopus",
     "nub",
     "nub2",

--- a/src/meta/riff.c
+++ b/src/meta/riff.c
@@ -353,8 +353,9 @@ VGMSTREAM* init_vgmstream_riff(STREAMFILE* sf) {
      * .saf: Whacked! (Xbox)
      * .mwv: Level-5 games [Dragon Quest VIII (PS2), Rogue Galaxy (PS2)]
      * .ima: Baja: Edge of Control (PS3/X360)
+     * .nsa: Studio Ring games that uses NScripter [Hajimete no Otetsudai (PC)]
      */
-    if ( check_extensions(sf, "wav,lwav,xwav,da,dax,cd,med,snd,adx,adp,xss,xsew,adpcm,adw,wd,,sbv,wvx,str,at3,rws,aud,at9,saf,ima") ) {
+    if ( check_extensions(sf, "wav,lwav,xwav,da,dax,cd,med,snd,adx,adp,xss,xsew,adpcm,adw,wd,,sbv,wvx,str,at3,rws,aud,at9,saf,ima,nsa") ) {
         ;
     }
     else if ( check_extensions(sf, "mwv") ) {


### PR DESCRIPTION
The .nsa extension is originally used for the archive format for NScripter game engine, but there are NScripter games that uses .nsa extension for music file.

The music files of "Hajimete no Otetsudai" in JoshW archives have .wav extension (renamed), so I'll upload the re-ripped files later.