### PR TITLE
RWS: 0x809 File ID revision 

### DIFF
--- a/src/libvgmstream.vcxproj
+++ b/src/libvgmstream.vcxproj
@@ -606,6 +606,7 @@
     <ClCompile Include="meta\rsd.c" />
     <ClCompile Include="meta\rsf.c" />
     <ClCompile Include="meta\rws.c" />
+    <ClCompile Include="meta\rws_mono.c" />
     <ClCompile Include="meta\rwsd.c" />
     <ClCompile Include="meta\rwx.c" />
     <ClCompile Include="meta\rxws.c" />

--- a/src/libvgmstream.vcxproj.filters
+++ b/src/libvgmstream.vcxproj.filters
@@ -1639,6 +1639,9 @@
     <ClCompile Include="meta\rws.c">
       <Filter>meta\Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="meta\rws_mono.c">
+      <Filter>meta\Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="meta\rwsd.c">
       <Filter>meta\Source Files</Filter>
     </ClCompile>

--- a/src/meta/meta.h
+++ b/src/meta/meta.h
@@ -21,8 +21,6 @@ VGMSTREAM * init_vgmstream_agsc(STREAMFILE *streamFile);
 
 VGMSTREAM * init_vgmstream_ast(STREAMFILE *streamFile);
 
-VGMSTREAM* init_vgmstream_awd(STREAMFILE *sf);
-
 VGMSTREAM * init_vgmstream_brstm(STREAMFILE *streamFile);
 
 VGMSTREAM * init_vgmstream_cstr(STREAMFILE *streamFile);
@@ -989,5 +987,9 @@ VGMSTREAM* init_vgmstream_bigrp(STREAMFILE* sf);
 VGMSTREAM* init_vgmstream_sscf_encrypted(STREAMFILE* sf);
 
 VGMSTREAM* init_vgmstream_ego_dic(STREAMFILE* sf);
+
+VGMSTREAM* init_vgmstream_awd(STREAMFILE* sf);
+
+VGMSTREAM* init_vgmstream_rws_mono(STREAMFILE* sf);
 
 #endif /*_META_H*/

