### PR TITLE
PS2_MIC: Changed interleave value range check.

### DIFF
--- a/src/meta/ps2_mic.c
+++ b/src/meta/ps2_mic.c
@@ -20,7 +20,7 @@ VGMSTREAM* init_vgmstream_mic_koei(STREAMFILE* sf) {
     channels        = read_u32le(0x08,sf);
     if (channels > 4) goto fail; /* 1/2/4 are known */
     interleave      = read_u32le(0x0c,sf);
-    if (interleave != 0x10) goto fail;
+    if (interleave != 0x10 && interleave != 0x20) goto fail;
 
     loop_end        = read_s32le(0x10,sf);
     loop_start      = read_s32le(0x14,sf);


### PR DESCRIPTION
Interleave value for most data is 0x10, but Kessen(JP) interleave is 0x20.
Kessen(EN/EU) is 0x10.