### PR TITLE
Bump CMake minimum version to 3.11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.6)
+cmake_minimum_required(VERSION 3.11)
 project(vgmstream NONE)
 
 if(CMAKE_SYSTEM_NAME MATCHES Darwin)


### PR DESCRIPTION
[FetchContent](https://cmake.org/cmake/help/latest/module/FetchContent.html) is new in 3.11. If I've misunderstood then please reject this, but it seems like 3.11 is now a minimum requirement.