### PR TITLE
STHD: Fix special value check [Dinosaur Hunting (Xbox)]

### DIFF
--- a/src/meta/sthd.c
+++ b/src/meta/sthd.c
@@ -16,7 +16,6 @@ VGMSTREAM * init_vgmstream_sthd(STREAMFILE *sf) {
         goto fail;
     /* first block has special values */
     if (read_u16le(0x04,sf) != 0x0800 ||
-        read_u32le(0x0c,sf) != 0x0001 ||
         read_u32le(0x14,sf) != 0x0000)
         goto fail;
 


### PR DESCRIPTION
The value of offset 0x0C is checked to be 0x0001, but the data for this game is 0x0000. Since this value is not referenced in decoding, it is not a problem, so it is unchecked.