### PR TITLE
EA BNK: .CAT extension (FIFA 2000)

### DIFF
--- a/src/formats.c
+++ b/src/formats.c
@@ -131,6 +131,7 @@ static const char* extension_list[] = {
 
     "cads",
     "caf",
+    "cat",
     "cbd2",
     "cd",
     "cfn", //fake extension for CAF (renamed, to be removed?)

--- a/src/meta/ea_schl.c
+++ b/src/meta/ea_schl.c
@@ -297,8 +297,9 @@ VGMSTREAM* init_vgmstream_ea_bnk(STREAMFILE* sf) {
      * .sdt: Harry Potter games, Burnout games (PSP)
      * .hdt/ldt: Burnout games (PSP)
      * .abk: GoldenEye - Rogue Agent
-     * .ast: FIFA 2004 (inside .big) */
-    if (!check_extensions(sf,"bnk,sdt,hdt,ldt,abk,ast"))
+     * .ast: FIFA 2004 (inside .big)
+     * .cat: FIFA 2000 (PC, chant.cat) */
+    if (!check_extensions(sf,"bnk,sdt,hdt,ldt,abk,ast,cat"))
         goto fail;
 
     if (target_stream == 0) target_stream = 1;


### PR DESCRIPTION
Various PC releases of FIFA 2000 have a `chant.cat` file using EA BNKl.