### PR TITLE
sspf mix

### DIFF
--- a/cli/vgmstream_cli.c
+++ b/cli/vgmstream_cli.c
@@ -635,7 +635,7 @@ fail:
 }
 
 static int convert_subsongs(cli_config* cfg) {
-    int res, oks, kos;
+    int res, kos;
     int subsong;
     /* restore original values in case of multiple parsed files */
     int start_temp = cfg->subsong_index;
@@ -651,7 +651,6 @@ static int convert_subsongs(cli_config* cfg) {
     //;VGM_LOG("CLI: subsongs %i to %i\n", cfg->subsong_index, cfg->subsong_end + 1);
 
     /* convert subsong range */
-    oks = 0;
     kos = 0 ;
     for (subsong = cfg->subsong_index; subsong < cfg->subsong_end + 1; subsong++) {
         cfg->subsong_index = subsong; 
@@ -661,7 +660,7 @@ static int convert_subsongs(cli_config* cfg) {
     }
 
     if (kos) {
-        fprintf(stderr, "failed %i of %i subsongs\n", kos, oks);
+        fprintf(stderr, "failed %i subsongs\n", kos);
     }
 
     cfg->subsong_index = start_temp;

--- a/src/coding/coding.h
+++ b/src/coding/coding.h
@@ -204,7 +204,7 @@ void decode_mtaf(VGMSTREAMCHANNEL* stream, sample_t* outbuf, int channelspacing,
 
 
 /* mta2_decoder */
-void decode_mta2(VGMSTREAMCHANNEL* stream, sample_t* outbuf, int channelspacing, int32_t first_sample, int32_t samples_to_do, int channel);
+void decode_mta2(VGMSTREAMCHANNEL* stream, sample_t* outbuf, int channelspacing, int32_t first_sample, int32_t samples_to_do, int channel, int config);
 
 
 /* mc3_decoder */

--- a/src/decode.c
+++ b/src/decode.c
@@ -1392,7 +1392,7 @@ void decode_vgmstream(VGMSTREAM* vgmstream, int samples_written, int samples_to_
         case coding_MTA2:
             for (ch = 0; ch < vgmstream->channels; ch++) {
                 decode_mta2(&vgmstream->ch[ch], buffer+ch,
-                        vgmstream->channels, vgmstream->samples_into_block, samples_to_do, ch);
+                        vgmstream->channels, vgmstream->samples_into_block, samples_to_do, ch, vgmstream->codec_config);
             }
             break;
         case coding_MC3:

--- a/src/formats.c
+++ b/src/formats.c
@@ -502,6 +502,7 @@ static const char* extension_list[] = {
     "ssd", //txth/reserved [Zack & Wiki (Wii)]
     "ssm",
     "sspr",
+    "ssp",
     "sss",
     "ster",
     "sth",
@@ -1386,6 +1387,7 @@ static const meta_info meta_info_list[] = {
         {meta_WBK_NSLB,             "Treyarch NSLB header"},
         {meta_DSP_APEX,             "Koei Tecmo APEX header"},
         {meta_MPEG,                 "MPEG header"},
+        {meta_SSPF,                 "Konami SSPF header"},
 };
 
 void get_vgmstream_coding_description(VGMSTREAM* vgmstream, char* out, size_t out_size) {

--- a/src/libvgmstream.vcxproj
+++ b/src/libvgmstream.vcxproj
@@ -264,6 +264,7 @@
     <ClCompile Include="meta\sqex_scd.c" />
     <ClCompile Include="meta\sqex_scd_sscf.c" />
     <ClCompile Include="meta\sqex_sead.c" />
+    <ClCompile Include="meta\sspc.c" />
     <ClCompile Include="meta\sspr.c" />
     <ClCompile Include="meta\sthd.c" />
     <ClCompile Include="meta\tun.c" />

--- a/src/libvgmstream.vcxproj.filters
+++ b/src/libvgmstream.vcxproj.filters
@@ -1687,6 +1687,9 @@
     <ClCompile Include="meta\sqex_sead.c">
       <Filter>meta\Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="meta\sspc.c">
+      <Filter>meta\Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="meta\sspr.c">
       <Filter>meta\Source Files</Filter>
     </ClCompile>

--- a/src/meta/aifc.c
+++ b/src/meta/aifc.c
@@ -83,6 +83,7 @@ VGMSTREAM* init_vgmstream_aifc(STREAMFILE* sf) {
     /* checks */
     if (!is_id32be(0x00,sf, "FORM"))
         goto fail;
+VGM_LOG("1\n");
 
     /* .aif: common (AIFF or AIFC), .aiff: common AIFF, .aifc: common AIFC
      * .laif/laiff/laifc: for plugins
@@ -95,18 +96,18 @@ VGMSTREAM* init_vgmstream_aifc(STREAMFILE* sf) {
      * .fda: Homeworld 2 (PC)
      * .n64: Turok (N64) src
      * .pcm: Road Rash (SAT)
-     * .wav: SimCity 3000 (Mac)
+     * .wav: SimCity 3000 (Mac) (both AIFC and AIFF)
      * .lwav: for media players that may confuse this format with the usual RIFF WAVE file.
      * .xa: SimCity 3000 (Mac)
      */
-    if (check_extensions(sf, "aif,laif,")) {
+    if (check_extensions(sf, "aif,laif,wav,lwav,")) {
         is_aifc_ext = 1;
         is_aiff_ext = 1;
     }
-    else if (check_extensions(sf, "aifc,laifc,afc,cbd2,bgm,fda,n64,wav,lwav,xa")) {
+    else if (check_extensions(sf, "aifc,laifc,afc,cbd2,bgm,fda,n64,xa")) {
         is_aifc_ext = 1;
     }
-    else if (check_extensions(sf, "aiff,laiff,acm,adp,ai,pcm,wav")) {
+    else if (check_extensions(sf, "aiff,laiff,acm,adp,ai,pcm")) {
         is_aiff_ext = 1;
     }
     else {
@@ -136,8 +137,10 @@ VGMSTREAM* init_vgmstream_aifc(STREAMFILE* sf) {
             aifx_size += 0x08; /* [Psychic Force Puzzle Taisen CD2 (PS1)] */
     }
 
-    if (aifx_size + 0x08 != file_size)
+    if (aifx_size + 0x08 != file_size) {
+        vgm_logi("AIFF: wrong reported size %x + 0x8 vs file size %x\n", aifx_size, file_size);
         goto fail;
+    }
 
 
     /* read through chunks to verify format and find metadata */

--- a/src/meta/ea_1snh.c
+++ b/src/meta/ea_1snh.c
@@ -235,10 +235,14 @@ static int parse_header(STREAMFILE* sf, eacs_header* ea, uint32_t offset) {
         ea->num_samples = read_s32(offset+0x0c, sf);
         ea->loop_start  = read_s32(offset+0x10, sf);
         ea->loop_end    = read_s32(offset+0x14, sf) + ea->loop_start; /* loop length */
-        ea->data_offset = read_s32(offset+0x18, sf); /* 0 when blocked */
+        ea->data_offset = read_s32(offset+0x18, sf); /* 0 when blocked, usually */
         /* 0x1c: pan/volume/etc? (0x7F)
          * rest may be padding/garbage */
         //VGM_ASSERT(ea->type != 0, "EA EACS: unknown type %i\n", ea->type);
+
+        /* blocked should set 0 but in rare cases points to data start [NBA Live 95 (MS-DOS)] */
+        if (!ea->is_bank)
+            ea->data_offset = 0;
 
         if (ea->codec == EA_CODEC_IMA)
             ea->codec_config = get_ea_1snh_ima_version(sf, 0x00, ea);

--- a/src/meta/hca.c
+++ b/src/meta/hca.c
@@ -46,7 +46,7 @@ VGMSTREAM* init_vgmstream_hca_subkey(STREAMFILE* sf, uint16_t subkey) {
         uint8_t keybuf[0x08+0x02];
         size_t keysize;
 
-        keysize = read_key_file(keybuf, 0x08+0x04, sf);
+        keysize = read_key_file(keybuf, sizeof(keybuf), sf);
         if (keysize == 0x08) { /* standard */
             keycode = get_u64be(keybuf+0x00);
         }

--- a/src/meta/meta.h
+++ b/src/meta/meta.h
@@ -7,6 +7,7 @@ typedef VGMSTREAM* (*init_vgmstream_t)(STREAMFILE* sf);
 
 VGMSTREAM* init_vgmstream_silence(int channels, int sample_rate, int32_t num_samples);
 VGMSTREAM* init_vgmstream_silence_container(int total_subsongs);
+VGMSTREAM* init_vgmstream_silence_base(VGMSTREAM* vgmstream);
 
 
 VGMSTREAM* init_vgmstream_adx(STREAMFILE* sf);

--- a/src/meta/meta.h
+++ b/src/meta/meta.h
@@ -977,4 +977,6 @@ VGMSTREAM* init_vgmstream_ubi_ckd_cwav(STREAMFILE* sf);
 
 VGMSTREAM* init_vgmstream_mpeg(STREAMFILE* sf);
 
+VGMSTREAM* init_vgmstream_sspf(STREAMFILE* sf);
+
 #endif /*_META_H*/

--- a/src/meta/meta.h
+++ b/src/meta/meta.h
@@ -655,6 +655,7 @@ VGMSTREAM* init_vgmstream_opus_prototype(STREAMFILE* sf);
 VGMSTREAM* init_vgmstream_opus_opusnx(STREAMFILE* sf);
 VGMSTREAM* init_vgmstream_opus_nsopus(STREAMFILE* sf);
 VGMSTREAM* init_vgmstream_opus_sqex(STREAMFILE* sf);
+VGMSTREAM* init_vgmstream_opus_rsnd(STREAMFILE* sf);
 
 VGMSTREAM * init_vgmstream_raw_al(STREAMFILE * streamFile);
 

--- a/src/meta/opus.c
+++ b/src/meta/opus.c
@@ -511,3 +511,32 @@ VGMSTREAM* init_vgmstream_opus_sqex(STREAMFILE* sf) {
 fail:
     return NULL;
 }
+
+
+/* Idea Factory(?) variation [Birushana: Ichijuu no Kaze (Switch)] */
+VGMSTREAM* init_vgmstream_opus_rsnd(STREAMFILE* sf) {
+    off_t offset = 0;
+    int num_samples = 0, loop_start = 0, loop_end = 0, loop_flag;
+
+    /* checks */
+    if (!is_id32be(0x00, sf,"RSND"))
+        goto fail;
+    if (!check_extensions(sf, "rsnd"))
+        goto fail;
+    /* 0x04: 00? (16b)*/
+    /* 0x06: 00? (8b)*/
+    loop_flag = read_u8(0x07, sf);
+    if (loop_flag) { /* not really needed as both will be 0 */
+        loop_start = read_s32le(0x08, sf);
+        loop_end = read_s32le(0x0c, sf);
+    }
+    offset = read_u32le(0x10, sf); /* always 0x40 */
+    /* 0x14: offset again? */
+    /* 0x18+: null? (unknown numbers in bgm050) */
+    num_samples = 0; /* not loop_end as it isn't set when looping is disabled */
+
+
+    return init_vgmstream_opus(sf, meta_OPUS, offset, num_samples, loop_start, loop_end);
+fail:
+    return NULL;
+}

--- a/src/meta/silence.c
+++ b/src/meta/silence.c
@@ -1,7 +1,7 @@
 #include "meta.h"
 
 /* silent stream - mainly for engines that need them or dummy subsongs */
-VGMSTREAM* init_vgmstream_silence(int channels, int sample_rate, int32_t num_samples) {
+static VGMSTREAM* init_vgmstream_silence_internal(int channels, int sample_rate, int32_t num_samples, uint32_t channel_layout) {
     VGMSTREAM* vgmstream = NULL;
 
     if (channels <= 0)
@@ -18,6 +18,7 @@ VGMSTREAM* init_vgmstream_silence(int channels, int sample_rate, int32_t num_sam
     vgmstream->meta_type = meta_SILENCE;
     vgmstream->sample_rate = sample_rate;
     vgmstream->num_samples = num_samples;
+    vgmstream->channel_layout = channel_layout;
 
     vgmstream->coding_type = coding_SILENCE;
     vgmstream->layout_type = layout_none;
@@ -28,11 +29,15 @@ fail:
     return NULL;
 }
 
+VGMSTREAM* init_vgmstream_silence(int channels, int sample_rate, int32_t num_samples) {
+    return init_vgmstream_silence_internal(channels, sample_rate, num_samples, 0);
+}
+
 /* silent stream - for containers that have dummy streams but it's a hassle to detect/filter out */
 VGMSTREAM* init_vgmstream_silence_container(int total_subsongs) {
     VGMSTREAM* vgmstream = NULL;
 
-    vgmstream = init_vgmstream_silence(0, 0, 0);
+    vgmstream = init_vgmstream_silence_internal(0, 0, 0, 0);
     if (!vgmstream) goto fail;
 
     vgmstream->num_streams = total_subsongs;
@@ -42,4 +47,15 @@ VGMSTREAM* init_vgmstream_silence_container(int total_subsongs) {
 fail:
     close_vgmstream(vgmstream);
     return NULL;
+}
+
+VGMSTREAM* init_vgmstream_silence_base(VGMSTREAM* v) {
+    if (!v)
+        return init_vgmstream_silence_internal(0, 0, 0, 0);
+
+    return init_vgmstream_silence_internal(
+        v->channels,
+        v->sample_rate,
+        0, //v->num_samples ?
+        v->channel_layout);
 }

--- a/src/meta/sspf.c
+++ b/src/meta/sspf.c
@@ -1,0 +1,120 @@
+#include "meta.h"
+
+
+/* SSPF - Konami/KCET banks [Metal Gear Solid 4 (PS3)] */
+VGMSTREAM* init_vgmstream_sspf(STREAMFILE* sf) {
+    VGMSTREAM* vgmstream = NULL;
+    off_t start_offset;
+    int loop_flag, channels, sample_rate;
+    int32_t num_samples, loop_start;
+    int total_subsongs, target_subsong = sf->stream_index;
+    uint32_t file_size, pad_size, offset, bwav_offset, iwav_offset, ssw2_offset, stream_size;
+    uint32_t codec;
+
+
+    /* checks */
+    if (!is_id32be(0x00,sf, "SSPF"))
+        goto fail;
+    if (!check_extensions(sf, "ssp"))
+        goto fail;
+
+    /* extra check to ignore .spc, that are a RAM pack of .ssp with a ~0x800 table at the end */
+    file_size = read_u32be(0x08, sf) + 0x08; /* without padding */
+    pad_size = 0;
+    if (file_size % 0x800) /* add padding */
+        pad_size = 0x800 - (file_size % 0x800);
+    if (file_size != get_streamfile_size(sf) && file_size + pad_size != get_streamfile_size(sf))
+        goto fail;
+    /* 0x0c: "loadBank"? (always 2? MTA2 is always 1) */
+
+    /* read chunks (fixed order) */
+    bwav_offset = read_u32be(0x04, sf) + 0x08;
+    if (!is_id32be(bwav_offset,sf, "BWAV"))
+        goto fail;
+
+    iwav_offset = read_u32be(bwav_offset + 0x04, sf) + 0x08 + bwav_offset;
+
+    if (!is_id32be(iwav_offset,sf, "IWAV"))
+        goto fail;
+    /* past IWAV are some more chunks then padding (variable? some are defined in debug structs only, not seen) */
+
+    total_subsongs = read_u32be(iwav_offset + 0x08,sf);
+    if (target_subsong == 0) target_subsong = 1;
+    if (target_subsong < 0 || target_subsong > total_subsongs || total_subsongs < 1) goto fail;
+
+    offset = iwav_offset + 0x10 + (target_subsong - 1) * 0x20;
+
+    /* IWAV entry supposedly contains more info but seems only offset and some ID at 0x14, rest is 0 */
+    ssw2_offset = read_u32be(offset + 0x00,sf) + bwav_offset;
+    if (is_id32be(ssw2_offset,sf, "SSWF")) {
+        /* 
+        04 kType (always 0x01)
+        05 nChannels
+        06 freq
+        08 lpStart
+        0C nSamples
+        */
+
+        /* data is some unknown codec that seems to be ADPCM header + byte (simplified MTA2 with only 1 group?) */
+        vgm_logi("SSPF: unsupported SSWF variant at %x\n", ssw2_offset);
+        goto fail;
+    }
+    else if (is_id32be(ssw2_offset,sf, "SSW2")) {
+        stream_size = read_u32be(ssw2_offset + 0x04,sf);
+        /* 08 version? (always 0) */
+        num_samples = read_s32be(ssw2_offset + 0x0c,sf);
+        codec = read_u32be(ssw2_offset + 0x10,sf); /* kType (always 0x21) */
+        if (read_u32be(ssw2_offset + 0x10,sf) != 0x21)
+            goto fail;
+        if (read_u8(ssw2_offset + 0x14,sf) != 0x08) /* nBlocks? */
+            goto fail;
+        if (read_u8(ssw2_offset + 0x15,sf) != 0x01) /* nChannels? */
+            goto fail;
+
+        channels = 1;
+        sample_rate = read_u16be(ssw2_offset + 0x16,sf);
+        loop_start = read_s32be(ssw2_offset + 0x18,sf);
+        /* 0x1c: lpStartAddr (0xFFFFFFFF is none) */
+
+        loop_flag = loop_start != 0x7FFFFFFF;
+        start_offset = ssw2_offset + 0x20;
+    }
+    else {
+        vgm_logi("SSPF: unknown variant at %x\n", ssw2_offset);
+        goto fail;
+    }
+
+
+    /* build the VGMSTREAM */
+    vgmstream = allocate_vgmstream(channels, loop_flag);
+    if (!vgmstream) goto fail;
+
+    vgmstream->meta_type = meta_SSPF;
+    vgmstream->sample_rate = sample_rate;
+    vgmstream->num_samples = num_samples;
+    vgmstream->loop_start_sample = loop_start;
+    vgmstream->loop_end_sample = num_samples;
+
+    vgmstream->num_streams = total_subsongs;
+    vgmstream->stream_size = stream_size;
+
+    switch (codec) {
+        case 0x21:
+            vgmstream->coding_type = coding_MTA2;
+            vgmstream->codec_config = 1;
+            vgmstream->layout_type = layout_none;
+            break;
+        
+        default:
+            vgm_logi("SSPF: unknown codec %x\n", codec);
+            goto fail;
+    }
+
+    if (!vgmstream_open_stream(vgmstream, sf, start_offset))
+        goto fail;
+    return vgmstream;
+
+fail:
+    close_vgmstream(vgmstream);
+    return NULL;
+}

--- a/src/meta/txtp.c
+++ b/src/meta/txtp.c
@@ -218,15 +218,12 @@ static void clean_txtp(txtp_header* txtp, int fail) {
 
 static int parse_silents(txtp_header* txtp) {
     int i;
-    int channels = 0;
-    int sample_rate = 0;
-    int32_t num_samples = 0;
+    VGMSTREAM* v_base = NULL;
 
     /* silents use same channels as close files */
     for (i = 0; i < txtp->vgmstream_count; i++) {
         if (!txtp->entry[i].silent) {
-            channels = txtp->vgmstream[i]->channels;
-            sample_rate = txtp->vgmstream[i]->sample_rate;
+            v_base = txtp->vgmstream[i];
             break;
         }
     }
@@ -236,7 +233,7 @@ static int parse_silents(txtp_header* txtp) {
         if (!txtp->entry[i].silent)
             continue;
 
-        txtp->vgmstream[i] = init_vgmstream_silence(channels, sample_rate, num_samples);
+        txtp->vgmstream[i] = init_vgmstream_silence_base(v_base);
         if (!txtp->vgmstream[i]) goto fail;
 
         apply_settings(txtp->vgmstream[i], &txtp->entry[i]);

--- a/src/vgmstream.c
+++ b/src/vgmstream.c
@@ -519,6 +519,7 @@ VGMSTREAM* (*init_vgmstream_functions[])(STREAMFILE* sf) = {
     init_vgmstream_wbk_nslb,
     init_vgmstream_dsp_apex,
     init_vgmstream_ubi_ckd_cwav,
+    init_vgmstream_sspf,
 
     /* lower priority metas (no clean header identity, somewhat ambiguous, or need extension/companion file to identify) */
     init_vgmstream_mpeg,

--- a/src/vgmstream.c
+++ b/src/vgmstream.c
@@ -520,6 +520,7 @@ VGMSTREAM* (*init_vgmstream_functions[])(STREAMFILE* sf) = {
     init_vgmstream_dsp_apex,
     init_vgmstream_ubi_ckd_cwav,
     init_vgmstream_sspf,
+    init_vgmstream_opus_rsnd,
 
     /* lower priority metas (no clean header identity, somewhat ambiguous, or need extension/companion file to identify) */
     init_vgmstream_mpeg,

--- a/src/vgmstream.h
+++ b/src/vgmstream.h
@@ -754,6 +754,7 @@ typedef enum {
     meta_WBK_NSLB,
     meta_DSP_APEX,
     meta_MPEG,
+    meta_SSPF,
 
 } meta_t;
 


### PR DESCRIPTION
- Preserve channel layout when downmixing some cases
- Add SSPF .ssp [Metal Gear Solid 4 (PS3)]
- Fix some EA 1SNh .asf [NBA Live 95 (PC)]
- Add .rsnd NSOpus [Birushana: Ichijuu no Kaze (Switch)]
- Fix .wav AIFF [Sim City 3000 (Mac)]