### PR TITLE
cwav archives

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,19 @@ There are multiple end-user components:
 The main library (plain *vgmstream*) is the code that handles the internal conversion, while the
 above components are what you use to get sound.
 
-See [components](doc/USAGE.md#components) in the *usage guide* for install instructions and
+If you just want to convert game audio to `.wav`, easiest would be getting *test.exe/vgmstream-cli* (see
+below) then drag-and-drop one or more files to the executable. This should create `(file.extension).wav`,
+if the format is supported. More usable would be installing a music player like *foobar2000* (for
+Windows) or *Audacious* (for Linux) then the appropriate component, so you can listen to VGM without
+converting and set options like infinite looping.
+
+See [components](doc/USAGE.md#components) in the *usage guide* for full install instructions and
 explanations. The aim is feature parity, but there are a few differences between them due to
 missing implementation on vgmstream's side or lack of support in target player or API.
+
+Note vgmstream cannot *encode* (convert from `.wav` to some video game format), it only *decodes*
+(plays game audio).
+
 
 ### Windows
 You should get `vgmstream-win.zip`, which also bundles various components, or

--- a/fb2k/foo_vgmstream.cpp
+++ b/fb2k/foo_vgmstream.cpp
@@ -443,6 +443,7 @@ void input_vgmstream::get_subsong_info(t_uint32 p_subsong, pfc::string_base & ti
     if (infostream && title) {
         vgmstream_title_t tcfg = {0};
         tcfg.remove_extension = 1;
+        tcfg.remove_archive = 1;
 
         const char* filename_str = filename;
         vgmstream_get_title(temp, sizeof(temp), filename_str, infostream, &tcfg);

--- a/src/libvgmstream.vcxproj
+++ b/src/libvgmstream.vcxproj
@@ -144,6 +144,7 @@
     <ClInclude Include="meta\ubi_sb_streamfile.h" />
     <ClInclude Include="meta\ubi_sb_garbage_streamfile.h" />
     <ClInclude Include="meta\ubi_lyn_streamfile.h" />
+    <ClInclude Include="meta\ubi_ckd_cwav_streamfile.h" />
     <ClInclude Include="meta\meta.h" />
     <ClInclude Include="meta\hca_bf.h" />
     <ClInclude Include="meta\hca_keys.h" />
@@ -558,6 +559,7 @@
     <ClCompile Include="meta\vgs.c" />
     <ClCompile Include="meta\ubi_bao.c" />
     <ClCompile Include="meta\ubi_ckd.c" />
+    <ClCompile Include="meta\ubi_ckd_cwav.c" />
     <ClCompile Include="meta\ubi_hx.c" />
     <ClCompile Include="meta\ubi_lyn.c" />
     <ClCompile Include="meta\ubi_raki.c" />

--- a/src/libvgmstream.vcxproj.filters
+++ b/src/libvgmstream.vcxproj.filters
@@ -194,6 +194,9 @@
     <ClInclude Include="meta\ubi_lyn_streamfile.h">
       <Filter>meta\Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="meta\ubi_ckd_cwav_streamfile.h">
+      <Filter>meta\Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="meta\meta.h">
       <Filter>meta\Header Files</Filter>
     </ClInclude>
@@ -1148,6 +1151,9 @@
       <Filter>meta\Source Files</Filter>
     </ClCompile>
     <ClCompile Include="meta\ubi_ckd.c">
+      <Filter>meta\Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="meta\ubi_ckd_cwav.c">
       <Filter>meta\Source Files</Filter>
     </ClCompile>
     <ClCompile Include="meta\ubi_hx.c">

--- a/src/meta/hca_keys.h
+++ b/src/meta/hca_keys.h
@@ -874,8 +874,11 @@ static const hcakey_info hcakey_list[] = {
         // Super Robot Wars 30 (PC)
         {6734488621090458},     // 0017ECFB5201069A
 
-		// CHUNITHM NEW (AC)
-		{32931609366120192},	// 0074FF1FCE264700
+        // CHUNITHM NEW (AC)
+        {32931609366120192},	// 0074FF1FCE264700
+
+        // Shaman King: Funbari Chronicle (Android)
+        {1620612098671},        // 0000017954022A6F
 
 };
 

--- a/src/meta/meta.h
+++ b/src/meta/meta.h
@@ -971,4 +971,6 @@ VGMSTREAM* init_vgmstream_lpcm_fb(STREAMFILE* sf);
 VGMSTREAM* init_vgmstream_wbk(STREAMFILE* sf);
 VGMSTREAM* init_vgmstream_wbk_nslb(STREAMFILE* sf);
 
+VGMSTREAM* init_vgmstream_ubi_ckd_cwav(STREAMFILE* sf);
+
 #endif /*_META_H*/

--- a/src/meta/riff.c
+++ b/src/meta/riff.c
@@ -355,13 +355,14 @@ VGMSTREAM* init_vgmstream_riff(STREAMFILE* sf) {
      * .rws: Climax ATRAC3 [Silent Hill Origins (PSP), Oblivion (PSP)]
      * .aud: EA Replay ATRAC3
      * .at9: standard ATRAC9
+     * .ckd: renamed ATRAC9 [Rayman Origins (Vita)]
      * .saf: Whacked! (Xbox)
      * .mwv: Level-5 games [Dragon Quest VIII (PS2), Rogue Galaxy (PS2)]
      * .ima: Baja: Edge of Control (PS3/X360)
      * .nsa: Studio Ring games that uses NScripter [Hajimete no Otetsudai (PC)]
      * .pcm: Silent Hill Arcade (PC)
      */
-    if ( check_extensions(sf, "wav,lwav,xwav,da,dax,cd,med,snd,adx,adp,xss,xsew,adpcm,adw,wd,,sbv,wvx,str,at3,rws,aud,at9,saf,ima,nsa,pcm") ) {
+    if ( check_extensions(sf, "wav,lwav,xwav,da,dax,cd,med,snd,adx,adp,xss,xsew,adpcm,adw,wd,,sbv,wvx,str,at3,rws,aud,at9,ckd,saf,ima,nsa,pcm") ) {
         ;
     }
     else if ( check_extensions(sf, "mwv") ) {
@@ -590,6 +591,11 @@ VGMSTREAM* init_vgmstream_riff(STREAMFILE* sf) {
                     JunkFound = 1;
                     break;
 
+
+                case 0x64737068: /* "dsph" */
+                case 0x63776176: /* "cwav" */
+                    goto fail; /* parse elsewhere */
+
                 default:
                     /* ignorance is bliss */
                     break;
@@ -623,6 +629,10 @@ VGMSTREAM* init_vgmstream_riff(STREAMFILE* sf) {
             read_u32be(start_offset+0x34, sf) == 0xFFFFFFFF && /* always */
             read_u32be(start_offset+0x38, sf) == 0xFFFFFFFF &&
             read_u32be(start_offset+0x3c, sf) == 0xFFFFFFFF)
+        goto fail;
+
+    ///* MSADPCM .ckd are parsed elsewhere, though they are valid so no big deal if parsed here (just that loops should be ignored) */
+    if (!fmt.is_at9 && check_extensions(sf, "ckd"))
         goto fail;
 
     /* ignore Gitaroo Man Live! (PSP) multi-RIFF (to allow chunked TXTH) */

--- a/src/meta/sli.c
+++ b/src/meta/sli.c
@@ -3,51 +3,40 @@
 
 
 /* .sli+ogg/opus - KiriKiri engine / WaveLoopManager loop points loader [Fate/Stay Night (PC), World End Economica (PC)] */
-VGMSTREAM * init_vgmstream_sli_ogg(STREAMFILE *streamFile) {
-    VGMSTREAM * vgmstream = NULL;
-    STREAMFILE * streamData = NULL;
+VGMSTREAM* init_vgmstream_sli_ogg(STREAMFILE* sf) {
+    VGMSTREAM* vgmstream = NULL;
+    STREAMFILE* sf_data = NULL;
     int32_t loop_start = -1, loop_length = -1;
     int32_t loop_from = -1, loop_to = -1;
 
     /* checks */
-    if (!check_extensions(streamFile, "sli"))
+    if (!check_extensions(sf, "sli"))
         goto fail;
 
     {
         /* try with file.ogg/opus.sli=header and file.ogg/opus=data */
         char basename[PATH_LIMIT];
-        get_streamfile_basename(streamFile,basename,PATH_LIMIT);
-        streamData = open_streamfile_by_filename(streamFile, basename);
-        if (!streamData) goto fail;
+        get_streamfile_basename(sf,basename,PATH_LIMIT);
+        sf_data = open_streamfile_by_filename(sf, basename);
+        if (!sf_data) goto fail;
     }
 
+    if (!is_id32be(0x00, sf_data, "OggS"))
+        goto fail;
 
     /* let the real initer do the parsing */
-    if (check_extensions(streamData, "ogg")) { /* Fate/Stay Night (PC) */
-#ifdef VGM_USE_VORBIS
-        vgmstream = init_vgmstream_ogg_vorbis(streamData);
+    if (is_id32be(0x1c, sf_data, "Opus")) { /* Sabbat of the Witch (PC) */
+        vgmstream = init_vgmstream_ogg_opus(sf_data);
+        if (!vgmstream) goto fail;
+
+        /* somehow sli+opus use 0 encoder delay in the OpusHead (to simplify looping?) */
+        vgmstream->meta_type = meta_OPUS_SLI;
+    }
+    else { /* Fate/Stay Night (PC) */
+        vgmstream = init_vgmstream_ogg_vorbis(sf_data);
         if (!vgmstream) goto fail;
 
         vgmstream->meta_type = meta_OGG_SLI;
-#else
-    goto fail;
-#endif
-    }
-    else if (check_extensions(streamData, "opus")) { /* Sabbat of the Witch (PC) */
-#ifdef VGM_USE_FFMPEG
-        vgmstream = init_vgmstream_ffmpeg(streamData);
-        if (!vgmstream) goto fail;
-
-        /* FFmpeg's Opus encoder delay is borked but no need to fix:
-         * somehow sli+opus use 0 in the OpusHead (to simplify looping?) */
-
-        vgmstream->meta_type = meta_OPUS_SLI;
-#else
-    goto fail;
-#endif
-    }
-    else {
-        goto fail;
     }
 
 
@@ -59,58 +48,63 @@ VGMSTREAM * init_vgmstream_sli_ogg(STREAMFILE *streamFile) {
         int line_ok;
 
         sli_offset = 0;
-        while ((loop_start == -1 || loop_length == -1) && sli_offset < get_streamfile_size(streamFile)) {
+        while ((loop_start == -1 || loop_length == -1) && sli_offset < get_streamfile_size(sf)) {
             char *endptr, *foundptr;
 
-            bytes_read = read_line(line, sizeof(line), sli_offset, streamFile, &line_ok);
+            bytes_read = read_line(line, sizeof(line), sli_offset, sf, &line_ok);
             if (!line_ok) goto fail;
+            sli_offset += bytes_read;
+            /* files may be padded with 0s */
 
-            if (memcmp("LoopStart=",line,10)==0 && line[10] != '\0') {
-                loop_start = strtol(line+10,&endptr,10);
+            /* comments in v2.0 [Sabbath of the Witch (PC), KARAKARA (PC)] */
+            if (line[0] == '#')
+                continue;
+
+            if (memcmp("LoopStart=", line,10) == 0 && line[10] != '\0') {
+                loop_start = strtol(line + 10, &endptr, 10);
                 if (*endptr != '\0') {
                     loop_start = -1; /* if it didn't parse cleanly */
                 }
             }
-            else if (memcmp("LoopLength=",line,11)==0 && line[11] != '\0') {
-                loop_length = strtol(line+11,&endptr,10);
+            else if (memcmp("LoopLength=", line, 11) == 0 && line[11] != '\0') {
+                loop_length = strtol(line + 11, &endptr, 10);
                 if (*endptr != '\0') {
                     loop_length = -1; /* if it didn't parse cleanly */
                 }
             }
 
-            /* a completely different format (2.0?), also with .sli extension and can be handled similarly */
+            /* a completely different format ("#2.00"?), can be handled similarly */
             if ((foundptr = strstr(line,"To=")) != NULL && isdigit(foundptr[3])) {
-                loop_to = strtol(foundptr+3,&endptr,10);
+                loop_to = strtol(foundptr + 3, &endptr, 10);
                 if (*endptr != ';') {
                     loop_to = -1;
                 }
             }
             if ((foundptr = strstr(line,"From=")) != NULL && isdigit(foundptr[5])) {
-                loop_from = strtol(foundptr+5,&endptr,10);
+                loop_from = strtol(foundptr + 5, &endptr, 10);
                 if (*endptr != ';') {
                     loop_from = -1;
                 }
             }
 
-            sli_offset += bytes_read;
         }
     }
 
     if (loop_start != -1 && loop_length != -1) { /* v1 */
-        vgmstream_force_loop(vgmstream,1,loop_start, loop_start+loop_length);
+        vgmstream_force_loop(vgmstream, 1, loop_start, loop_start + loop_length);
     }
     else if (loop_from != -1 && loop_to != -1) { /* v2 */
-        vgmstream_force_loop(vgmstream,1,loop_to, loop_from);
+        vgmstream_force_loop(vgmstream, 1, loop_to, loop_from);
     }
     else {
         goto fail; /* if there's no loop points the .sli wasn't valid */
     }
 
-    close_streamfile(streamData);
+    close_streamfile(sf_data);
     return vgmstream;
 
 fail:
-    close_streamfile(streamData);
+    close_streamfile(sf_data);
     close_vgmstream(vgmstream);
     return NULL;
 }

--- a/src/meta/ubi_ckd_cwav.c
+++ b/src/meta/ubi_ckd_cwav.c
@@ -1,0 +1,37 @@
+#include "meta.h"
+#include "../coding/coding.h"
+#include "ubi_ckd_cwav_streamfile.h"
+
+/* CKD RIFF - UbiArt Framework (v1) audio container [Rayman Origins (3DS)] */
+VGMSTREAM* init_vgmstream_ubi_ckd_cwav(STREAMFILE* sf) {
+    VGMSTREAM* vgmstream = NULL;
+    STREAMFILE* temp_sf = NULL;
+
+    /* checks */
+    if (!is_id32be(0x00,sf, "RIFF"))
+        goto fail;
+    if (!is_id32be(0x08,sf, "WAVE"))
+        goto fail;
+
+    if (!(is_id32be(0x0c,sf, "dsph") || is_id32be(0x0c,sf, "cwav")))
+        goto fail;
+
+    /* .wav: main (unlike .wav.cdk of other versions) */
+    if (!check_extensions(sf,"wav,lwav"))
+        goto fail;
+
+    /* inside dsph (header+start, optional) and cwav (body, always) RIFF chunks is a full "CWAV",
+     * since dsph also contains some data just deblock */
+
+    temp_sf = setup_ubi_ckd_cwav_streamfile(sf);
+    if (!temp_sf) goto fail;
+
+    vgmstream = init_vgmstream_rwsd(temp_sf);
+    if (!vgmstream) goto fail;
+
+    return vgmstream;
+
+fail:
+    close_vgmstream(vgmstream);
+    return NULL;
+}

--- a/src/meta/ubi_ckd_cwav_streamfile.h
+++ b/src/meta/ubi_ckd_cwav_streamfile.h
@@ -1,0 +1,37 @@
+#ifndef _UBI_CKD_CWAV_STREAMFILE_H_
+#define _UBI_CKD_CWAV_STREAMFILE_H_
+#include "deblock_streamfile.h"
+
+static void block_callback(STREAMFILE *sf, deblock_io_data *data) {
+    uint32_t chunk_type = read_u32be(data->physical_offset + 0x00, sf);
+    uint32_t chunk_size = read_u32le(data->physical_offset + 0x04, sf);
+
+    if (chunk_type == get_id32be("RIFF")) {
+        data->data_size = 0x0;
+        data->skip_size = 0x0;
+        data->block_size = 0x0c;
+    }
+    else {
+        data->data_size = chunk_size;
+        data->skip_size = 0x08;
+        data->block_size = data->data_size + data->skip_size;
+    }
+}
+
+/* Deblocks CWAV streams inside RIFF */
+static STREAMFILE* setup_ubi_ckd_cwav_streamfile(STREAMFILE* sf) {
+    STREAMFILE *new_sf = NULL;
+    deblock_config_t cfg = {0};
+
+    cfg.stream_start = 0x00;
+    cfg.stream_size = get_streamfile_size(sf);
+    cfg.block_callback = block_callback;
+
+    /* setup sf */
+    new_sf = open_wrap_streamfile(sf);
+    new_sf = open_io_deblock_streamfile_f(new_sf, &cfg);
+    new_sf = open_fakename_streamfile_f(new_sf, NULL, "bcwav");
+    return new_sf;
+}
+
+#endif /* _UBI_CKD_CWAV_STREAMFILE_H_ */

--- a/src/plugins.c
+++ b/src/plugins.c
@@ -65,7 +65,7 @@ int vgmstream_ctx_is_valid(const char* filename, vgmstream_ctx_valid_cfg *cfg) {
 }
 
 void vgmstream_get_title(char* buf, int buf_len, const char* filename, VGMSTREAM* vgmstream, vgmstream_title_t* cfg) {
-    const char *pos;
+    const char* pos;
     char* pos2;
     char temp[1024];
 
@@ -79,6 +79,13 @@ void vgmstream_get_title(char* buf, int buf_len, const char* filename, VGMSTREAM
         pos = filename;
     else
         pos++;
+
+    /* special case for foobar that uses a (archive)|(subfile) notation when opening a 7z/zip/etc directly */
+    if (cfg && cfg->remove_archive) {
+        const char* subpos = strchr(pos, '|');
+        if (subpos)
+            pos = subpos + 1;
+    }
     strncpy(buf, pos, buf_len);
 
     /* name without extension */

--- a/src/plugins.h
+++ b/src/plugins.h
@@ -72,6 +72,7 @@ typedef struct {
     int force_title;
     int subsong_range;
     int remove_extension;
+    int remove_archive;
 } vgmstream_title_t;
 
 /* get a simple title for plugins */

--- a/src/vgmstream.c
+++ b/src/vgmstream.c
@@ -53,7 +53,6 @@ VGMSTREAM* (*init_vgmstream_functions[])(STREAMFILE* sf) = {
     init_vgmstream_vpk,
     init_vgmstream_genh,
     init_vgmstream_ogg_vorbis,
-    init_vgmstream_sli_ogg,
     init_vgmstream_sfl_ogg,
     init_vgmstream_sadb,
     init_vgmstream_ps2_bmdx,
@@ -529,6 +528,7 @@ VGMSTREAM* (*init_vgmstream_functions[])(STREAMFILE* sf) = {
     init_vgmstream_mic_koei,
     init_vgmstream_seb,
     init_vgmstream_ps2_pnb,
+    init_vgmstream_sli_ogg,
 
     /* lowest priority metas (should go after all metas, and TXTH should go before raw formats) */
     init_vgmstream_txth,            /* proper parsers should supersede TXTH, once added */

--- a/src/vgmstream.c
+++ b/src/vgmstream.c
@@ -518,6 +518,7 @@ VGMSTREAM* (*init_vgmstream_functions[])(STREAMFILE* sf) = {
     init_vgmstream_wbk,
     init_vgmstream_wbk_nslb,
     init_vgmstream_dsp_apex,
+    init_vgmstream_ubi_ckd_cwav,
 
     /* lower priority metas (no clean header identity, somewhat ambiguous, or need extension/companion file to identify) */
     init_vgmstream_agsc,


### PR DESCRIPTION
- txtp-maker: rename dupes by default, cut long names
- SLI: ignore comments and cleanup
- Add HCA key
- Fix some Ubi CKD [Rayman Origins (3DS/Vita)]
- Fix companion files in foobar 7z/zip archives
