### PR TITLE
CMake: Add stripping

### DIFF
--- a/cli/CMakeLists.txt
+++ b/cli/CMakeLists.txt
@@ -53,7 +53,9 @@ elseif(VGMSTREAM_VERSION)
 	target_compile_definitions(vgmstream_cli PRIVATE VGMSTREAM_VERSION="${VGMSTREAM_VERSION}")
 endif()
 
-
+if(CMAKE_CXX_COMPILER_ID MATCHES Clang OR CMAKE_CXX_COMPILER_ID MATCHES GNU)
+	set_target_properties(vgmstream_cli PROPERTIES LINK_FLAGS_RELEASE -s)
+endif()
 
 # Install the CLI program
 install(TARGETS vgmstream_cli
@@ -80,9 +82,11 @@ if(NOT WIN32 AND BUILD_V123)
 
 	# Include the version string
 	target_compile_definitions(vgmstream123 PRIVATE VGMSTREAM_VERSION="${VGMSTREAM_VERSION}")
-
 	
-
+	if(CMAKE_CXX_COMPILER_ID MATCHES Clang OR CMAKE_CXX_COMPILER_ID MATCHES GNU)
+		set_target_properties(vgmstream123 PROPERTIES LINK_FLAGS_RELEASE -s)
+	endif()
+	
 	# Install vgmstream123
 	install(TARGETS vgmstream123
 		RUNTIME DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)

--- a/cmake/dependencies/celt.cmake
+++ b/cmake/dependencies/celt.cmake
@@ -96,6 +96,9 @@ if(NOT WIN32 AND USE_CELT)
 			mdct_backward
 			mdct_init
 			mdct_clear
+			clt_mdct_init
+			clt_mdct_clear
+			compute_pulse_cache
 		)
 		
 		foreach(ver 0061 0110)

--- a/cmake/dependencies/ffmpeg.cmake
+++ b/cmake/dependencies/ffmpeg.cmake
@@ -113,6 +113,7 @@ if(USE_FFMPEG)
 				--disable-nvenc
 				--disable-nvdec
 				--disable-vdpau
+				--disable-vulkan
 				--enable-parser=${FFMPEG_CONF_PARSER}
 				--enable-demuxer=${FFMPEG_CONF_DEMUXER}
 				--enable-decoder=${FFMPEG_CONF_DECODER}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -71,4 +71,8 @@ if(NOT EMSCRIPTEN)
 	setup_target(libvgmstream_shared TRUE)
 	
 	target_include_directories(libvgmstream_shared PRIVATE ${libvgmstream_includes})
+	
+	if(CMAKE_CXX_COMPILER_ID MATCHES Clang OR CMAKE_CXX_COMPILER_ID MATCHES GNU)
+		set_target_properties(libvgmstream_shared PROPERTIES LINK_FLAGS_RELEASE -s)
+	endif()
 endif()


### PR DESCRIPTION
- Strips binaries on gcc/clang
  - Affects Linux binary size: from 14.2mb to 6.1mb for static, and from 3.1mb to 2.6mb for shared
  - Does not affect wasm binary size
- Fix building static linux binaries on Ubuntu 22.10 by renaming a few functions in libcelt that clash with system libopus
- Fix building wasm binaries on systems with Vulkan installed