### PR TITLE
ue4riff acx misc

### DIFF
--- a/doc/TXTH.md
+++ b/doc/TXTH.md
@@ -92,8 +92,6 @@ as explained below, but often will use default values. Accepted codec strings:
 #   * Interleave is multiple of 0x1 (default)
 # - PCM8_U         PCM 8-bit unsigned
 #   * Variation with modified encoding
-# - PCM8_U_int     PCM 8-bit unsigned (interleave block)
-#   * Variation with modified encoding
 # - PCM8_SB        PCM 8-bit with sign bit
 #   * Variation with modified encoding
 #   * For few rare games [Sonic CD (SCD)]

--- a/fb2k/foo_vgmstream.cpp
+++ b/fb2k/foo_vgmstream.cpp
@@ -168,6 +168,13 @@ void input_vgmstream::get_info(t_uint32 p_subsong, file_info & p_info, abort_cal
     if (get_description_tag(temp,description,"stream count: ")) p_info.meta_set("stream_count",temp);
     if (get_description_tag(temp,description,"stream index: ")) p_info.meta_set("stream_index",temp);
     if (get_description_tag(temp,description,"stream name: ")) p_info.meta_set("stream_name",temp);
+    if (loop_end) {
+        p_info.meta_set("loop_start", pfc::format_int(loop_start));
+        p_info.meta_set("loop_end", pfc::format_int(loop_end));
+        // has extra text info
+        //if (get_description_tag(temp,description,"loop start: ")) p_info.meta_set("loop_start",temp);
+        //if (get_description_tag(temp,description,"loop end: ")) p_info.meta_set("loop_end",temp); 
+    }
 
     /* get external file tags */
     //todo optimize and don't parse tags again for this session (not sure how), seems foobar

--- a/src/base/seek.c
+++ b/src/base/seek.c
@@ -34,10 +34,10 @@ static void seek_force_decode(VGMSTREAM* vgmstream, int samples) {
 }
 
 
-static void seek_layout_standard(VGMSTREAM* vgmstream, int32_t seek_sample) {
+static void seek_body(VGMSTREAM* vgmstream, int32_t seek_sample) {
     //;VGM_LOG("SEEK: body / seekr=%i, curr=%i\n", seek_sample, vgmstream->current_sample);
 
-    int32_t decode_samples = 0;
+    int32_t decode_samples;
 
     play_state_t* ps = &vgmstream->pstate;
     bool is_looped = vgmstream->loop_flag || vgmstream->loop_target > 0; /* loop target disabled loop flag during decode */
@@ -45,12 +45,8 @@ static void seek_layout_standard(VGMSTREAM* vgmstream, int32_t seek_sample) {
     int play_forever = vgmstream->config.play_forever;
 
     /* seek=10 would be seekr=10-5+3=8 inside decoder */
-    int32_t seek_relative = seek_sample;
-    if (is_config)
-        seek_relative = seek_relative - ps->pad_begin_duration + ps->trim_begin_duration;
+    int32_t seek_relative = seek_sample - ps->pad_begin_duration + ps->trim_begin_duration;
 
-
-    //;VGM_LOG("SEEK: body / seekr=%i, curr=%i\n", seek_relative, vgmstream->current_sample);
 
     /* seek can be in some part of the body, depending on looping/decoder's current position/etc */
     if (!is_looped && seek_relative < vgmstream->current_sample) {
@@ -92,9 +88,12 @@ static void seek_layout_standard(VGMSTREAM* vgmstream, int32_t seek_sample) {
     }
     else {
         /* looped seek after loop start: can be clamped between loop parts (relative to decoder's current_sample) to minimize decoding */
-        int32_t loop_body = (vgmstream->loop_end_sample - vgmstream->loop_start_sample);
-        int32_t loop_seek = (seek_relative - vgmstream->loop_start_sample) % loop_body;
-        int     loop_count = loop_seek / loop_body;
+        //int32_t loop_outr = (vgmstream->num_samples - vgmstream->loop_end_sample);
+        int32_t loop_part = (vgmstream->loop_end_sample - vgmstream->loop_start_sample); /* samples of 1 looped part */
+        int32_t loop_seek = (seek_relative - vgmstream->loop_start_sample); /* samples within loop region */
+        int     loop_count = loop_seek / loop_part; /* not accurate when loop_target is set */
+        loop_seek = loop_seek % loop_part; /* clamp within single loop after calcs */
+
 
         /* current must have reached loop start at some point, otherwise force it (NOTE: some layouts don't actually set hit_loop) */
         if (!vgmstream->hit_loop) {
@@ -104,40 +103,39 @@ static void seek_layout_standard(VGMSTREAM* vgmstream, int32_t seek_sample) {
             }
 
             int32_t skip_samples = (vgmstream->loop_start_sample - vgmstream->current_sample);
-            //;VGM_LOG("SEEK: must loop / skip=%i, curr=%i\n", skip_samples, vgmstream->current_sample);
+            //;VGM_LOG("SEEK: force loop region / skip=%i, curr=%i\n", skip_samples, vgmstream->current_sample);
 
             seek_force_decode(vgmstream, skip_samples);
         }
 
-        /* current must be in loop area (may happen at start) */
+        /* current must be in loop area (may happen at start since it's smaller than loop_end) */
         if (vgmstream->current_sample < vgmstream->loop_start_sample
                 || vgmstream->current_sample < vgmstream->loop_end_sample) {
-            ;VGM_LOG("SEEK: outside loop area / curr=%i, ls=%i, le=%i\n", vgmstream->current_sample, vgmstream->current_sample, vgmstream->loop_end_sample);
+            //;VGM_LOG("SEEK: outside loop region / curr=%i, ls=%i, le=%i\n", vgmstream->current_sample, vgmstream->current_sample, vgmstream->loop_end_sample);
             seek_force_loop_end(vgmstream, 0);
         }
 
-        int32_t loop_curr = vgmstream->current_sample - vgmstream->loop_start_sample;
+        //;VGM_LOG("SEEK: in loop region / seekr=%i, seekl=%i, loops=%i, dec_curr=%i\n", seek_relative, loop_seek, loop_count, loop_curr);
 
-        //;VGM_LOG("SEEK: in loop / seekr=%i, seekl=%i, loops=%i, cur=%i, dec=%i\n", seek_relative, loop_seek, loop_count, loop_curr, decode_samples);
+        /* when "ignore fade" is set and seek falls into the outro part (loop count if bigged than expected), adjust seek
+         * to do a whole part + outro samples (should probably calculate correct loop_count before but...) */
+        if (vgmstream->loop_target && loop_count >= vgmstream->loop_target) {
+            loop_seek = loop_part + (seek_relative - vgmstream->loop_start_sample) - vgmstream->loop_target * loop_part;
+            loop_count = vgmstream->loop_target - 1;  /* so seek_force_loop_end detection kicks in and adds +1 */
 
-        /* when "ignore fade" is used and seek falls into non-fade part, this needs to seek right before it
-            so when calling seek_force_loop_end detection kicks in, and non-fade then decodes normally */
-        if (vgmstream->loop_target && vgmstream->loop_target == loop_count) {
-            loop_seek = loop_body;
-            //decode_samples += loop_seek;
-
-            //VGM_LOG("outside!: %i\n", loop_body);
+            //;VGM_LOG("SEEK: outro outside / seek=%i, count=%i\n", decode_samples, loop_seek, loop_count);
         }
-
+        
+        int32_t loop_curr = vgmstream->current_sample - vgmstream->loop_start_sample;
         if (loop_seek < loop_curr) {
-            decode_samples += loop_seek;
+            decode_samples = loop_seek;
             seek_force_loop_end(vgmstream, loop_count);
 
             //;VGM_LOG("SEEK: loop reset / dec=%i, loop=%i\n", decode_samples, loop_count);
         }
         else {
-            decode_samples += (loop_seek - loop_curr);
-            //vgmstream->loop_count = loop_count - 1; //todo
+            decode_samples = (loop_seek - loop_curr);
+            vgmstream->loop_count = loop_count;
 
             //;VGM_LOG("SEEK: loop forward / dec=%i, loop=%i\n", decode_samples, loop_count);
         }
@@ -147,18 +145,13 @@ static void seek_layout_standard(VGMSTREAM* vgmstream, int32_t seek_sample) {
                 && seek_sample >= ps->pad_begin_duration + ps->body_duration
                 && seek_sample < ps->pad_begin_duration + ps->body_duration + ps->fade_duration) {
             ps->fade_left = ps->pad_begin_duration + ps->body_duration + ps->fade_duration - seek_sample;
+
             //;VGM_LOG("SEEK: in fade / fade=%i, %i\n", ps->fade_left, ps->fade_duration);
         }
     }
 
-    /* done at the end in case of reset */
-    if (is_config) {
-        ps->pad_begin_left = 0;
-        ps->trim_begin_left = 0;
-    }
-
     seek_force_decode(vgmstream, decode_samples);
-    ;VGM_LOG("SEEK: force=%i, current=%i\n", decode_samples, vgmstream->current_sample);
+    //;VGM_LOG("SEEK: decode=%i, current=%i\n", decode_samples, vgmstream->current_sample);
 }
 
 
@@ -220,7 +213,7 @@ void seek_vgmstream(VGMSTREAM* vgmstream, int32_t seek_sample) {
         reset_vgmstream(vgmstream);
         ps->pad_begin_left = ps->pad_begin_duration - seek_sample;
 
-        //;VGM_LOG("SEEK: pad start / dec=%i\n", decode_samples);
+        //;VGM_LOG("SEEK: pad start / dec=%i\n", 0);
     }
 
     /* pad end and beyond: ignored */
@@ -230,16 +223,15 @@ void seek_vgmstream(VGMSTREAM* vgmstream, int32_t seek_sample) {
         if (!is_looped)
             vgmstream->current_sample = vgmstream->num_samples + 1;
 
-        //;VGM_LOG("SEEK: end silence / dec=%i\n", decode_samples);
+        //;VGM_LOG("SEEK: end silence / dec=%i\n", 0);
         /* looping decoder state isn't changed (seek backwards could use current sample) */
     }
 
     /* body: seek relative to decoder's current sample */
     else {
 #if 0 
-        //TODO issues: handles seek into loops number N  correctly, and into fade region
-        //- handle looping within
-        //- handle 
+        //TODO calculate samples into loop number N, and into fade region (segmented layout can only seek to loop start)
+
         /* optimize as layouts can seek faster internally */
         if (vgmstream->layout_type == layout_segmented) {
             seek_layout_segmented(vgmstream, seek_sample);
@@ -249,10 +241,15 @@ void seek_vgmstream(VGMSTREAM* vgmstream, int32_t seek_sample) {
         }
         else
 #endif
-        seek_layout_standard(vgmstream, seek_sample);
+        seek_body(vgmstream, seek_sample);
 
+        /* done at the end in case of reset (that restores these values) */
+        if (is_config) {
+            ps->pad_begin_left = 0;
+            ps->trim_begin_left = 0;
+        }
     }
 
-
-    vgmstream->pstate.play_position = seek_sample;
+    if (is_config)
+        vgmstream->pstate.play_position = seek_sample;
 }

--- a/src/meta/acb.c
+++ b/src/meta/acb.c
@@ -1248,7 +1248,6 @@ void load_acb_wave_info(STREAMFILE* sf, VGMSTREAM* vgmstream, int waveid, int po
 
     /* done */
 fail:
-VGM_LOG("close %x\n", (uint32_t)acb.CueNames);
     utf_close(acb.Header);
     utf_close(acb.CueNames);
 

--- a/src/meta/acx.c
+++ b/src/meta/acx.c
@@ -5,31 +5,49 @@
 VGMSTREAM* init_vgmstream_acx(STREAMFILE* sf) {
     VGMSTREAM* vgmstream = NULL;
     STREAMFILE* temp_sf = NULL;
-    off_t subfile_offset;
-    size_t subfile_size;
+    uint32_t subfile_offset, subfile_size, subfile_id;
     int total_subsongs, target_subsong = sf->stream_index;
 
 
     /* checks */
-    if (!check_extensions(sf,"acx"))
-        goto fail;
     if (read_u32be(0x00,sf) != 0x00000000)
-        goto fail;
+        return NULL;
 
     /* simple container for sfx and rarely music [Burning Rangers (SAT)],
      * mainly used until .csb was introduced */
-
     total_subsongs = read_u32be(0x04,sf);
+    if (total_subsongs > 256 || total_subsongs == 0) /* arbitrary max */
+        return NULL;
+
+    if (!check_extensions(sf,"acx"))
+        return NULL;
+
+    init_vgmstream_t init_vgmstream = NULL;
+    const char* fake_ext = NULL;
+
     if (target_subsong == 0) target_subsong = 1;
     if (target_subsong < 0 || target_subsong > total_subsongs || total_subsongs < 1) goto fail;
 
     subfile_offset = read_u32be(0x08 + (target_subsong-1) * 0x08 + 0x00,sf);
     subfile_size   = read_u32be(0x08 + (target_subsong-1) * 0x08 + 0x04,sf);
 
-    temp_sf = setup_subfile_streamfile(sf, subfile_offset, subfile_size, "adx");
+    subfile_id = read_u32be(subfile_offset,sf);
+    if (subfile_id == get_id32be("OggS")) { /* 12Riven (PC) */
+        init_vgmstream = init_vgmstream_ogg_vorbis;
+        fake_ext = "ogg";
+    }
+    else if ((subfile_id & 0xFFFF0000) == 0x80000000) {
+        init_vgmstream = init_vgmstream_adx;
+        fake_ext = "adx";
+    }
+    else {
+        goto fail;
+    }
+
+    temp_sf = setup_subfile_streamfile(sf, subfile_offset, subfile_size, fake_ext);
     if (!temp_sf) goto fail;
 
-    vgmstream = init_vgmstream_adx(temp_sf);
+    vgmstream = init_vgmstream(temp_sf);
     if (!vgmstream) goto fail;
 
     vgmstream->num_streams = total_subsongs;

--- a/src/meta/riff.c
+++ b/src/meta/riff.c
@@ -324,7 +324,7 @@ fail:
     return 0;
 }
 
-static int is_ue4_msadpcm(STREAMFILE* sf, riff_fmt_chunk* fmt, int fact_sample_count, off_t start_offset);
+static bool is_ue4_msadpcm(STREAMFILE* sf, riff_fmt_chunk* fmt, int fact_sample_count, off_t start_offset, uint32_t data_size);
 static size_t get_ue4_msadpcm_interleave(STREAMFILE* sf, riff_fmt_chunk* fmt, off_t start, size_t size);
 
 
@@ -865,7 +865,7 @@ VGMSTREAM* init_vgmstream_riff(STREAMFILE* sf) {
     }
 
     /* UE4 uses interleaved mono MSADPCM, try to autodetect without breaking normal MSADPCM */
-    if (fmt.coding_type == coding_MSADPCM && is_ue4_msadpcm(sf, &fmt, fact_sample_count, start_offset)) {
+    if (fmt.coding_type == coding_MSADPCM && is_ue4_msadpcm(sf, &fmt, fact_sample_count, start_offset, data_size)) {
         vgmstream->coding_type = coding_MSADPCM_int;
         vgmstream->codec_config = 1; /* mark as UE4 MSADPCM */
         vgmstream->frame_size = fmt.block_size;
@@ -873,6 +873,8 @@ VGMSTREAM* init_vgmstream_riff(STREAMFILE* sf) {
         vgmstream->interleave_block_size = get_ue4_msadpcm_interleave(sf, &fmt, start_offset, data_size);
         if (fmt.size == 0x36)
             vgmstream->num_samples = read_s32le(fmt.offset+0x08+0x32, sf);
+        else if (fmt.size == 0x32)
+            vgmstream->num_samples = msadpcm_bytes_to_samples(data_size / fmt.channels, fmt.block_size, 1);
     }
 
     /* Dynasty Warriors 5 (Xbox) 6ch interleaves stereo frames, probably not official */
@@ -937,53 +939,79 @@ fail:
     return NULL;
 }
 
-/* UE4 MSADPCM is quite normal but has a few minor quirks we can use to detect it */
-static int is_ue4_msadpcm(STREAMFILE* sf, riff_fmt_chunk* fmt, int fact_sample_count, off_t start) {
+static bool is_ue4_msadpcm_blocks(STREAMFILE* sf, riff_fmt_chunk* fmt, uint32_t offset, uint32_t data_size) {
+    uint32_t max_offset = 10 * fmt->block_size; /* try N blocks */
+    if (max_offset > offset + data_size)
+        max_offset = offset + data_size;
 
-    /* multichannel ok */
-    if (fmt->channels < 2)
-        goto fail;
+    /* UE4 encoder doesn't calculate optimal coefs and uses certain values every frame.
+     * Implicitly this should reject stereo frames (not used in UE4), that have scale/coefs in different positions. */
+    while (offset < max_offset) {
+        uint8_t coefs = read_u8(offset+0x00, sf);
+        uint16_t scale = read_u16le(offset+0x01, sf);
 
-    /* UE4 class is "ADPCM", assume it's the extension too */
-    if (!check_extensions(sf, "adpcm"))
-        goto fail;
+        /* mono frames should only fill the lower bits (4b index) */
+        if (coefs > 0x07)
+            return false;
 
-    /* UE4 encoder doesn't add "fact" */
-    if (fact_sample_count != 0)
-        goto fail;
-
-    /* fixed block size */
-    if (fmt->block_size != 0x200)
-        goto fail;
-
-    /* later UE4 versions use 0x36 */
-    if (fmt->size != 0x32 && fmt->size != 0x36)
-        goto fail;
-
-    /* size 0x32 in older UE4 matches standard MSADPCM, so add extra detection */
-    if (fmt->size == 0x32) {
-        off_t offset = start;
-        off_t max_offset = 5 * fmt->block_size; /* try N blocks */
-        if (max_offset > get_streamfile_size(sf))
-            max_offset = get_streamfile_size(sf);
-
-        /* their encoder doesn't calculate optimal coefs and uses fixed values every frame
-         * (could do it for fmt size 0x36 too but maybe they'll fix it in the future) */
-        while (offset <= max_offset) {
-            if (read_u8(offset+0x00, sf) != 0 || read_u16le(offset+0x01, sf) != 0x00E6)
-                goto fail;
-            offset += fmt->block_size;
+        /* size 0x36 always uses scale 0x00E6 and coefs 0x00 while size 0x32 usually does, except for early
+         * games where it may use more standard values [2013: Infected Wars (iPhone)] */
+        if (fmt->block_size == 0x200) {
+            if (scale == 0x00E6 && coefs != 0x00)
+                return false;
         }
+        else {
+            if (scale > 0x4000) { /* observed max (high scales exists) */
+                VGM_LOG("RIFF: unexpected UE4 MSADPCM scale=%x\n", scale);
+                return false;
+            }
+        }
+
+        offset += fmt->block_size;
     }
 
-    return 1;
-fail:
-    return 0;
+    return true;
+}
+
+/* UE4 MSADPCM has a few minor quirks we can use to detect it */
+static bool is_ue4_msadpcm(STREAMFILE* sf, riff_fmt_chunk* fmt, int fact_sample_count, off_t start, uint32_t data_size) {
+
+    /* UE4 allows >=2ch (sample rate may be anything), while mono files are just regular MSADPCM */
+    if (fmt->channels < 2)
+        return false;
+
+    /* UE4 encoder doesn't add "fact" while regular encoders usually do (but not always) */
+    if (fact_sample_count != 0)
+        return false;
+
+    /* later UE4 versions use fmt size 0x36 (unlike standard MSADPCM's 0x32), and only certain block sizes */
+    if (fmt->size == 0x36) {
+        if (!(fmt->block_size == 0x200))
+            return false;
+    }
+    else if (fmt->size == 0x32) {
+        /* other than 0x200 is rarely used [2013: Infected Wars (iPhone)] */
+        if (!(fmt->block_size == 0x200 || fmt->block_size == 0x9b || fmt->block_size == 0x69))
+            return false;
+
+        /* could do it for fmt size 0x36 too but not important */
+        if (!is_ue4_msadpcm_blocks(sf, fmt, start, data_size))
+            return false;
+    }
+    else {
+        return false;
+    }
+
+    /* UE4's class is "ADPCM", assume it's the extension too (also safer since can't tell UE4 MSADPCM from .wav ADPCM in some cases) */
+    if (!check_extensions(sf, "adpcm"))
+        return false;
+
+    return true;
 }
 
 /* for maximum annoyance later UE4 versions (~v4.2x?) interleave single frames instead of
  * half interleave, but don't have flags to detect so we need some heuristics. Most later
- * games with 0x36 chunk size use v2_interleave but notably Travis Strikes Again doesn't  */
+ * games with 0x36 chunk size use v2_interleave but notably Travis Strikes Again doesn't */
 static size_t get_ue4_msadpcm_interleave(STREAMFILE* sf, riff_fmt_chunk* fmt, off_t start, size_t size) {
     size_t v1_interleave = size / fmt->channels;
     size_t v2_interleave = fmt->block_size;
@@ -1009,23 +1037,19 @@ static size_t get_ue4_msadpcm_interleave(STREAMFILE* sf, riff_fmt_chunk* fmt, of
     is_blank_full = memcmp(nibbles_full, empty, nibbles_size) == 0;
 
     /* last frame is almost always padded, so should at half interleave */
-    if (!is_blank_half && !is_blank_full) {
+    if (!is_blank_half && !is_blank_full)
         return v1_interleave;
-    }
 
-    /* last frame is padded, and half interleave is not: should be regular interleave*/
-    if (!is_blank_half && is_blank_full) {
+    /* last frame is padded, and half interleave is not: should be regular interleave */
+    if (!is_blank_half && is_blank_full)
         return v2_interleave;
-    }
 
     /* last frame is silent-ish, so should at half interleave (TSA's SML_DarknessLoop_01, TSA_CAD_YAKATA)
      * this doesn't work too well b/c num_samples at 0x36 uses all data, may need adjustment */
     {
-
-        int i;
         int empty_nibbles_full = 1, empty_nibbles_half = 1;
 
-        for (i = 0; i < sizeof(nibbles_full); i++) {
+        for (int i = 0; i < sizeof(nibbles_full); i++) {
             uint8_t n1 = ((nibbles_full[i] >> 0) & 0x0f);
             uint8_t n2 = ((nibbles_full[i] >> 4) & 0x0f);
             if ((n1 != 0x0 && n1 != 0xf && n1 != 0x1) || (n2 != 0x0 && n2 != 0xf && n2 != 0x1)) {
@@ -1034,7 +1058,7 @@ static size_t get_ue4_msadpcm_interleave(STREAMFILE* sf, riff_fmt_chunk* fmt, of
             }
         }
 
-        for (i = 0; i < sizeof(nibbles_half); i++) {
+        for (int i = 0; i < sizeof(nibbles_half); i++) {
             uint8_t n1 = ((nibbles_half[i] >> 0) & 0x0f);
             uint8_t n2 = ((nibbles_half[i] >> 4) & 0x0f);
             if ((n1 != 0x0 && n1 != 0xf && n1 != 0x1) || (n2 != 0x0 && n2 != 0xf && n2 != 0x1)) {
@@ -1043,10 +1067,8 @@ static size_t get_ue4_msadpcm_interleave(STREAMFILE* sf, riff_fmt_chunk* fmt, of
             }
         }
 
-        if (empty_nibbles_full && empty_nibbles_half){
-            VGM_LOG("v1 b\n");
+        if (empty_nibbles_full && empty_nibbles_half)
             return v1_interleave;
-        }
     }
 
     /* other tests? */

--- a/src/meta/txth.c
+++ b/src/meta/txth.c
@@ -25,7 +25,6 @@ typedef enum {
     AICA = 10,          /* YAMAHA AICA ADPCM (Dreamcast games) */
     MSADPCM = 11,       /* MS ADPCM (Windows games) */
     NGC_DSP = 12,       /* NGC DSP (Nintendo games) */
-    PCM8_U_int = 13,    /* 8-bit unsigned PCM (interleaved) */
     PSX_bf = 14,        /* PS-ADPCM with bad flags */
     MS_IMA = 15,        /* Microsoft IMA ADPCM */
     PCM8_U = 16,        /* 8-bit unsigned PCM */
@@ -265,7 +264,6 @@ VGMSTREAM* init_vgmstream_txth(STREAMFILE* sf) {
         case PCM16BE:       coding = coding_PCM16BE; break;
         case PCM8:          coding = coding_PCM8; break;
         case PCM8_U:        coding = coding_PCM8_U; break;
-        case PCM8_U_int:    coding = coding_PCM8_U_int; break;
         case PCM8_SB:       coding = coding_PCM8_SB; break;
         case ULAW:          coding = coding_ULAW; break;
         case ALAW:          coding = coding_ALAW; break;
@@ -336,9 +334,6 @@ VGMSTREAM* init_vgmstream_txth(STREAMFILE* sf) {
 
     /* codec specific (taken from GENH with minimal changes) */
     switch (coding) {
-        case coding_PCM8_U_int:
-            vgmstream->layout_type = layout_none;
-            break;
         case coding_PCM24LE:
         case coding_PCM24BE:
         case coding_PCM16LE:
@@ -979,7 +974,6 @@ static txth_codec_t parse_codec(txth_header* txth, const char* val) {
     else if (is_string(val,"PCM16LE"))      return PCM16LE;
     else if (is_string(val,"PCM8"))         return PCM8;
     else if (is_string(val,"PCM8_U"))       return PCM8_U;
-    else if (is_string(val,"PCM8_U_int"))   return PCM8_U_int;
     else if (is_string(val,"PCM8_SB"))      return PCM8_SB;
     else if (is_string(val,"SDX2"))         return SDX2;
     else if (is_string(val,"DVI_IMA"))      return DVI_IMA;
@@ -2159,7 +2153,6 @@ static int get_bytes_to_samples(txth_header* txth, uint32_t bytes) {
         case PCM16LE:
             return pcm16_bytes_to_samples(bytes, txth->channels);
         case PCM8:
-        case PCM8_U_int:
         case PCM8_U:
         case PCM8_SB:
         case ULAW:

--- a/src/meta/zsnd.c
+++ b/src/meta/zsnd.c
@@ -21,7 +21,7 @@ VGMSTREAM* init_vgmstream_zsnd(STREAMFILE* sf) {
 
     /* .zss/zsm: standard
      * .ens/enm: same for PS2
-     * .zsd: normal or compact [BMX XXX (Xbox), Aggresive Inline (Xbox), Dave Mirra Freestyle BMX (PS1/PS2)] */
+     * .zsd: normal or compact [BMX XXX (Xbox), Aggresive Inline (Xbox), Dave Mirra Freestyle BMX 1/2 (PS1/PS2)] */
     if (!check_extensions(sf, "zss,zsm,ens,enm,zsd"))
         return NULL;
     /* probably zss=stream, zsm=memory; no diffs other than size */
@@ -68,7 +68,7 @@ VGMSTREAM* init_vgmstream_zsnd(STREAMFILE* sf) {
          * table1 may have more entries than table2/3, and sometimes isn't set
          */
 
-        /* V1 has no table heads, rare [Aggresive Inline (Xbox), Dave Mirra Freestyle BMX (PS1/PS2)]
+        /* V1 has no table heads, rare [Aggresive Inline (Xbox), Dave Mirra Freestyle BMX 1/2 (PS1/PS2)]
          * no apparent flag but we can test if table heads offsets appear */
         is_v1 = read_32bit(0x14,sf) <= read_32bit(0x1c,sf) &&
                 read_32bit(0x1c,sf) <= read_32bit(0x24,sf) &&
@@ -185,7 +185,7 @@ VGMSTREAM* init_vgmstream_zsnd(STREAMFILE* sf) {
             case 0x50533220: /* "PS2 " (also for PSP) */
             case 0x50535820: /* "PSX "  */
                 if (table2_entries == 0) {
-                    /* rare, seen in MUSIC.ZSD but SFX*.ZSD do have headers [Dave Mirra Freestyle BMX (PS1/PS2)] */
+                    /* rare, seen in MUSIC.ZSD but SFX*.ZSD do have headers [Dave Mirra Freestyle BMX 1/2 (PS1/PS2)] */
                     sample_rate = 0x1000;
                     layers = 0x02;
                 }


### PR DESCRIPTION
- Fix some .adpcm [2013: Infected Wars (iOS)]
- Fix some .acx [12Riven (PC)]
- Fix some .wave [Mighty Switch Force! (Wii)]
- Export loop_start/loop_end for foobar's playlist
- Fix seeking into the outro region when loop+outro is set
- Add TXTP frame_size for MSADPCM interleaved mode [Metal Gear Solid 2 (PC)]
- Remove unused TXTH codec PCM8_U_int (use PCM8_U + interleave)
