### PR TITLE
VAS: Manhunt 2 PSP audio

### DIFF
--- a/src/base/render.c
+++ b/src/base/render.c
@@ -302,6 +302,7 @@ int render_layout(sample_t* buf, int32_t sample_count, VGMSTREAM* vgmstream) {
         case layout_blocked_vid1:
         case layout_blocked_ubi_sce:
         case layout_blocked_tt_ad:
+        case layout_blocked_vas:
             render_vgmstream_blocked(buf, sample_count, vgmstream);
             break;
         case layout_segmented:

--- a/src/formats.c
+++ b/src/formats.c
@@ -1430,6 +1430,7 @@ static const meta_info meta_info_list[] = {
         {meta_NXOF,                 "Nihon Falcom FDK header"},
         {meta_GWB_GWD,              "Ubisoft GWB+GWD header"},
         {meta_CBX,                  "Traveller's Tales CBX header"},
+        {meta_VAS,                  "Manhunt 2 .VAS header"},
 };
 
 void get_vgmstream_coding_description(VGMSTREAM* vgmstream, char* out, size_t out_size) {

--- a/src/formats.c
+++ b/src/formats.c
@@ -630,6 +630,7 @@ static const char* extension_list[] = {
     "wavebatch",
     "wavm",
     "wavx", //txth/reserved [LEGO Star Wars (Xbox)]
+    "wax",
     "way",
     "wb",
     "wb2",

--- a/src/formats.c
+++ b/src/formats.c
@@ -972,6 +972,7 @@ static const layout_info layout_info_list[] = {
         {layout_blocked_vid1,           "blocked (VID1)"},
         {layout_blocked_ubi_sce,        "blocked (Ubi SCE)"},
         {layout_blocked_tt_ad,          "blocked (TT AD)"},
+        {layout_blocked_vas,            "blocked (VAS)"},
 };
 
 static const meta_info meta_info_list[] = {

--- a/src/layout/blocked.c
+++ b/src/layout/blocked.c
@@ -207,6 +207,9 @@ void block_update(off_t block_offset, VGMSTREAM* vgmstream) {
         case layout_blocked_tt_ad:
             block_update_tt_ad(block_offset,vgmstream);
             break;
+        case layout_blocked_vas:
+            block_update_vas(block_offset,vgmstream);
+            break;
         default: /* not a blocked layout */
             break;
     }

--- a/src/layout/blocked_vas.c
+++ b/src/layout/blocked_vas.c
@@ -1,7 +1,7 @@
 #include "layout.h"
 #include "../vgmstream.h"
 
-/* VAS - Manhunt 2 PSP blocked audio layout */
+/* VAS - Manhunt 2 PSP VAGs/2AGs blocked audio layout */
 void block_update_vas(off_t block_offset, VGMSTREAM* vgmstream) {
     size_t block_size;
     int num_streams;

--- a/src/layout/blocked_vas.c
+++ b/src/layout/blocked_vas.c
@@ -1,0 +1,17 @@
+#include "layout.h"
+#include "../vgmstream.h"
+
+/* VAS - Manhunt 2 PSP blocked audio layout */
+void block_update_vas(off_t block_offset, VGMSTREAM* vgmstream) {
+    size_t block_size;
+    int num_streams;
+
+    /* no headers */
+    block_size = 0x40;
+    num_streams = vgmstream->num_streams;
+
+    vgmstream->current_block_offset = block_offset;
+    vgmstream->next_block_offset = block_offset + (block_size * num_streams);
+    vgmstream->current_block_size = block_size;
+    vgmstream->ch[0].offset = block_offset;
+}

--- a/src/layout/layout.h
+++ b/src/layout/layout.h
@@ -48,6 +48,7 @@ void block_update_vs_square(off_t block_offset, VGMSTREAM* vgmstream);
 void block_update_vid1(off_t block_offset, VGMSTREAM* vgmstream);
 void block_update_ubi_sce(off_t block_offset, VGMSTREAM* vgmstream);
 void block_update_tt_ad(off_t block_offset, VGMSTREAM* vgmstream);
+void block_update_vas(off_t block_offset, VGMSTREAM* vgmstream);
 
 /* other layouts */
 void render_vgmstream_interleave(sample_t* buffer, int32_t sample_count, VGMSTREAM* vgmstream);

--- a/src/libvgmstream.vcxproj
+++ b/src/libvgmstream.vcxproj
@@ -319,6 +319,7 @@
     <ClCompile Include="layout\blocked_thp.c" />
     <ClCompile Include="layout\blocked_tt_ad.c" />
     <ClCompile Include="layout\blocked_ubi_sce.c" />
+    <ClCompile Include="layout\blocked_vas.c" />
     <ClCompile Include="layout\blocked_vgs.c" />
     <ClCompile Include="layout\blocked_vid1.c" />
     <ClCompile Include="layout\blocked_vs.c" />

--- a/src/libvgmstream.vcxproj
+++ b/src/libvgmstream.vcxproj
@@ -692,6 +692,7 @@
     <ClCompile Include="meta\vab.c" />
     <ClCompile Include="meta\vag.c" />
     <ClCompile Include="meta\vai.c" />
+    <ClCompile Include="meta\vas.c" />
     <ClCompile Include="meta\vgs.c" />
     <ClCompile Include="meta\vgs_ps.c" />
     <ClCompile Include="meta\vid1.c" />

--- a/src/libvgmstream.vcxproj.filters
+++ b/src/libvgmstream.vcxproj.filters
@@ -778,6 +778,9 @@
     <ClCompile Include="layout\blocked_ubi_sce.c">
       <Filter>layout\Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="layout\blocked_vas.c">
+      <Filter>layout\Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="layout\blocked_vgs.c">
       <Filter>layout\Source Files</Filter>
     </ClCompile>

--- a/src/libvgmstream.vcxproj.filters
+++ b/src/libvgmstream.vcxproj.filters
@@ -1897,6 +1897,9 @@
     <ClCompile Include="meta\vai.c">
       <Filter>meta\Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="meta\vas.c">
+      <Filter>meta\Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="meta\vgs.c">
       <Filter>meta\Source Files</Filter>
     </ClCompile>

--- a/src/meta/meta.h
+++ b/src/meta/meta.h
@@ -1002,4 +1002,6 @@ VGMSTREAM* init_vgmstream_gwb_gwd(STREAMFILE* sf);
 
 VGMSTREAM* init_vgmstream_cbx(STREAMFILE* sf);
 
+VGMSTREAM* init_vgmstream_vas(STREAMFILE* sf);
+
 #endif /*_META_H*/

--- a/src/meta/riff.c
+++ b/src/meta/riff.c
@@ -399,8 +399,9 @@ VGMSTREAM* init_vgmstream_riff(STREAMFILE* sf) {
      * .dat/ldat: RollerCoaster Tycoon 1/2 (PC)
      * .wma/lwma: SRS: Street Racing Syndicate (Xbox), Fast and the Furious (Xbox)
      * .caf: Topple (iOS)
+     * .wax: Lamborghini (Xbox)
      */
-    if (!check_extensions(sf, "wav,lwav,xwav,mwv,da,dax,cd,med,snd,adx,adp,xss,xsew,adpcm,adw,wd,,sbv,wvx,str,at3,rws,aud,at9,ckd,saf,ima,nsa,pcm,xvag,ogg,logg,p1d,xms,mus,dat,ldat,wma,lwma,caf")) {
+    if (!check_extensions(sf, "wav,lwav,xwav,mwv,da,dax,cd,med,snd,adx,adp,xss,xsew,adpcm,adw,wd,,sbv,wvx,str,at3,rws,aud,at9,ckd,saf,ima,nsa,pcm,xvag,ogg,logg,p1d,xms,mus,dat,ldat,wma,lwma,caf,wax")) {
         return NULL;
     }
 

--- a/src/meta/vas.c
+++ b/src/meta/vas.c
@@ -1,0 +1,57 @@
+#include "meta.h"
+#include "../coding/coding.h"
+
+/* VAS - Manhunt 2 [PSP] */
+VGMSTREAM* init_vgmstream_rstm_rockstar(STREAMFILE* sf) {
+    VGMSTREAM* vgmstream = NULL;
+    off_t stream_offset;
+    size_t stream_size;
+    int sample_rate, channels, loop_flag = 0;
+
+
+    /* checks */
+
+    /* VAGs: v1, used in prerelease builds
+     * 2AGs: v2, used in the final release */
+    if (!is_id32be(0x00, sf, "VAGs") && !is_id32be(0x00, sf, "2AGs"))
+        goto fail;
+
+    if (!check_extensions(sf, "vas"))
+        goto fail;
+
+    stream_size = read_u32le(0x04, sf);
+    sample_rate = read_u16le(0x08, sf);
+    /* read_u8(0x0C, sf); // interleave size * 0x10? never used, always mono */
+    channels = read_u8(0x0B, sf);
+    if (channels != 1) goto fail;
+
+    stream_offset = 0x0C;
+    /* offset by 32 bytes for v2, stream name field? always empty in Manhunt 2 */
+    if (is_id32be(0x00, sf, "2AGs"))
+        stream_offset += 0x20;
+
+    /* might conflict with the standard VAG otherwise */
+    if (stream_size + stream_offset != get_streamfile_size(sf))
+        goto fail;
+    
+
+    /* build the VGMSTREAM */
+    vgmstream = allocate_vgmstream(channels, loop_flag);
+    if (!vgmstream) goto fail;
+
+    vgmstream->meta_type = meta_VAS;
+    vgmstream->coding_type = coding_PSX;
+    vgmstream->layout_type = layout_none;
+    vgmstream->sample_rate = sample_rate;
+    vgmstream->stream_size = stream_size;
+    vgmstream->interleave_block_size = 0;
+    vgmstream->num_samples = ps_bytes_to_samples(stream_size, channels);
+
+    if (!vgmstream_open_stream(vgmstream, sf, stream_offset))
+        goto fail;
+    return vgmstream;
+
+fail:
+    close_vgmstream(vgmstream);
+    return NULL;
+}

--- a/src/meta/vas.c
+++ b/src/meta/vas.c
@@ -2,7 +2,7 @@
 #include "../coding/coding.h"
 
 /* VAS - Manhunt 2 [PSP] */
-VGMSTREAM* init_vgmstream_rstm_rockstar(STREAMFILE* sf) {
+VGMSTREAM* init_vgmstream_vas(STREAMFILE* sf) {
     VGMSTREAM* vgmstream = NULL;
     off_t stream_offset;
     size_t stream_size;

--- a/src/meta/vas.c
+++ b/src/meta/vas.c
@@ -5,8 +5,9 @@
 VGMSTREAM* init_vgmstream_vas(STREAMFILE* sf) {
     VGMSTREAM* vgmstream = NULL;
     off_t stream_offset;
-    size_t stream_size;
-    int sample_rate, channels, loop_flag = 0;
+    size_t data_size, stream_size;
+    int sample_rate, num_streams, channels, loop_flag = 0;
+    int is_v2, block_size, target_subsong = sf->stream_index;
 
 
     /* checks */
@@ -19,21 +20,33 @@ VGMSTREAM* init_vgmstream_vas(STREAMFILE* sf) {
     if (!check_extensions(sf, "vas"))
         goto fail;
 
-    stream_size = read_u32le(0x04, sf);
+    data_size = read_u32le(0x04, sf);
     sample_rate = read_u16le(0x08, sf);
-    /* read_u8(0x0C, sf); // interleave size * 0x10? never used, always mono */
-    channels = read_u8(0x0B, sf);
-    if (channels != 1) goto fail;
+    if (read_u8(0x0A, sf)) goto fail; /* always 0? */
+    num_streams = read_u8(0x0B, sf);
+    if (num_streams < 1 || num_streams > 32) goto fail;
+    if (!target_subsong) target_subsong = 1;
 
+    is_v2 = is_id32be(0x00, sf, "2AGs");
+
+    block_size = 0x40;
     stream_offset = 0x0C;
-    /* offset by 32 bytes for v2, stream name field? always empty in Manhunt 2 */
-    if (is_id32be(0x00, sf, "2AGs"))
-        stream_offset += 0x20;
+    /* only in v2, 32 byte buffer of the intended order for stream blocks */
+    if (is_v2) stream_offset += 0x20;
 
     /* might conflict with the standard VAG otherwise */
-    if (stream_size + stream_offset != get_streamfile_size(sf))
+    if (data_size + stream_offset != get_streamfile_size(sf))
         goto fail;
-    
+
+    target_subsong -= 1; /* zero index */
+    /* currently threre are no known v1 multi-stream blocked sounds, prerelease
+     * builds also use v2 for those, but this should be how v1 works in theory */
+    stream_offset += block_size * (is_v2 ? read_u8(0x0C + target_subsong, sf) : target_subsong);
+
+
+    stream_size = data_size / num_streams;
+
+    channels = 1; /* might be read_u8(0x0A, sf) + 1? */
 
     /* build the VGMSTREAM */
     vgmstream = allocate_vgmstream(channels, loop_flag);
@@ -41,10 +54,11 @@ VGMSTREAM* init_vgmstream_vas(STREAMFILE* sf) {
 
     vgmstream->meta_type = meta_VAS;
     vgmstream->coding_type = coding_PSX;
-    vgmstream->layout_type = layout_none;
+    vgmstream->num_streams = num_streams;
     vgmstream->sample_rate = sample_rate;
     vgmstream->stream_size = stream_size;
     vgmstream->interleave_block_size = 0;
+    vgmstream->layout_type = layout_blocked_vas;
     vgmstream->num_samples = ps_bytes_to_samples(stream_size, channels);
 
     if (!vgmstream_open_stream(vgmstream, sf, stream_offset))

--- a/src/vgmstream.c
+++ b/src/vgmstream.c
@@ -524,6 +524,7 @@ init_vgmstream_t init_vgmstream_functions[] = {
     init_vgmstream_gwb_gwd,
     init_vgmstream_s_pack,
     init_vgmstream_cbx,
+    init_vgmstream_vas,
 
     /* lower priority metas (no clean header identity, somewhat ambiguous, or need extension/companion file to identify) */
     init_vgmstream_scd_pcm,

--- a/src/vgmstream_types.h
+++ b/src/vgmstream_types.h
@@ -233,6 +233,7 @@ typedef enum {
     layout_blocked_vid1,
     layout_blocked_ubi_sce,
     layout_blocked_tt_ad,
+    layout_blocked_vas,
 
     /* otherwise odd */
     layout_segmented,       /* song divided in segments (song sections) */

--- a/src/vgmstream_types.h
+++ b/src/vgmstream_types.h
@@ -704,6 +704,7 @@ typedef enum {
     meta_NXOF,
     meta_GWB_GWD,
     meta_CBX,
+    meta_VAS,
 
 } meta_t;
 


### PR DESCRIPTION
.VAS (VAGs/2AGs) blocked audio format used in the PSP version of Manhunt 2.  No relation or similarities to the standard Sony VAG.

Also added the .WAX extension to RIFF used by Lamborghini (Xbox) - did that last year and never pushed it or made the PR, oops.