### PR TITLE
Fallthrough in LZ4 state machine for a MSVC bug

### DIFF
--- a/src/meta/xnb_lz4mg.h
+++ b/src/meta/xnb_lz4mg.h
@@ -154,7 +154,7 @@ static int lz4mg_decompress(lz4mg_stream_t* strm) {
                 } while (next_len == LZ4MG_VARLEN_CONTINUE);
 
                 ctx->state = SET_MATCH;
-                break;
+                // Falthrough for MSVC
 
             case SET_MATCH:
                 ctx->match_len += LZ4MG_MIN_MATCH_LEN;
@@ -164,7 +164,7 @@ static int lz4mg_decompress(lz4mg_stream_t* strm) {
                     ctx->match_pos = LZ4MG_WINDOW_SIZE + ctx->match_pos;
 
                 ctx->state = COPY_MATCH;
-                break;
+                // Fallthrough for MSVC
 
             case COPY_MATCH:
                  while (ctx->match_len > 0) {


### PR DESCRIPTION
This works around an issue in Visual Studio 2022 "Microsoft (R) C/C++ Optimizing Compiler Version 19.36.32532 for x64" with /O2. It seems to have trouble tying together the states, this perhaps links the data and control flow more simply.