### PR TITLE
support WWise Opus > 8 channels when mapping type is 255

### DIFF
--- a/src/coding/coding.h
+++ b/src/coding/coding.h
@@ -638,7 +638,7 @@ typedef struct {
     /* multichannel-only */
     int coupled_count;
     int stream_count;
-    int channel_mapping[8];
+    int channel_mapping[255];
     /* frame table */
     off_t table_offset;
     int table_count;


### PR DESCRIPTION
Some games use WWise Opus with 8+ channels, when this happens the mapping type gets set to 255 (instead of 1.) As far as I can tell no additional mapping has been made for those channels and the audio engine instead uses linear (0...N) mapping. Adding this to the opus header is still required for ffmpeg to be able to tell libopus how to decode the audio streams.