### PR TITLE
RWS 0x80D: DSP-ADPCM initial sample history data

### DIFF
--- a/src/meta/awd.c
+++ b/src/meta/awd.c
@@ -6,7 +6,7 @@
 /* AWD - Audio Wave Dictionary (RenderWare) */
 VGMSTREAM* init_vgmstream_awd(STREAMFILE* sf) {
     VGMSTREAM* vgmstream = NULL;
-    char header_name[STREAM_NAME_SIZE], stream_name[STREAM_NAME_SIZE];
+    char file_name[STREAM_NAME_SIZE], header_name[STREAM_NAME_SIZE], stream_name[STREAM_NAME_SIZE];
     int /*bit_depth = 0,*/ channels = 0, sample_rate = 0, stream_codec = -1, total_subsongs = 0, target_subsong = sf->stream_index;
     int interleave, loop_flag;
     off_t data_offset, header_name_offset, misc_data_offset, linked_list_offset, wavedict_offset;
@@ -115,7 +115,8 @@ VGMSTREAM* init_vgmstream_awd(STREAMFILE* sf) {
     vgmstream->num_streams = total_subsongs;
     vgmstream->interleave_block_size = interleave;
 
-    if (header_name_offset)
+    get_streamfile_basename(sf, file_name, STREAM_NAME_SIZE);
+    if (header_name_offset && strcmp(file_name, header_name))
         snprintf(vgmstream->stream_name, STREAM_NAME_SIZE, "%s/%s", header_name, stream_name);
     else
         snprintf(vgmstream->stream_name, STREAM_NAME_SIZE, "%s", stream_name);

--- a/src/meta/rws_809.c
+++ b/src/meta/rws_809.c
@@ -7,7 +7,7 @@
 VGMSTREAM* init_vgmstream_rws_809(STREAMFILE* sf) {
     VGMSTREAM* vgmstream = NULL;
     bool big_endian;
-    char header_name[STREAM_NAME_SIZE], stream_name[STREAM_NAME_SIZE];
+    char file_name[STREAM_NAME_SIZE], header_name[STREAM_NAME_SIZE], stream_name[STREAM_NAME_SIZE];
     int channels = 0, idx, interleave, loop_flag, sample_rate = 0, total_subsongs, target_subsong = sf->stream_index;
     read_u32_t read_u32;
     off_t chunk_offset, header_offset, misc_data_offset = 0, stream_name_offset, stream_offset = 0;
@@ -136,7 +136,11 @@ VGMSTREAM* init_vgmstream_rws_809(STREAMFILE* sf) {
             goto fail;
     }
 
-    snprintf(vgmstream->stream_name, STREAM_NAME_SIZE, "%s/%s", header_name, stream_name);
+    get_streamfile_basename(sf, file_name, STREAM_NAME_SIZE);
+    if (strcmp(file_name, header_name) == 0)
+        snprintf(vgmstream->stream_name, STREAM_NAME_SIZE, "%s", stream_name);
+    else
+        snprintf(vgmstream->stream_name, STREAM_NAME_SIZE, "%s/%s", header_name, stream_name);
 
     if (!vgmstream_open_stream(vgmstream, sf, stream_offset + 0x0C))
         goto fail;


### PR DESCRIPTION
The field is empty in most of the GCN games I have on hand that use RWS 0x80D.  Call of Duty: Finest Hour is one such game that has non-zero data for initial sample history.

Also added a check for AWD and RWS 0x809 if the bank name is identical to the file name, and skip it from being displayed.  Consistent behavior with RWS 0x80D.