### PR TITLE
Fix .2dx9 loop detection

### DIFF
--- a/src/meta/2dx9.c
+++ b/src/meta/2dx9.c
@@ -24,8 +24,8 @@ VGMSTREAM * init_vgmstream_2dx9(STREAMFILE *streamFile) {
     if (read_32bitBE(0x6a,streamFile) != 0x64617461) /* data */
         goto fail;
 
-    /* IIDX 13 has a false flag for looping files. Konami, pls. */
-    loop_flag = (read_16bitLE(0x0e,streamFile) > -1);
+    /* Some data loop from beginning to the end by hardcoded flag so cannot be recognized from sound file */
+    loop_flag = (read_32bitLE(0x14,streamFile) > 0);
     channel_count = read_16bitLE(0x2e,streamFile);
     start_offset = 0x72;
     
@@ -37,7 +37,7 @@ VGMSTREAM * init_vgmstream_2dx9(STREAMFILE *streamFile) {
     vgmstream->sample_rate = read_32bitLE(0x30,streamFile);
     vgmstream->num_samples = read_32bitLE(0x66,streamFile);
     if (loop_flag) {
-        vgmstream->loop_start_sample = 0;
+        vgmstream->loop_start_sample = read_32bitLE(0x14,streamFile) / 2 / channel_count;
         vgmstream->loop_end_sample = vgmstream->num_samples;
     }
 


### PR DESCRIPTION
0xe isn't loop flag but sound category
https://github.com/vgmstream/vgmstream/blob/776c4d8cf53a73336e1314660ae2a04961b288e3/src/meta/2dx9.c#L27-L28