### PR TITLE
PS1 ilf patch

### DIFF
--- a/src/formats.c
+++ b/src/formats.c
@@ -229,6 +229,7 @@ static const char* extension_list[] = {
     "ifs",
     "ikm",
     "ild",
+    "ilf", //txth/reserved [Madden NFL 98 (PS1)]
     "ilv", //txth/reserved [Star Wars Episode III (PS2)]
     "ima",
     "imc",


### PR DESCRIPTION
the .ILF extension can be found on the PS1 versions of **Madden NFL 98** and **Madden NFL 99**.
this is just for txth stuff.