### PR TITLE
Further fix ktac.c without VGM_USE_FFMPEG

### DIFF
--- a/src/meta/ktac.c
+++ b/src/meta/ktac.c
@@ -1,6 +1,7 @@
 #include "meta.h"
 #include "../coding/coding.h"
 
+#ifdef VGM_USE_FFMPEG
 typedef struct {
     int loop_flag;
     int32_t loop_start;
@@ -10,6 +11,7 @@ typedef struct {
     mp4_custom_t mp4;
     int type;
 } ktac_header_t;
+#endif
 
 
 /* KTAC - Koei Tecmo custom AAC [Kin'iro no Corda 3 (Vita), Shingeki no Kyojin: Shichi kara no Dasshutsu (3DS), Dynasty Warriors (PS4)] */


### PR DESCRIPTION
This struct can't be defined without mp4_custom_t, which requires VGM_USE_FFMPEG.

It seems like 9958c00b0e8aafa369f53975d2ed91aefd1d4fb9 was meant to fix this but missed the struct. `ktac_header_t` isn't even needed anymore since it's only used for temporary values in this one function, but this was the quickest fix.