### PR TITLE
Fix sample rate of EA swvr

### DIFF
--- a/src/meta/ea_swvr.c
+++ b/src/meta/ea_swvr.c
@@ -122,7 +122,7 @@ VGMSTREAM* init_vgmstream_ea_swvr(STREAMFILE* sf) {
                     goto fail;
                 coding = coding_PCM8_U_int;
                 channels = 1;
-                sample_rate = 16000; /* assumed */
+                sample_rate = 22050; /* assumed */
             }
             else {
                 //todo


### PR DESCRIPTION
Hello, I've encountered a problem of sample rate when attempting to decode the recorded voices of the game Future Cop LAPD (PC version, with French translations). I found that using a sample rate of 22050 instead of 16000 fixes *my* issue.

For comparison, I've attached a ZIP archive that contains two WAV files generated by `vgmstream`:
1. `16000.wav`, which is *before* this patch;
2. `22050.wav`, which is *after* this patch.

The second wave is much, much closer to the game than the first.
[sounds.zip](https://github.com/vgmstream/vgmstream/files/8844699/sounds.zip)

However, as I did not find in the binary file where the sample rate resides, I am afraid this may depend on games. Even though this fixes Future Cop LAPD, it may break other games.

If this PR cannot be merged because of the point above, for the record: the wave files can still be manually patched to update the sample rate from 16000 to 22050. Hopefully, this will be useful to someone :smiley: 