### PR TITLE
Add support for FDK (NX) Opus Header

### DIFF
--- a/doc/FORMATS.md
+++ b/doc/FORMATS.md
@@ -1124,10 +1124,6 @@ different internally (encrypted, different versions, etc) and not always can be 
   - Entergram NXA header [*NXA*]
   - *opus_nxa*: `.nxa`
   - Codecs: Opus
-- **fdk_nxopus.c**
-  - Nihon Falcom FDK Opus Header [*FDK_NXOPUS*]
-  - *opus_fdk*: `.nxopus`
-  - Codecs: Opus
 - **pc_ast.c**
   - Capcom AST (PC) header [*PC_AST*]
   - *pc_ast*: `.ast`
@@ -1795,6 +1791,10 @@ different internally (encrypted, different versions, etc) and not always can be 
 - **snds.c**
   - Sony SNDS header [*SNDS*]
   - Codecs: ATRAC9
+- **nxof.c**
+  - Nihon Falcom FDK Opus Header [*NXOF*]
+  - *nxof*: `.nxopus`
+  - Codecs: Opus
 - **scd_pcm.c**
   - Lunar: Eternal Blue .PCM header [*SCD_PCM*]
   - *scd_pcm*: `.pcm`

--- a/doc/FORMATS.md
+++ b/doc/FORMATS.md
@@ -1124,6 +1124,10 @@ different internally (encrypted, different versions, etc) and not always can be 
   - Entergram NXA header [*NXA*]
   - *opus_nxa*: `.nxa`
   - Codecs: Opus
+- **fdk_nxopus.c**
+  - Nihon Falcom FDK Opus Header [*FDK_NXOPUS*]
+  - *opus_fdk*: `.nxopus`
+  - Codecs: Opus
 - **pc_ast.c**
   - Capcom AST (PC) header [*PC_AST*]
   - *pc_ast*: `.ast`

