### PR TITLE
Add new hca key for Puyo Puyo Puzzle Pop (iOS)

### DIFF
--- a/src/meta/hca_keys.h
+++ b/src/meta/hca_keys.h
@@ -1305,8 +1305,8 @@ static const hcakey_info hcakey_list[] = {
         // Jujutsu Kaisen: Cursed Clash (multi)
         {984703514306706654},    // DAA5EA10B547CDE
 
-        // Puyo Puyo Puzzle Pop (iOS)
-        {9999},                  // hope it is the right key
+        // Puyo Puyo Puzzle Pop (iOS/macOS)
+        {9999},                  // I don't know what this number comment does, so anyone can fill this comment up with the number
 
 };
 

--- a/src/meta/hca_keys.h
+++ b/src/meta/hca_keys.h
@@ -1305,6 +1305,9 @@ static const hcakey_info hcakey_list[] = {
         // Jujutsu Kaisen: Cursed Clash (multi)
         {984703514306706654},    // DAA5EA10B547CDE
 
+        // Puyo Puyo Puzzle Pop (iOS)
+        {9999},                  // hope it is the right key
+
 };
 
 #endif/*_HCA_KEYS_H_*/

--- a/src/meta/hca_keys.h
+++ b/src/meta/hca_keys.h
@@ -1306,7 +1306,7 @@ static const hcakey_info hcakey_list[] = {
         {984703514306706654},    // DAA5EA10B547CDE
 
         // Puyo Puyo Puzzle Pop (iOS)
-        {9999},                  // Todo: Fill this up with the number like the other keys
+        {9999},                  // 000000000000270F
 
 };
 

--- a/src/meta/hca_keys.h
+++ b/src/meta/hca_keys.h
@@ -1305,8 +1305,8 @@ static const hcakey_info hcakey_list[] = {
         // Jujutsu Kaisen: Cursed Clash (multi)
         {984703514306706654},    // DAA5EA10B547CDE
 
-        // Puyo Puyo Puzzle Pop (iOS/macOS)
-        {9999},                  // I don't know what this number comment does, so anyone can fill this comment up with the number
+        // Puyo Puyo Puzzle Pop (iOS)
+        {9999},                  // Todo: Fill this up with the number like the other keys
 
 };
 


### PR DESCRIPTION
I don't know what the other number next to the other keys mean, so someone'll have to fill that up, but the main key was filled up and works with the foobar2000 component.