--- a/src/meta/rws_mono.c
+++ b/src/meta/rws_mono.c
@@ -17,8 +17,7 @@ VGMSTREAM* init_vgmstream_rws_mono(STREAMFILE* sf) {
     /* checks */
     if (read_u32le(0x00, sf) != 0x809) /* File ID */
         goto fail;
-    if (read_u32le(0x04, sf) + 0x0C != get_streamfile_size(sf))
-        goto fail;
+
     /* Burnout 2: Point of Impact (PS2, GCN, Xbox):
      * Predecessor to the common 0x80D-0x80F tag rws.c (which is also used in B2)
      * with some parts of it later reworked into awd.c seemingly */
@@ -29,7 +28,7 @@ VGMSTREAM* init_vgmstream_rws_mono(STREAMFILE* sf) {
      * 0x00000809: File ID
      * 0x0000080A: File header ID
      * 0x0000080C: File data ID
-     * 
+     *
      * 0x00000802: Stream ID
      * 0x00000803: Stream header ID
      * 0x00000804: Stream data ID
@@ -73,7 +72,7 @@ VGMSTREAM* init_vgmstream_rws_mono(STREAMFILE* sf) {
             if (channels != 1)
                 goto fail;
 
-            /* Assumed misc data offs/size at header_offset + 0x20 to +0x24 
+            /* Assumed misc data offs/size at header_offset + 0x20 to +0x24
              * which is always empty since GCN uses PCM S16BE encoding here */
 
             read_string(stream_name, STREAM_NAME_SIZE, header_offset + 0x7C, sf);

--- a/src/meta/rws_mono.c
+++ b/src/meta/rws_mono.c
@@ -1,0 +1,134 @@
+#include "meta.h"
+#include "../coding/coding.h"
+#include "../util/endianness.h"
+
+
+/* RWS - RenderWare Stream (with the tag 0x809) */
+VGMSTREAM* init_vgmstream_rws_mono(STREAMFILE* sf) {
+    VGMSTREAM* vgmstream = NULL;
+    bool big_endian;
+    char header_name[STREAM_NAME_SIZE], stream_name[STREAM_NAME_SIZE];
+    int bit_depth = 0, channels = 0, idx, interleave, loop_flag, sample_rate = 0, total_subsongs, target_subsong = sf->stream_index;
+    read_u32_t read_u32;
+    off_t chunk_offset, header_offset, stream_offset = 0;
+    size_t chunk_size, header_size, stream_size = 0;
+
+
+    /* checks */
+    if (read_u32le(0x00, sf) != 0x809) /* File ID */
+        goto fail;
+    if (read_u32le(0x04, sf) + 0x0C != get_streamfile_size(sf))
+        goto fail;
+    /* Burnout 2: Point of Impact (PS2, GCN, Xbox):
+     * Predecessor to the common 0x80D-0x80F tag rws.c (which is also used in B2)
+     * with some parts of it later reworked into awd.c seemingly */
+    if (!check_extensions(sf, "rws"))
+        goto fail;
+
+    /* Uses various chunk IDs across the file:
+     * 0x00000809: File ID
+     * 0x0000080A: File header ID
+     * 0x0000080C: File data ID
+     * 
+     * 0x00000802: Stream ID
+     * 0x00000803: Stream header ID
+     * 0x00000804: Stream data ID
+     */
+
+    chunk_offset = 0x0C;
+    if (read_u32le(chunk_offset, sf) != 0x80A) /* File header ID */
+        goto fail;
+    chunk_size = read_u32le(chunk_offset + 0x04, sf); /* usually 0x44 */
+
+    read_string(header_name, STREAM_NAME_SIZE, chunk_offset + 0x40, sf);
+
+    chunk_offset += chunk_size + 0x0C;
+    if (read_u32le(chunk_offset, sf) != 0x80C) /* File data ID */
+        goto fail;
+
+    big_endian = guess_endian32(chunk_offset + 0x0C, sf);
+    read_u32 = big_endian ? read_u32be : read_u32le;
+
+    total_subsongs = read_u32(chunk_offset + 0x0C, sf);
+
+    if (!target_subsong)
+        target_subsong = 1;
+
+    chunk_offset += 0x10;
+    for (idx = 1; idx <= total_subsongs; idx++) {
+        if (read_u32le(chunk_offset, sf) != 0x802) /* Stream ID */
+            goto fail;
+        chunk_size = read_u32le(chunk_offset + 0x04, sf);
+
+        if (idx == target_subsong) {
+            header_offset = chunk_offset + 0x0C;
+            if (read_u32le(header_offset, sf) != 0x803) /* Stream header ID */
+                goto fail;
+            header_size = read_u32le(header_offset + 0x04, sf); /* usually 0xA0 */
+
+            sample_rate = read_u32(header_offset + 0x10, sf);
+            stream_size = read_u32(header_offset + 0x18, sf);
+            bit_depth = read_u8(header_offset + 0x1C, sf);
+            channels = read_u8(header_offset + 0x1D, sf); /* always 1? */
+            if (channels != 1)
+                goto fail;
+
+            /* Assumed misc data offs/size at header_offset + 0x20 to +0x24 
+             * which is always empty since GCN uses PCM S16BE encoding here */
+
+            read_string(stream_name, STREAM_NAME_SIZE, header_offset + 0x7C, sf);
+
+            stream_offset = header_offset + header_size + 0x0C;
+            if (read_u32le(stream_offset, sf) != 0x804) /* Stream data ID */
+                goto fail;
+            if (read_u32le(stream_offset + 0x04, sf) != stream_size)
+                goto fail;
+        }
+        chunk_offset += chunk_size + 0x0C;
+    }
+
+    if (total_subsongs < 1 || target_subsong > total_subsongs)
+        goto fail;
+
+    interleave = 0;
+    loop_flag = 0;
+
+    /* build the VGMSTREAM */
+    vgmstream = allocate_vgmstream(channels, loop_flag);
+    if (!vgmstream)
+        goto fail;
+
+    vgmstream->meta_type = meta_RWS;
+    vgmstream->layout_type = layout_none;
+    vgmstream->sample_rate = sample_rate;
+    vgmstream->stream_size = stream_size;
+    vgmstream->num_streams = total_subsongs;
+    vgmstream->interleave_block_size = interleave;
+
+    /* Likely unreliable, but currently only can be tested with Burnout 2 */
+    switch (bit_depth) {
+        case 4: /* PS-ADPCM, normally DSP-ADPCM would be 4 too (as is in awd.c) but GCN uses PCM */
+            vgmstream->num_samples = ps_bytes_to_samples(stream_size, channels);
+            vgmstream->coding_type = coding_PSX;
+            break;
+
+        case 16: /* PCM Signed 16-bit */
+            vgmstream->num_samples = pcm16_bytes_to_samples(stream_size, channels);
+            vgmstream->coding_type = big_endian ? coding_PCM16BE : coding_PCM16LE;
+            break;
+
+        default:
+            goto fail;
+    }
+
+    snprintf(vgmstream->stream_name, STREAM_NAME_SIZE, "%s/%s", header_name, stream_name);
+
+    if (!vgmstream_open_stream(vgmstream, sf, stream_offset + 0x0C))
+        goto fail;
+
+    return vgmstream;
+
+fail:
+    close_vgmstream(vgmstream);
+    return NULL;
+}

--- a/src/vgmstream.c
+++ b/src/vgmstream.c
@@ -529,6 +529,7 @@ init_vgmstream_t init_vgmstream_functions[] = {
     init_vgmstream_s_p_sth,
     init_vgmstream_utf_ahx,
     init_vgmstream_ego_dic,
+    init_vgmstream_rws_mono,
 
     /* lower priority metas (no clean header identity, somewhat ambiguous, or need extension/companion file to identify) */
     init_vgmstream_scd_pcm,


### PR DESCRIPTION
Currently seems to only be known being used in Burnout 2: Point of Impact (PS2, 2002) as its only RWS format, and also alongside the common 0x80D File ID revision in the GCN & Xbox (2003) ports.

Seems to be Mono only as well like AWD (also 0x809 ID).  Platform/codec detection could probably use some work, but PS2 seemed to always use the usual PS-ADPCM, while GCN and Xbox - seemingly always signed 16-bit PCM.

Also, while this probably doesn't really matter much, wasn't entirely sure on the naming of the function and file.  Originally it was rws_809.c / init_vgmstream_rws_809, eventually I changed it to _mono.  Not really a huge fan of either name, though.