### PR TITLE
Cli: Json output fixes

### DIFF
--- a/cli/vgmstream_cli.c
+++ b/cli/vgmstream_cli.c
@@ -263,7 +263,6 @@ static int parse_config(cli_config* cfg, int argc, char** argv) {
                 print_json_version();
                 goto fail;
             case 'I':
-                cfg->print_metaonly = 1;
                 cfg->print_metajson = 1;
                 break;
 #endif
@@ -796,6 +795,7 @@ static int convert_file(cli_config* cfg) {
     }
     else {
         print_json_info(vgmstream, cfg);
+        printf("\n");
     }
 #endif
 


### PR DESCRIPTION
- Allow converting files when using Json metadata output, to get the old behavior use the `-m` flag together with `-I`
- Add a new line after outputting Json, to have at least some kind of separation when dealing with multiple subsongs in the output, ideally it would be inside an array instead