### PR TITLE
RSTM: Fix stream sizes and looping

### DIFF
--- a/src/meta/rstm_rockstar.c
+++ b/src/meta/rstm_rockstar.c
@@ -4,8 +4,9 @@
 /* RSTM - from Rockstar games [Midnight Club 3, Bully - Canis Canim Edit (PS2)] */
 VGMSTREAM* init_vgmstream_rstm_rockstar(STREAMFILE* sf) {
     VGMSTREAM* vgmstream = NULL;
-    uint32_t start_offset;
-    int channels, loop_flag;
+    off_t stream_offset, loop_start, loop_end;
+    size_t stream_size;
+    int sample_rate, channels, loop_flag;
 
 
     /* checks */
@@ -14,30 +15,38 @@ VGMSTREAM* init_vgmstream_rstm_rockstar(STREAMFILE* sf) {
 
     /* .rsm: in filelist
      * .rstm: header id */
-    if (!check_extensions(sf,"rsm,rstm"))
+    if (!check_extensions(sf, "rsm,rstm"))
         return NULL;
 
-    loop_flag = (read_s32le(0x24,sf) > 0);
-    channels = read_s32le(0x0C,sf);
-    start_offset = 0x800;
+    sample_rate = read_s32le(0x08, sf);
+    channels    = read_s32le(0x0C, sf);
+    /* 0x10-0x18 - empty padding(?) */
+    stream_size = read_s32le(0x18, sf);
+    loop_start  = read_s32le(0x1C, sf);
+    loop_end    = read_s32le(0x20, sf);
+    /* other loop start/ends after here? (uncommon) */
+    stream_offset = 0x800;
+
+    //loop_flag = (read_s32le(0x24,sf) > 0);
+    loop_flag = loop_end != stream_size;
 
 	/* build the VGMSTREAM */
-    vgmstream = allocate_vgmstream(channels,loop_flag);
+    vgmstream = allocate_vgmstream(channels, loop_flag);
     if (!vgmstream) goto fail;
 
     vgmstream->meta_type = meta_RSTM_ROCKSTAR;
 
-    vgmstream->sample_rate = read_s32le(0x08,sf);
-    vgmstream->num_samples = ps_bytes_to_samples(read_u32le(0x20,sf),channels);
-    vgmstream->loop_start_sample = ps_bytes_to_samples(read_u32le(0x24,sf),channels);
-    vgmstream->loop_end_sample = vgmstream->num_samples;
+    vgmstream->sample_rate = sample_rate;
+    vgmstream->num_samples = ps_bytes_to_samples(stream_size, channels);
+    vgmstream->loop_start_sample = ps_bytes_to_samples(loop_start, channels);
+    vgmstream->loop_end_sample = ps_bytes_to_samples(loop_end, channels);
 
     vgmstream->coding_type = coding_PSX;
     vgmstream->layout_type = layout_interleave;
     vgmstream->interleave_block_size = 0x10;
 
     /* open the file for reading */
-    if ( !vgmstream_open_stream(vgmstream, sf, start_offset) )
+    if ( !vgmstream_open_stream(vgmstream, sf, stream_offset) )
         goto fail;
     return vgmstream;
 


### PR DESCRIPTION
Apparently this has been broken ever since it was first added back in 2008.  Affects Midnight Club 3 to a much lesser degree with it just having the Win/Lose tracks affected, unlike Bully.  Prior to this, it was using the loop end sample as the total stream size, so many songs were just cut off short.

Some rare few songs have additional loop start/end offsets after 0x24, but I'm not quite sure what to do with those.  But as it is with this PR, the music in Bully should actually play entirely and loop properly.

I've currently made the loop flag done by checking if the loop end offset is equal to the total stream size, ~~however in theory it could just be set to just 1, and it will still terminate on its own because that's where the PS-ADPCM end marker would already be present.~~

https://github.com/vgmstream/vgmstream/assets/55930127/2e495d16-ff97-4494-a8ce-425553b08609

