### PR TITLE
another extension add

### DIFF
--- a/src/meta/aifc.c
+++ b/src/meta/aifc.c
@@ -106,7 +106,7 @@ VGMSTREAM* init_vgmstream_aifc(STREAMFILE* sf) {
     else if (check_extensions(sf, "aifc,laifc,afc,cbd2,bgm,fda,n64,wav,lwav,xa")) {
         is_aifc_ext = 1;
     }
-    else if (check_extensions(sf, "aiff,laiff,acm,adp,ai,pcm")) {
+    else if (check_extensions(sf, "aiff,laiff,acm,adp,ai,pcm,wav")) {
         is_aiff_ext = 1;
     }
     else {

--- a/src/meta/aifc.c
+++ b/src/meta/aifc.c
@@ -95,12 +95,15 @@ VGMSTREAM* init_vgmstream_aifc(STREAMFILE* sf) {
      * .fda: Homeworld 2 (PC)
      * .n64: Turok (N64) src
      * .pcm: Road Rash (SAT)
+     * .wav: SimCity 3000 (Mac)
+     * .lwav: for media players that may confuse this format with the usual RIFF WAVE file.
+     * .xa: SimCity 3000 (Mac)
      */
     if (check_extensions(sf, "aif,laif,")) {
         is_aifc_ext = 1;
         is_aiff_ext = 1;
     }
-    else if (check_extensions(sf, "aifc,laifc,afc,cbd2,bgm,fda,n64")) {
+    else if (check_extensions(sf, "aifc,laifc,afc,cbd2,bgm,fda,n64,wav,lwav,xa")) {
         is_aifc_ext = 1;
     }
     else if (check_extensions(sf, "aiff,laiff,acm,adp,ai,pcm")) {


### PR DESCRIPTION
this time i'm adding two.
the macOS version of SimCity 3000 doesn't use Maxis' XA format. instead, it uses the so-called "standard" AIFC format.
in case anyone wants to test this new change, here are the files.
[simcity3000_mac_aifc.tar](https://www.sendspace.com/file/6y932b)