### PR TITLE
AWD/RWS: codec index/uuid research notes

### DIFF
--- a/src/formats.c
+++ b/src/formats.c
@@ -1427,7 +1427,7 @@ static const meta_info meta_info_list[] = {
         {meta_VAB,                  "Sony VAB header"},
         {meta_BIGRP,                "Inti Creates .BIGRP header"},
         {meta_DIC1,                 "Codemasters DIC1 header"},
-        {meta_AWD,                  "RenderWare Audio Wave Dictionary header"},
+        {meta_AWD,                  "RenderWare AWD header"},
         {meta_SQUEAKSTREAM,         "Torus SqueakStream header"},
         {meta_SQUEAKSAMPLE,         "Torus SqueakSample header"},
         {meta_SNDS,                 "Sony SNDS header"},

--- a/src/meta/rws_809.c
+++ b/src/meta/rws_809.c
@@ -112,7 +112,8 @@ VGMSTREAM* init_vgmstream_rws_809(STREAMFILE* sf) {
     vgmstream->num_streams = total_subsongs;
     vgmstream->interleave_block_size = interleave;
 
-    /* Seems to be the same as in rws_80d.c, maybe merge the two switches into one function? */
+    /* should be the same as in rws_80d, maybe merge the two switches into one function? */
+    /* the full list of all the valid codec UUIDs can also be found listed in rws_80d */
     switch (codec_uuid) {
         case 0xD01BD217: /* {D01BD217-3587-4EED-B9D9-B8E86EA9B995}: PCM Signed 16-bit */
             vgmstream->num_samples = pcm16_bytes_to_samples(stream_size, channels);

--- a/src/meta/rws_80d.c
+++ b/src/meta/rws_80d.c
@@ -299,8 +299,23 @@ VGMSTREAM* init_vgmstream_rws(STREAMFILE* sf) {
     vgmstream->current_block_size = rws.block_size / vgmstream->channels;
     vgmstream->full_block_size = rws.block_layers_size;
 
+    /* these should be all the codec uuids, even if many aren't ever used
+     * based on the research at https://burnout.wiki/wiki/Wave_Dictionary
+     *  {D9EA9798-BBBC-447B-96B2-654759102E16}: PS ADPCM
+     *  {D01BD217-3587-4EED-B9D9-B8E86EA9B995}: PCM
+     *  {DA1E4382-2C99-4C61-AD99-7F364B211537}: Float
+     *  {F86215B0-31D5-4C29-BD37-CDBF9BD10C53}: DSP ADPCM
+     *  {632FA22B-11DD-458F-AA27-A5C346E9790E}: Xbox IMA ADPCM
+     *  {3F1D8147-B7C4-41E6-A69B-3CC0025B33C7}: WMA
+     *  {BACFB36E-529D-4692-BF53-324256B0734F}: MP3
+     *  {34D09A54-57D3-409E-A6AD-2BC845AEC339}: MP2
+     *  {04C15BA7-F907-40AB-A49F-EEFEF8C4D296}: MP1
+     *  {A30DB390-58A9-43C4-B9D2-55D84D3AE754}: AC3
+     *  {EF386593-B611-432D-957F-A71ADE44227A}: IMA ADPCM
+     */
+
     switch(rws.codec) {
-        case 0xD01BD217: /* {D01BD217,3587,4EED,B9,D9,B8,E8,6E,A9,B9,95} PCM PC/X360/PS2 */
+        case 0xD01BD217: /* {D01BD217-3587-4EED-B9D9-B8E86EA9B995} PCM PC/X360/PS2 */
             /* D.i.R.T.: Origin of the Species (PC), The Legend of Spyro (X360), kill.switch (PS2) */
             if (rws.interleave == 0x02) { /* PC, X360 */
                 vgmstream->coding_type = coding_PCM16_int;
@@ -315,7 +330,7 @@ VGMSTREAM* init_vgmstream_rws(STREAMFILE* sf) {
             vgmstream->num_samples = pcm16_bytes_to_samples(stream_size, rws.channels);
             break;
 
-        case 0xD9EA9798: /* {D9EA9798,BBBC,447B,96,B2,65,47,59,10,2E,16} PS-ADPCM PS2 */
+        case 0xD9EA9798: /* {D9EA9798-BBBC-447B-96B2-654759102E16} PS-ADPCM PS2 */
             /* Silent Hill Origins (PS2), Ghost Rider (PS2), Max Payne 2 (PS2), Nana (PS2) */
             vgmstream->coding_type = coding_PSX;
             vgmstream->interleave_block_size = rws.block_size / 2;
@@ -323,7 +338,7 @@ VGMSTREAM* init_vgmstream_rws(STREAMFILE* sf) {
             vgmstream->num_samples = ps_bytes_to_samples(stream_size, rws.channels);
             break;
 
-        case 0xF86215B0: /* {F86215B0,31D5,4C29,BD,37,CD,BF,9B,D1,0C,53} DSP GC/Wii */
+        case 0xF86215B0: /* {F86215B0-31D5-4C29-BD37-CDBF9BD10C53} DSP GC/Wii */
             /* Burnout 2 (GC), Alice in Wonderland (Wii), Call of Duty: Finest Hour (GC) */
             vgmstream->coding_type = coding_NGC_DSP;
             vgmstream->interleave_block_size = rws.block_size / 2;
@@ -336,8 +351,8 @@ VGMSTREAM* init_vgmstream_rws(STREAMFILE* sf) {
             vgmstream->num_samples = dsp_bytes_to_samples(stream_size, rws.channels);
             break;
 
-        case 0xEF386593: /* {EF386593,B611,432D,95,7F,A7,1A,DE,44,22,7A} XBOX-IMA PC */
-        case 0x632FA22B: /* {632FA22B,11DD,458F,AA,27,A5,C3,46,E9,79,0E} XBOX-IMA Xbox */
+        case 0xEF386593: /* {EF386593-B611-432D-957F-A71ADE44227A} XBOX-IMA PC */
+        case 0x632FA22B: /* {632FA22B-11DD-458F-AA27-A5C346E9790E} XBOX-IMA Xbox */
             /* Broken Sword 3 (PC), Jacked (PC/Xbox), Burnout 2 (Xbox) */
             vgmstream->coding_type = coding_XBOX_IMA; /* same data though different uuid */
             vgmstream->interleave_block_size = 0;


### PR DESCRIPTION
Nothing really changed code-wise, but added additional information about all of the valid RenderWare codec indices and UUIDs even if a bunch of them are likely never used in practice.  Based on [research](https://burnout.wiki/wiki/Wave_Dictionary#Enumerations) done by fellow Burnout researchers, namely escape209 and burninrubber0.