### PR TITLE
log kt

### DIFF
--- a/doc/USAGE.md
+++ b/doc/USAGE.md
@@ -579,7 +579,7 @@ Console location and format depends on plugin:
 - *Audacious*: start with `audacious -V` from terminal
 - CLI utils: printed to stdout directly
 
-Only a few errors are printed ATM but may be helpful for more common cases.
+Only a few errors types are printed but may be helpful for more common cases.
 
 ## Tagging
 Some of vgmstream's plugins support simple read-only tagging via external files.

--- a/src/formats.c
+++ b/src/formats.c
@@ -119,7 +119,7 @@ static const char* extension_list[] = {
     "brstm",
     "brstmspm",
     "brwav",
-    "brwsd",
+    "brwsd", //fake extension for RWSD (non-format)
     "bsnd",
     "btsnd",
     "bvg",
@@ -1225,7 +1225,8 @@ static const meta_info meta_info_list[] = {
         {meta_HCA,                  "CRI HCA header"},
         {meta_SVAG_SNK,             "SNK SVAG header"},
         {meta_PS2_VDS_VDM,          "Procyon Studio VDS/VDM header"},
-        {meta_FFMPEG,               "FFmpeg supported file format"},
+        {meta_FFMPEG,               "FFmpeg supported format"},
+        {meta_FFMPEG_faulty,        "FFmpeg supported format (check log)"},
         {meta_X360_CXS,             "tri-Crescendo CXS header"},
         {meta_AKB,                  "Square-Enix AKB header"},
         {meta_X360_PASX,            "Premium Agency PASX header"},

--- a/src/libvgmstream.vcxproj
+++ b/src/libvgmstream.vcxproj
@@ -203,6 +203,7 @@
     <ClCompile Include="meta\bcstm.c" />
     <ClCompile Include="meta\bfstm.c" />
     <ClCompile Include="meta\bfwav.c" />
+    <ClCompile Include="meta\bw_mp3_riff.c" />
     <ClCompile Include="meta\bwav.c" />
     <ClCompile Include="meta\esf.c" />
     <ClCompile Include="meta\excitebots.c" />

--- a/src/libvgmstream.vcxproj.filters
+++ b/src/libvgmstream.vcxproj.filters
@@ -1948,6 +1948,9 @@
     <ClCompile Include="meta\bwav.c">
       <Filter>meta\Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="meta\bw_mp3_riff.c">
+      <Filter>meta\Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="meta\rad.c">
       <Filter>meta\Source Files</Filter>
     </ClCompile>

--- a/src/meta/bw_mp3_riff.c
+++ b/src/meta/bw_mp3_riff.c
@@ -1,0 +1,75 @@
+#include "meta.h"
+#include "../coding/coding.h"
+
+
+/* Bioware pseudo-format (for sfx) [Star Wars: Knights of the Old Republic 1/2 (PC/Switch/iOS)] */
+VGMSTREAM* init_vgmstream_bw_mp3_riff(STREAMFILE* sf) {
+    VGMSTREAM* vgmstream = NULL;
+    STREAMFILE* temp_sf = NULL;
+    uint32_t subfile_offset = 0, subfile_size = 0;
+
+
+    /* checks */
+    if (read_u32be(0x00, sf) != 0xFFF360C4)
+        goto fail;
+    //if ((read_u32be(0x00, sf) & 0xFFF00000) != 0xFFF00000) /* no point to check other mp3s */
+    //    goto fail;
+    if (!is_id32be(0x0d, sf, "LAME") && !is_id32be(0x1d6, sf, "RIFF"))
+        goto fail;
+
+    /* strange mix of micro empty MP3 (LAME3.93, common header) + standard RIFF */
+
+    subfile_offset = 0x1d6;
+    subfile_size = read_u32le(subfile_offset + 0x04, sf) + 0x08;
+
+    temp_sf = setup_subfile_streamfile(sf, subfile_offset, subfile_size, "wav");
+    if (!temp_sf) goto fail;
+
+    /* init the VGMSTREAM */
+    vgmstream = init_vgmstream_riff(temp_sf);
+    if (!vgmstream) goto fail;
+
+    close_streamfile(temp_sf);
+    return vgmstream;
+
+fail:
+    close_streamfile(temp_sf);
+    close_vgmstream(vgmstream);
+    return NULL;
+}
+
+/* Bioware pseudo-format (for music) [Star Wars: Knights of the Old Republic 1/2 (PC/Switch/iOS)] */
+VGMSTREAM* init_vgmstream_bw_riff_mp3(STREAMFILE* sf) {
+    VGMSTREAM* vgmstream = NULL;
+    STREAMFILE* temp_sf = NULL;
+    uint32_t subfile_offset = 0, subfile_size = 0;
+
+
+    /* checks */
+    if (!is_id32be(0x00, sf, "RIFF"))
+        goto fail;
+    if (read_u32le(0x04, sf) != 0x32)
+        goto fail;
+    if (get_streamfile_size(sf) <= 0x32 + 0x08) /* ? */
+        goto fail;
+
+    /* strange mix of micro RIFF (with codec 0x01, "fact" and "data" size 0)) + standard MP3 (sometimes with ID3) */
+
+    subfile_offset = 0x3A;
+    subfile_size = get_streamfile_size(sf) - subfile_offset;
+
+    temp_sf = setup_subfile_streamfile(sf, subfile_offset, subfile_size, "mp3");
+    if (!temp_sf) goto fail;
+
+    /* init the VGMSTREAM */
+    vgmstream = init_vgmstream_mpeg(temp_sf);
+    if (!vgmstream) goto fail;
+
+    close_streamfile(temp_sf);
+    return vgmstream;
+
+fail:
+    close_streamfile(temp_sf);
+    close_vgmstream(vgmstream);
+    return NULL;
+}

--- a/src/meta/meta.h
+++ b/src/meta/meta.h
@@ -988,4 +988,7 @@ VGMSTREAM* init_vgmstream_adm3(STREAMFILE* sf);
 
 VGMSTREAM* init_vgmstream_tt_ad(STREAMFILE* sf);
 
+VGMSTREAM* init_vgmstream_bw_mp3_riff(STREAMFILE* sf);
+VGMSTREAM* init_vgmstream_bw_riff_mp3(STREAMFILE* sf);
+
 #endif /*_META_H*/

--- a/src/vgmstream.c
+++ b/src/vgmstream.c
@@ -524,6 +524,8 @@ VGMSTREAM* (*init_vgmstream_functions[])(STREAMFILE* sf) = {
     init_vgmstream_esf,
     init_vgmstream_adm3,
     init_vgmstream_tt_ad,
+    init_vgmstream_bw_mp3_riff,
+    init_vgmstream_bw_riff_mp3,
 
     /* lower priority metas (no clean header identity, somewhat ambiguous, or need extension/companion file to identify) */
     init_vgmstream_mpeg,

--- a/src/vgmstream.h
+++ b/src/vgmstream.h
@@ -587,7 +587,8 @@ typedef enum {
     meta_HCA,               /* CRI HCA */
     meta_SVAG_SNK,
     meta_PS2_VDS_VDM,       /* Graffiti Kingdom */
-    meta_FFMPEG,            /* any file supported by FFmpeg */
+    meta_FFMPEG,
+    meta_FFMPEG_faulty,
     meta_X360_CXS,          /* Eternal Sonata (Xbox 360) */
     meta_AKB,               /* SQEX iOS */
     meta_X360_PASX,         /* Namco PASX (Soul Calibur II HD X360) */


### PR DESCRIPTION
- Tweak truncated .aix to not loop
- Fix some .atsl/ktsl2asbin [Nioh (PS4)]
- Extra logs on broken RIFF
- Add Bioware fake .wav [Star Wars: KOTOR 1/2 (PC)]
