### PR TITLE
musx bcwav

### DIFF
--- a/src/meta/bfwav.c
+++ b/src/meta/bfwav.c
@@ -280,10 +280,11 @@ static VGMSTREAM* init_vgmstream_bxwav(STREAMFILE* sf, bxwav_type_t type) {
                     /* 0x0c: ADPCM offset (from channel info offset), 0xFFFFFFFF otherwise */
                     /* 0x10: padding */
 
-                    if (read_u16(chnf_offset + 0x00, sf) != 0x1F00)
+                    /* 3DS doesn't seem to check this, allow for odd bcwavs from rstmcpp */
+                    if ((read_u16(chnf_offset + 0x00, sf) & 0x1F00) != 0x1F00) /* (ex. 0x1F01) */
                         goto fail;
                     chdt_offset = read_u32(chnf_offset + 0x04, sf) + data_offset + 0x08;
-                    coef_offset = read_u32(chnf_offset + 0x0c, sf) + chnf_offset;
+                    coef_offset = read_u32(chnf_offset + 0x0c, sf) + chnf_offset; /* usually after all channel info but will allow any position */
                     break;
 
                 default:

--- a/src/meta/hca_keys.h
+++ b/src/meta/hca_keys.h
@@ -95,6 +95,8 @@ static const hcakey_info hcakey_list[] = {
         {9001712656335836006},      // 7CEC81F7C3091366
 
         // Ikemen Vampire - Ijin-tachi to Koi no Yuuwaku (iOS/Android)
+        // Ikemen Villains (Android)
+        // Ikemen Prince (Android)
         {45152594117267709},        // 00A06A0B8D0C10FD
 
         // Super Robot Wars X-Omega (iOS/Android)
@@ -1172,6 +1174,9 @@ static const hcakey_info hcakey_list[] = {
 
         // Punishing: Gray Raven (Android)-newer assets
         {62855594017927612},    // 00DF4ED46995B1BC 
+
+        {45152594117267709},    // 00A06A0B8D0C10FD
+        
 };
 
 #endif/*_HCA_KEYS_H_*/

--- a/src/meta/musx.c
+++ b/src/meta/musx.c
@@ -519,7 +519,8 @@ static int parse_musx(STREAMFILE* sf, musx_header* musx) {
                         case 0x44415434: /* "DAT4" */
                         case 0x44415435: /* "DAT5" */
                         case 0x44415438: /* "DAT8" */
-                            /* found on PS3/Wii (but not always?) */
+                        case 0x44415439: /* "DAT9" [Disney Infinity (X360)] */
+                            /* found on PS3/Wii/X360 (but not always?) */
                             musx->stream_size = read_u32le(0x44, sf);
                             musx->channels    = read_u32le(0x48, sf);
                             musx->sample_rate = read_u32le(0x4c, sf);

--- a/src/meta/ubi_ckd.c
+++ b/src/meta/ubi_ckd.c
@@ -56,6 +56,10 @@ VGMSTREAM* init_vgmstream_ubi_ckd(STREAMFILE* sf) {
                 } else if (find_chunk_be(sf, 0x6461744C,first_offset,0, &chunk_offset,&chunk_size)) { /* "datL" */
                     /* mono "datL" or full interleave with a "datR" after the "datL" (no check, pretend it exists) */
                     start_offset = chunk_offset;
+
+                    /* chunks follow RIFF's spec of "odd sizes treated as even" [Rayman Origins (Wii)-420_hud~sfx_endofmap_discoloop.wav.ckd] */
+                    if (chunk_size % 0x02 != 0) 
+                        chunk_size += 0x01;
                     data_size = chunk_size * channels;
                     interleave = (0x4+0x4) + chunk_size; /* don't forget to skip the "datR"+size chunk */
                 } else {


### PR DESCRIPTION
- Fix some DSP .ckd [Rayman Origins (Wii)]
- Fix some MUSX [Disney Infinity (X360)]]
- Relax .bcwav validations for buggy files
- Allow compiling with older FFmpeg versions