--- a/src/formats.c
+++ b/src/formats.c
@@ -392,6 +392,7 @@ static const char* extension_list[] = {
     "nwa",
     "nwav",
     "nxa",
+    "nxopus",
 
     //"ogg", //common
     "ogg_",
@@ -1416,6 +1417,7 @@ static const meta_info meta_info_list[] = {
         {meta_SQUEAKSTREAM,         "Torus SqueakStream header"},
         {meta_SQUEAKSAMPLE,         "Torus SqueakSample header"},
         {meta_SNDS,                 "Sony SNDS header"},
+        {meta_FDK_NXOPUS,           "Nihon Falcom FDK Opus Header"},
 };
 
 void get_vgmstream_coding_description(VGMSTREAM* vgmstream, char* out, size_t out_size) {

--- a/src/formats.c
+++ b/src/formats.c
@@ -1417,7 +1417,7 @@ static const meta_info meta_info_list[] = {
         {meta_SQUEAKSTREAM,         "Torus SqueakStream header"},
         {meta_SQUEAKSAMPLE,         "Torus SqueakSample header"},
         {meta_SNDS,                 "Sony SNDS header"},
-        {meta_FDK_NXOPUS,           "Nihon Falcom FDK Opus Header"},
+        {meta_NXOF,                 "Nihon Falcom FDK Opus Header"},
 };
 
 void get_vgmstream_coding_description(VGMSTREAM* vgmstream, char* out, size_t out_size) {

--- a/src/libvgmstream.vcxproj
+++ b/src/libvgmstream.vcxproj
@@ -425,6 +425,7 @@
     <ClCompile Include="meta\ezw.c" />
     <ClCompile Include="meta\fag.c" />
     <ClCompile Include="meta\fda.c" />
+    <ClCompile Include="meta\fdk_nxopus.c" />
     <ClCompile Include="meta\ffdl.c" />
     <ClCompile Include="meta\ffmpeg.c" />
     <ClCompile Include="meta\ffw.c" />

--- a/src/libvgmstream.vcxproj
+++ b/src/libvgmstream.vcxproj
@@ -425,7 +425,6 @@
     <ClCompile Include="meta\ezw.c" />
     <ClCompile Include="meta\fag.c" />
     <ClCompile Include="meta\fda.c" />
-    <ClCompile Include="meta\fdk_nxopus.c" />
     <ClCompile Include="meta\ffdl.c" />
     <ClCompile Include="meta\ffmpeg.c" />
     <ClCompile Include="meta\ffw.c" />
@@ -536,6 +535,7 @@
     <ClCompile Include="meta\nwav.c" />
     <ClCompile Include="meta\nxa.c" />
     <ClCompile Include="meta\nxap.c" />
+    <ClCompile Include="meta\nxof.c" />
     <ClCompile Include="meta\ogg_opus.c" />
     <ClCompile Include="meta\ogg_vorbis.c" />
     <ClCompile Include="meta\ogl.c" />

--- a/src/libvgmstream.vcxproj.filters
+++ b/src/libvgmstream.vcxproj.filters
@@ -1096,9 +1096,6 @@
     <ClCompile Include="meta\fda.c">
       <Filter>meta\Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="meta\fdk_nxopus.c">
-      <Filter>meta\Source Files</Filter>
-    </ClCompile>
     <ClCompile Include="meta\ffdl.c">
       <Filter>meta\Source Files</Filter>
     </ClCompile>
@@ -1427,6 +1424,9 @@
       <Filter>meta\Source Files</Filter>
     </ClCompile>
     <ClCompile Include="meta\nxap.c">
+      <Filter>meta\Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="meta\nxof.c">
       <Filter>meta\Source Files</Filter>
     </ClCompile>
     <ClCompile Include="meta\ogg_opus.c">

--- a/src/libvgmstream.vcxproj.filters
+++ b/src/libvgmstream.vcxproj.filters
@@ -1096,6 +1096,9 @@
     <ClCompile Include="meta\fda.c">
       <Filter>meta\Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="meta\fdk_nxopus.c">
+      <Filter>meta\Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="meta\ffdl.c">
       <Filter>meta\Source Files</Filter>
     </ClCompile>

--- a/src/meta/fdk_nxopus.c
+++ b/src/meta/fdk_nxopus.c
@@ -1,0 +1,52 @@
+#include "meta.h"
+#include "../coding/coding.h"
+
+/* Nihon Falcom FDK NXOpus  [Ys X -NORDICS- (Switch)] */
+VGMSTREAM* init_vgmstream_opus_fdk(STREAMFILE* sf) {
+    VGMSTREAM* vgmstream = NULL;
+    off_t start_offset;
+    int loop_flag, channels, sample_rate;
+    size_t data_size, skip = 0;
+    int32_t num_samples, loop_start, loop_end;
+
+    /* checks */
+    if (!is_id32le(0x00, sf, "nxof"))
+        goto fail;
+    if (!check_extensions(sf,"nxopus"))
+        goto fail;
+
+    channels        = read_u8(0x05, sf);
+    sample_rate     = read_u32le(0x08, sf);
+    start_offset    = read_u32le(0x18, sf);
+    data_size       = read_u32le(0x1C, sf);
+    num_samples     = read_u32le(0x20, sf);
+    loop_start      = read_u32le(0x30, sf);
+    loop_end        = read_u32le(0x34, sf);
+
+    loop_flag = (loop_end > 0);
+
+    vgmstream = allocate_vgmstream(channels, loop_flag);
+    if (!vgmstream) goto fail;
+
+    vgmstream->meta_type = meta_FDK_NXOPUS;
+    vgmstream->sample_rate = sample_rate;
+    vgmstream->num_samples = num_samples;
+    vgmstream->loop_start_sample = loop_start;
+    vgmstream->loop_end_sample = loop_end;
+
+#ifdef VGM_USE_FFMPEG
+    vgmstream->codec_data = init_ffmpeg_switch_opus(sf, start_offset, data_size, vgmstream->channels, skip, vgmstream->sample_rate);
+    if (!vgmstream->codec_data) goto fail;
+    vgmstream->coding_type = coding_FFmpeg;
+    vgmstream->layout_type = layout_none;
+#else
+    goto fail;
+#endif
+
+    if (!vgmstream_open_stream(vgmstream, sf, start_offset))
+        goto fail;
+    return vgmstream;
+fail:
+    close_vgmstream(vgmstream);
+    return NULL;
+}

--- a/src/meta/meta.h
+++ b/src/meta/meta.h
@@ -625,7 +625,6 @@ VGMSTREAM* init_vgmstream_opus_opusnx(STREAMFILE* sf);
 VGMSTREAM* init_vgmstream_opus_nsopus(STREAMFILE* sf);
 VGMSTREAM* init_vgmstream_opus_sqex(STREAMFILE* sf);
 VGMSTREAM* init_vgmstream_opus_rsnd(STREAMFILE* sf);
-VGMSTREAM* init_vgmstream_opus_fdk(STREAMFILE* sf);
 
 VGMSTREAM * init_vgmstream_pc_ast(STREAMFILE * streamFile);
 
@@ -982,5 +981,7 @@ VGMSTREAM* init_vgmstream_squeakstream(STREAMFILE* sf);
 VGMSTREAM* init_vgmstream_squeaksample(STREAMFILE* sf);
 
 VGMSTREAM* init_vgmstream_snds(STREAMFILE* sf);
+
+VGMSTREAM* init_vgmstream_nxof(STREAMFILE* sf);
 
 #endif /*_META_H*/

--- a/src/meta/meta.h
+++ b/src/meta/meta.h
@@ -625,6 +625,7 @@ VGMSTREAM* init_vgmstream_opus_opusnx(STREAMFILE* sf);
 VGMSTREAM* init_vgmstream_opus_nsopus(STREAMFILE* sf);
 VGMSTREAM* init_vgmstream_opus_sqex(STREAMFILE* sf);
 VGMSTREAM* init_vgmstream_opus_rsnd(STREAMFILE* sf);
+VGMSTREAM* init_vgmstream_opus_fdk(STREAMFILE* sf);
 
 VGMSTREAM * init_vgmstream_pc_ast(STREAMFILE * streamFile);
 

--- a/src/meta/nxof.c
+++ b/src/meta/nxof.c
@@ -2,7 +2,7 @@
 #include "../coding/coding.h"
 
 /* Nihon Falcom FDK NXOpus  [Ys X -NORDICS- (Switch)] */
-VGMSTREAM* init_vgmstream_opus_fdk(STREAMFILE* sf) {
+VGMSTREAM* init_vgmstream_nxof(STREAMFILE* sf) {
     VGMSTREAM* vgmstream = NULL;
     off_t start_offset;
     int loop_flag, channels, sample_rate;
@@ -28,13 +28,14 @@ VGMSTREAM* init_vgmstream_opus_fdk(STREAMFILE* sf) {
     vgmstream = allocate_vgmstream(channels, loop_flag);
     if (!vgmstream) goto fail;
 
-    vgmstream->meta_type = meta_FDK_NXOPUS;
+    vgmstream->meta_type = meta_NXOF;
     vgmstream->sample_rate = sample_rate;
     vgmstream->num_samples = num_samples;
     vgmstream->loop_start_sample = loop_start;
     vgmstream->loop_end_sample = loop_end;
 
 #ifdef VGM_USE_FFMPEG
+    skip = switch_opus_get_encoder_delay(start_offset, sf);
     vgmstream->codec_data = init_ffmpeg_switch_opus(sf, start_offset, data_size, vgmstream->channels, skip, vgmstream->sample_rate);
     if (!vgmstream->codec_data) goto fail;
     vgmstream->coding_type = coding_FFmpeg;

--- a/src/vgmstream.c
+++ b/src/vgmstream.c
@@ -309,7 +309,6 @@ init_vgmstream_t init_vgmstream_functions[] = {
     init_vgmstream_opus_nus3,
     init_vgmstream_opus_sps_n1,
     init_vgmstream_opus_nxa,
-    init_vgmstream_opus_fdk,
     init_vgmstream_pc_ast,
     init_vgmstream_naac,
     init_vgmstream_ubi_sb,
@@ -522,6 +521,7 @@ init_vgmstream_t init_vgmstream_functions[] = {
     init_vgmstream_squeaksample,
     init_vgmstream_snds,
     init_vgmstream_adm2,
+    init_vgmstream_nxof,
 
     /* lower priority metas (no clean header identity, somewhat ambiguous, or need extension/companion file to identify) */
     init_vgmstream_scd_pcm,

--- a/src/vgmstream.c
+++ b/src/vgmstream.c
@@ -309,6 +309,7 @@ init_vgmstream_t init_vgmstream_functions[] = {
     init_vgmstream_opus_nus3,
     init_vgmstream_opus_sps_n1,
     init_vgmstream_opus_nxa,
+    init_vgmstream_opus_fdk,
     init_vgmstream_pc_ast,
     init_vgmstream_naac,
     init_vgmstream_ubi_sb,

--- a/src/vgmstream_types.h
+++ b/src/vgmstream_types.h
@@ -702,6 +702,7 @@ typedef enum {
     meta_SQUEAKSTREAM,
     meta_SQUEAKSAMPLE,
     meta_SNDS,
+    meta_FDK_NXOPUS,
 
 } meta_t;
 

--- a/src/vgmstream_types.h
+++ b/src/vgmstream_types.h
@@ -702,7 +702,7 @@ typedef enum {
     meta_SQUEAKSTREAM,
     meta_SQUEAKSAMPLE,
     meta_SNDS,
-    meta_FDK_NXOPUS,
+    meta_NXOF,
 
 } meta_t;
 


### PR DESCRIPTION
This adds support for the opus header of the Switch opus files from Nihon Falcom's FDK engine (first seen on the Switch version of Ys X -NORDICS-).

The header still has a huge chunk of unknown information but all the info for looping and decoding is read properly, and the data itself is the same format as other Switch games, so it's just a matter of decoding the header properly.


