### PR TITLE
RAGE AUD: Additional todo note

### DIFF
--- a/src/layout/blocked_rage_aud.c
+++ b/src/layout/blocked_rage_aud.c
@@ -9,7 +9,7 @@ void block_update_rage_aud(off_t block_offset, VGMSTREAM* vgmstream) {
     off_t seek_info_offset;
     int i;
 
-    //big_endian = read_u32le(0x00, sf) == 0; /* 64-bit number */
+    //big_endian = read_u32le(block_offset, sf) == 0; /* 64-bit number */
     read_u64_t read_u64 = vgmstream->codec_endian ? read_u64be : read_u64le;
     read_u32_t read_u32 = vgmstream->codec_endian ? read_u32be : read_u32le;
 
@@ -37,13 +37,13 @@ void block_update_rage_aud(off_t block_offset, VGMSTREAM* vgmstream) {
      * (table is max 0x7b8 + seek table offset + 0x800-padded) */
 
     /* TODO: This isn't really reliable, there are several very short 4-7ch streams in
-     * both MCLA and GTA4 whose seek tables are short enough to fit in 0x800 alignment
-     * 
+     * both MCLA and GTA4 whose seek tables are small enough to fit in 0x800 alignment
+     *
      * The best option might be to search for the highest start_entry offset across all the
      * seek info entries (offsets 0x00 and 0x04, can be along with the block_samples loop),
      * and do seek_info_size + furthest_offset * 0x08 + num_entries * 0x08, since sometimes
      * the number of seek entries are off by one, so just adding them all up won't match.
-     * 
+     *
      * However this should always be done from the 1st stream block, or at the very least
      * not the final block, since it can have less data left over due to it being the end
      * of the stream, where the calculation would result in it being smaller than it is.

--- a/src/meta/rage_aud.c
+++ b/src/meta/rage_aud.c
@@ -155,6 +155,13 @@ static int parse_aud_header(STREAMFILE* sf, aud_header* aud) {
         aud->stream_offset = read_u32(0x2c, sf);
         channel_info_offset = channel_table_offset + aud->channel_count * 0x10;
 
+        /* TODO: While not exactly relevant currently without it being supported yet,
+         * there are two Xbox 360 (XMA) streams, where the block count is off by one.
+         *
+         * This size check will fail on the following two files:
+         * GTA4 - Header says 2 blocks, actually has 3 - EP1_SFX/RP03_ML
+         * MCLA - Header says 3 blocks, actually has 4 - AUDIO/X360/SFX/AMBIENCE_STREAM/AMB_QUADSHOT_MALL_ADVERT_09
+         */
         if ((aud->block_count * aud->block_size) + aud->stream_offset != get_streamfile_size(sf)) {
             VGM_LOG("RAGE AUD: bad file size\n");
             goto fail;


### PR DESCRIPTION
Was meant to be a part of the previous PR, but I was too slow.

Additional TODO in the main RAGE AUD meta parser about two Xbox 360 files whose block counts mismatch the actual data.  Not quite relevant yet, since XMA blocked streams are not yet supported anyway, but useful to know in the future.
- `(MC: LA) AUDIO/X360/SFX/AMBIENCE_STREAM/AMB_QUADSHOT_MALL_ADVERT_09`
- `(GTA IV) EP1_SFX/RP03_ML`

Scanned through all the audio files on PC, PS3, and X360 of both games, these seemed to be the only two outliers.