### PR TITLE
Add Ongakukan ADPCM decoder

### DIFF
--- a/src/base/decode.c
+++ b/src/base/decode.c
@@ -49,6 +49,10 @@ void decode_free(VGMSTREAM* vgmstream) {
         free_imuse(vgmstream->codec_data);
     }
 
+    if (vgmstream->coding_type == coding_ONGAKUKAN_ADPCM) {
+        free_ongakukan_adp(vgmstream->codec_data);
+    }
+
     if (vgmstream->coding_type == coding_COMPRESSWAVE) {
         free_compresswave(vgmstream->codec_data);
     }
@@ -147,6 +151,10 @@ void decode_seek(VGMSTREAM* vgmstream) {
 
     if (vgmstream->coding_type == coding_IMUSE) {
         seek_imuse(vgmstream->codec_data, vgmstream->loop_current_sample);
+    }
+
+    if (vgmstream->coding_type == coding_ONGAKUKAN_ADPCM) {
+        seek_ongakukan_adp(vgmstream->codec_data, vgmstream->loop_current_sample);
     }
 
     if (vgmstream->coding_type == coding_COMPRESSWAVE) {
@@ -252,6 +260,10 @@ void decode_reset(VGMSTREAM* vgmstream) {
 
     if (vgmstream->coding_type == coding_IMUSE) {
         reset_imuse(vgmstream->codec_data);
+    }
+
+    if (vgmstream->coding_type == coding_ONGAKUKAN_ADPCM) {
+        reset_ongakukan_adp(vgmstream->codec_data);
     }
 
     if (vgmstream->coding_type == coding_COMPRESSWAVE) {
@@ -522,6 +534,8 @@ int decode_get_samples_per_frame(VGMSTREAM* vgmstream) {
             return 0; /* varies per mode */
         case coding_IMUSE:
             return 0; /* varies per frame */
+        case coding_ONGAKUKAN_ADPCM:
+            return 0; /* actually 1. */
         case coding_COMPRESSWAVE:
             return 0; /* multiple of 2 */
         case coding_EA_MT:
@@ -1527,6 +1541,10 @@ void decode_vgmstream(VGMSTREAM* vgmstream, int samples_written, int samples_to_
 
         case coding_IMUSE:
             decode_imuse(vgmstream, buffer, samples_to_do);
+            break;
+
+        case coding_ONGAKUKAN_ADPCM:
+            decode_ongakukan_adp(vgmstream, buffer, samples_to_do);
             break;
 
         case coding_COMPRESSWAVE:

--- a/src/coding/coding.h
+++ b/src/coding/coding.h
@@ -294,6 +294,16 @@ void reset_imuse(imuse_codec_data* data);
 void seek_imuse(imuse_codec_data* data, int32_t num_sample);
 void free_imuse(imuse_codec_data* data);
 
+/* ongakukan_adp_decoder */
+typedef struct ongakukan_adp_data ongakukan_adp_data;
+
+ongakukan_adp_data* init_ongakukan_adp(STREAMFILE* sf, int32_t data_offset, int32_t data_size,
+    char sound_is_adpcm, char sample_has_base_setup_from_the_start);
+void decode_ongakukan_adp(VGMSTREAM* vgmstream, sample_t* outbuf, int32_t samples_to_do);
+void reset_ongakukan_adp(ongakukan_adp_data* data);
+void seek_ongakukan_adp(ongakukan_adp_data* data, int32_t current_sample);
+void free_ongakukan_adp(ongakukan_adp_data* data);
+int32_t ongakukan_adp_get_samples(ongakukan_adp_data* data);
 
 /* compresswave_decoder */
 typedef struct compresswave_codec_data compresswave_codec_data;

--- a/src/coding/libs/ongakukan_adp_lib.c
+++ b/src/coding/libs/ongakukan_adp_lib.c
@@ -227,7 +227,7 @@ void decode_ongakukan_adpcm_sample(ongakukan_adp_t* handle, short int* sample_hi
             handle->base_pair = 0; /* set representing byte to 0 while we're at it. */
         }
         /* "pinch off" of a single-byte read. remember that we need two nibbles. */
-        (uint8_t)(handle->base_pair) = read_u8_wrapper(handle);
+        handle->base_pair = (uint8_t)read_u8_wrapper(handle);
 
         /* now pick two nibbles, subtract them, reverse the order of said nibbles so we can calc them one-by-one,
          * and finally tell handle that we're done with two samples and would like to take a break, please. */

--- a/src/coding/libs/ongakukan_adp_lib.c
+++ b/src/coding/libs/ongakukan_adp_lib.c
@@ -1,0 +1,258 @@
+
+/* Decodes Ongakukan ADPCM, found in their PS2 and PSP games.
+ * Basically their take on ADPCM with some companding and quantization involved.
+ * 
+ * Original decoder is a mix of COP0 and VU1 code, however PS2 floats aren't actually used (if at all) 
+ * when it comes to converting encoded sample data (consisting of a single byte with two 4-bit nibbles, respectively) to PCM16.
+ *
+ * The decoder you see here is a hand-crafted, faithful C adaptation of original MIPS R5900 (PS2) and R4000 (PSP) code, from various executables of their games.
+ * As a consequence of all this, a new, entirely custom decoder had to be designed from the ground-up into vgmstream. No info surrounding this codec was available. */
+
+/* Additional notes: 
+ * - This code does not support PCM16 sound data, in any way, shape, or form.
+ * -- Ongakukan's internal sound engine from their PS2 and PSP games allow for only two codecs: signed PCM16, and their own take on ADPCM, respectively.
+ * -- However, much of that support is reliant on a flag that's set to either one of the two codecs depending on the opened file extension.
+ *    Basically, how it works is: if sound data is "PCM16" (available to "wav" and "ads" files), set flag to 0.
+ *    If sound data is "ADPCM" (available to "adp" files), set it to 1.
+ * -- As vgmstream has built-in support for the former codec (and the many metas that use it) however, despite being fairly easy to add here,
+ *    re-implementing one from scratch would be a wasted effort regardless; it is consequentially not included. */
+
+#include <stdlib.h>
+#include "../../util/reader_sf.h"
+#include "ongakukan_adp_lib.h"
+
+/* the struct that oversees everything. */
+
+struct ongakukan_adp_t
+{
+    STREAMFILE* sf; /* streamfile var. */
+
+    long int data_offset; /* current offset of data that's being read. */
+    long int start_offset; /* base offset of encoded sound data. */
+    long int data_size; /* sound data size, basically ADP size if it didn't have 44 bytes more. */
+    long int sample_work; /* total number of samples, calc'd using data_size as a base. */
+    long int alt_sample_work1; /* represents current number of samples as they're decoded. */
+    long int alt_sample_work2; /* represents the many samples left to go through. */
+    long int samples_filled; /* how many samples were filled to vgmstream buffer. */
+    long int samples_consumed; /* how many samples vgmstream buffer had to consume. */
+
+    char sound_is_adpcm; /* 0 = no (see "additional notes" above) , 1 = yes */
+    char sample_startpoint_present; /* -1 = failed to make startpoint, 1 = startpoint present */
+    char sample_mode; /* 0 = creates decoding setup, 1 = continue decoding data with setup in place */
+    char sample_has_base_setup_from_the_start; /* 0 = no, 1 = yes */
+    char sample_pair_is_decoded; /* 0 = no, 1 = yes */
+
+    unsigned char base_pair; /* represents a read byte from ADPCM data, consisting of two 4-bit nibbles each.*/
+    long int base_scale; /* how loud should this sample be. */
+    void* sample_hist; /* two pairs of signed 16-bit data, representing samples. yes, it is void. */
+};
+
+/* filter table consisting of 16 numbers each. */
+
+const short int ongakukan_adpcm_filter[16] = { 233, 549, 453, 375, 310, 233, 233, 233, 233, 233, 233, 233, 310, 375, 453, 549 };
+
+/* streamfile read function declararion, more may be added in the future. */
+
+uint8_t read_u8_wrapper(ongakukan_adp_t* handle);
+
+/* function declarations for the inner workings of codec data. */
+
+char set_up_sample_startpoint(ongakukan_adp_t* handle);
+void decode_ongakukan_adpcm_sample(ongakukan_adp_t* handle, short int* sample_hist);
+
+/* codec management functions, meant to oversee and supervise ADP data from the top-down. 
+ * in layman terms, they control how ADP data should be handled and when. */
+
+ongakukan_adp_t* boot_ongakukan_adpcm(STREAMFILE* sf, long int data_offset, long int data_size,
+    char sound_is_adpcm, char sample_has_base_setup_from_the_start)
+{
+    ongakukan_adp_t* handle = NULL;
+
+    /* allocate handle using malloc. */
+    handle = (ongakukan_adp_t*)malloc(sizeof(handle));
+    if (!handle) goto fail;
+
+    /* now, to set up the rest of the handle with the data we have... */
+    handle->sf = sf;
+    handle->data_offset = data_offset;
+    handle->start_offset = data_offset;
+    handle->data_size = data_size;
+    handle->samples_filled = 0;
+    handle->samples_consumed = 0;
+    handle->sample_mode = 0;
+    handle->sound_is_adpcm = sound_is_adpcm;
+    handle->sample_has_base_setup_from_the_start = sample_has_base_setup_from_the_start;
+    handle->sample_startpoint_present = set_up_sample_startpoint(handle);
+    /* if we failed in planting up the seeds for an ADPCM decoder, we simply throw in the towel and take a walk in the park. */
+    if (handle->sample_startpoint_present == -1) { goto fail; }
+
+    return handle;
+fail:
+    free_all_ongakukan_adpcm(handle);
+    return NULL;
+}
+
+void free_all_ongakukan_adpcm(ongakukan_adp_t* handle)
+{
+    if (!handle) return;
+    close_streamfile(handle->sf);
+    free(handle->sample_hist);
+    free(handle);
+}
+
+void reset_all_ongakukan_adpcm(ongakukan_adp_t* handle)
+{
+    if (!handle) return;
+    /* wipe out certain values from handle so we can start over. */
+    handle->data_offset = handle->start_offset;
+    handle->sample_mode = 0;
+    handle->sample_has_base_setup_from_the_start = 1;
+    handle->alt_sample_work1 = 0;
+    handle->alt_sample_work2 = handle->sample_work;
+}
+
+void seek_ongakukan_adpcm_pos(ongakukan_adp_t* handle, long int target_sample)
+{
+    if (!handle) return;
+    /* for now, just do what reset_all_ongakukan_adpcm does but for the current sample instead of literally everything. */
+    if (handle->sound_is_adpcm == 0) { target_sample = target_sample << 1; }
+    else { target_sample = target_sample >> 1; }
+    handle->data_offset = handle->start_offset + target_sample;
+    handle->sample_mode = 0;
+    handle->sample_has_base_setup_from_the_start = 1;
+    handle->alt_sample_work1 = target_sample;
+    handle->alt_sample_work2 = handle->sample_work - target_sample;
+}
+
+long int grab_num_samples_from_ongakukan_adp(ongakukan_adp_t* handle)
+{
+    if (!handle) return 0;
+    return handle->sample_work;
+}
+
+long int grab_samples_filled_from_ongakukan_adp(ongakukan_adp_t* handle)
+{
+    if (!handle) return 0;
+    return handle->samples_filled;
+}
+
+void send_samples_filled_to_ongakukan_adp(long int samples_filled, ongakukan_adp_t* handle)
+{
+    if (!handle) return;
+    handle->samples_filled = samples_filled;
+}
+
+long int grab_samples_consumed_from_ongakukan_adp(ongakukan_adp_t* handle)
+{
+    if (!handle) return 0;
+    return handle->samples_consumed;
+}
+
+void send_samples_consumed_to_ongakukan_adp(long int samples_consumed, ongakukan_adp_t* handle)
+{
+    if (!handle) return;
+    handle->samples_consumed = samples_consumed;
+}
+
+void* grab_sample_hist_from_ongakukan_adp(ongakukan_adp_t* handle)
+{
+    if (!handle) return 0;
+    return &handle->sample_hist;
+}
+
+/* function definitions for the inner workings of codec data. */
+
+char set_up_sample_startpoint(ongakukan_adp_t* handle)
+{
+    /* malloc "sample hist" to 2 short ints */
+    handle->sample_hist = malloc(2 * sizeof(short int));
+
+    /* and make decoder fail hard if they don't have "sample hist" and opened streamfile object. */
+    if (!handle->sample_hist) return -1;
+    if (!handle->sf) return -1;
+
+    if (handle->sound_is_adpcm == 0) {
+        /* num_samples but for PCM16 sound data. */
+        handle->sample_work = handle->data_size >> 1;
+    }
+    else {
+        /* num_samples but for Ongakukan ADPCM sound data. */
+        handle->sample_work = handle->data_size << 1;
+    }
+    /* set "beginning" and "end" sample vars and send a "message" that we went through no sample yet.*/
+    handle->alt_sample_work1 = 0;
+    handle->alt_sample_work2 = handle->sample_work;
+    handle->sample_pair_is_decoded = 0;
+
+    return 1;
+}
+
+void decode_ongakukan_adp_data(ongakukan_adp_t* handle)
+{
+    /* set samples_filled to 0 and have our decoder go through every sample that exists in the sound data.*/
+    handle->samples_filled = 0;
+    decode_ongakukan_adpcm_sample(handle, handle->sample_hist);
+    /* if setup is established for further decoding, switch gears and have the decoder use that setup for as long as possible. */
+    if (handle->sample_has_base_setup_from_the_start == 1)
+    {
+        handle->sample_has_base_setup_from_the_start = 0;
+        handle->sample_mode = 1;
+    }
+    /* if sample pair is decoded, advance to next byte, tell our handle that we went through 2 samples and make decoder go through next available data again. */
+    if (handle->sample_pair_is_decoded == 1)
+    {
+        handle->data_offset++;
+        handle->alt_sample_work1 += 2;
+        handle->alt_sample_work2 -= 2;
+        handle->samples_consumed = 0;
+        handle->samples_filled += 2;
+        handle->sample_pair_is_decoded = 0;
+    }
+}
+
+void decode_ongakukan_adpcm_sample(ongakukan_adp_t* handle, short int* sample_hist)
+{
+    unsigned char nibble1 = 0, nibble2 = 0; /* two chars representing a 4-bit nibble. */
+    long int nibble1_1 = 0, nibble2_1 = 0; /* two long ints representing pure sample data. */
+
+    if (handle->sample_pair_is_decoded == 0)
+    {
+        /* sample_mode being 0 means we can just do a setup for future sample decoding so we have nothing to worry about in the future. */
+        if (handle->sample_mode == 0)
+        {
+            /* set "base scale", two "sample hist"s, and "base pair", respectively. */
+            handle->base_scale = 0x10; /* yes, this is how "base scale" is set; to 16. */
+            *(sample_hist+0) = 0; /* dereference first sample hist pos to something we can use. */
+            *(sample_hist+1) = 0; /* dereference second sample hist pos to something we can use. */
+            handle->base_pair = 0; /* set representing byte to 0 while we're at it. */
+        }
+        /* "pinch off" of a single-byte read. remember that we need two nibbles. */
+        (uint8_t)(handle->base_pair) = read_u8_wrapper(handle);
+
+        /* now pick two nibbles, subtract them, reverse the order of said nibbles so we can calc them one-by-one,
+         * and finally tell handle that we're done with two samples and would like to take a break, please. */
+        nibble1 = handle->base_pair & 0xf;
+        nibble1_1 = nibble1 + -8;
+        nibble2 = (handle->base_pair >> 4) & 0xf;
+        nibble2_1 = nibble2 + -8;
+        nibble2_1 = nibble2_1 * handle->base_scale;
+        *(sample_hist+0) = *(sample_hist+1) + nibble2_1;
+        handle->base_scale = (handle->base_scale * (ongakukan_adpcm_filter[nibble2])) >> 8;
+        nibble1_1 = nibble1_1 * handle->base_scale;
+        *(sample_hist+1) = *(sample_hist+0) + nibble1_1;
+        handle->base_scale = (handle->base_scale * (ongakukan_adpcm_filter[nibble1])) >> 8;
+        handle->sample_pair_is_decoded = 1;
+    }
+}
+
+/* streamfile read function definitions at the very bottom. */
+
+uint8_t read_u8_wrapper(ongakukan_adp_t* handle)
+{
+    /* if data_offset minus start_offset goes beyond data_size, return 0. */
+    if ((handle->data_offset - handle->start_offset) > handle->data_size) return 0;
+    /* if data_offset minus start_offset goes below 0, same. */
+    if ((handle->data_offset - handle->start_offset) < 0) return 0;
+    /* otherwise, read the byte from data_offset and see history get made. */
+    return read_u8((off_t)(handle->data_offset), handle->sf);
+}

--- a/src/coding/libs/ongakukan_adp_lib.c
+++ b/src/coding/libs/ongakukan_adp_lib.c
@@ -69,7 +69,7 @@ ongakukan_adp_t* boot_ongakukan_adpcm(STREAMFILE* sf, long int data_offset, long
     ongakukan_adp_t* handle = NULL;
 
     /* allocate handle using malloc. */
-    handle = malloc(sizeof(handle));
+    handle = malloc(sizeof(ongakukan_adp_t));
     if (!handle) goto fail;
 
     /* now, to set up the rest of the handle with the data we have... */

--- a/src/coding/libs/ongakukan_adp_lib.c
+++ b/src/coding/libs/ongakukan_adp_lib.c
@@ -1,14 +1,14 @@
 
 /* Decodes Ongakukan ADPCM, found in their PS2 and PSP games.
  * Basically their take on ADPCM with some companding and quantization involved.
- * 
- * Original decoder is a mix of COP0 and VU1 code, however PS2 floats aren't actually used (if at all) 
+ *
+ * Original decoder is a mix of COP0 and VU1 code, however PS2 floats aren't actually used (if at all)
  * when it comes to converting encoded sample data (consisting of a single byte with two 4-bit nibbles, respectively) to PCM16.
  *
  * The decoder you see here is a hand-crafted, faithful C adaptation of original MIPS R5900 (PS2) and R4000 (PSP) code, from various executables of their games.
  * As a consequence of all this, a new, entirely custom decoder had to be designed from the ground-up into vgmstream. No info surrounding this codec was available. */
 
-/* Additional notes: 
+/* Additional notes:
  * - This code does not support PCM16 sound data, in any way, shape, or form.
  * -- Ongakukan's internal sound engine from their PS2 and PSP games allow for only two codecs: signed PCM16, and their own take on ADPCM, respectively.
  * -- However, much of that support is reliant on a flag that's set to either one of the two codecs depending on the opened file extension.
@@ -60,7 +60,7 @@ uint8_t read_u8_wrapper(ongakukan_adp_t* handle);
 char set_up_sample_startpoint(ongakukan_adp_t* handle);
 void decode_ongakukan_adpcm_sample(ongakukan_adp_t* handle, short int* sample_hist);
 
-/* codec management functions, meant to oversee and supervise ADP data from the top-down. 
+/* codec management functions, meant to oversee and supervise ADP data from the top-down.
  * in layman terms, they control how ADP data should be handled and when. */
 
 ongakukan_adp_t* boot_ongakukan_adpcm(STREAMFILE* sf, long int data_offset, long int data_size,
@@ -69,7 +69,7 @@ ongakukan_adp_t* boot_ongakukan_adpcm(STREAMFILE* sf, long int data_offset, long
     ongakukan_adp_t* handle = NULL;
 
     /* allocate handle using malloc. */
-    handle = (ongakukan_adp_t*)malloc(sizeof(handle));
+    handle = malloc(sizeof(handle));
     if (!handle) goto fail;
 
     /* now, to set up the rest of the handle with the data we have... */

--- a/src/coding/libs/ongakukan_adp_lib.h
+++ b/src/coding/libs/ongakukan_adp_lib.h
@@ -28,4 +28,4 @@ void* grab_sample_hist_from_ongakukan_adp(ongakukan_adp_t* handle);
 /* function declaration for actually decoding samples, can't be that hard, right? */
 void decode_ongakukan_adp_data(ongakukan_adp_t* handle);
 
-#endif _ONGAKUKAN_ADP_LIB_
+#endif /* _ONGAKUKAN_ADP_LIB_ */

--- a/src/coding/libs/ongakukan_adp_lib.h
+++ b/src/coding/libs/ongakukan_adp_lib.h
@@ -1,0 +1,31 @@
+#ifndef _ONGAKUKAN_ADP_LIB_
+#define _ONGAKUKAN_ADP_LIB_
+
+/* Ongakukan ADP codec, found in PS2 and PSP games. */
+
+#include "../../util/reader_sf.h"
+
+/* typedef struct */
+typedef struct ongakukan_adp_t ongakukan_adp_t;
+
+/* function declaration for we need to set up the codec data. */
+ongakukan_adp_t* boot_ongakukan_adpcm(STREAMFILE* sf, long int data_offset, long int data_size,
+	char sample_needs_setup, char sample_has_base_setup_from_the_start);
+
+/* function declaration for freeing all memory related to ongakukan_adp_t struct var. */
+void free_all_ongakukan_adpcm(ongakukan_adp_t* handle);
+void reset_all_ongakukan_adpcm(ongakukan_adp_t* handle);
+void seek_ongakukan_adpcm_pos(ongakukan_adp_t* handle, long int target_sample);
+
+/* function declaration for when we need to get (and send) certain values from ongakukan_adp_t handle */
+long int grab_num_samples_from_ongakukan_adp(ongakukan_adp_t* handle);
+long int grab_samples_filled_from_ongakukan_adp(ongakukan_adp_t* handle);
+void send_samples_filled_to_ongakukan_adp(long int samples_filled, ongakukan_adp_t* handle);
+long int grab_samples_consumed_from_ongakukan_adp(ongakukan_adp_t* handle);
+void send_samples_consumed_to_ongakukan_adp(long int samples_consumed, ongakukan_adp_t* handle);
+void* grab_sample_hist_from_ongakukan_adp(ongakukan_adp_t* handle);
+
+/* function declaration for actually decoding samples, can't be that hard, right? */
+void decode_ongakukan_adp_data(ongakukan_adp_t* handle);
+
+#endif _ONGAKUKAN_ADP_LIB_

--- a/src/coding/ongakukan_adp_decoder.c
+++ b/src/coding/ongakukan_adp_decoder.c
@@ -1,6 +1,5 @@
 #include <stdlib.h>
 #include "coding.h"
-#include "coding_utils_samples.h"
 #include "libs/ongakukan_adp_lib.h"
 
 struct ongakukan_adp_data

--- a/src/coding/ongakukan_adp_decoder.c
+++ b/src/coding/ongakukan_adp_decoder.c
@@ -1,0 +1,97 @@
+#include <stdlib.h>
+#include "coding.h"
+#include "coding_utils_samples.h"
+#include "libs/ongakukan_adp_lib.h"
+
+struct ongakukan_adp_data
+{
+	void* handle;
+	//int32_t num_samples;
+	int16_t* samples;
+	int32_t samples_done;
+	int32_t samples_filled;
+	int32_t samples_consumed;
+	int32_t getting_samples;
+	STREAMFILE* sf;
+};
+
+ongakukan_adp_data* init_ongakukan_adp(STREAMFILE* sf, int32_t data_offset, int32_t data_size,
+	char sample_needs_setup, char sample_has_base_setup_from_the_start)
+{
+	ongakukan_adp_data* data = NULL;
+
+	data = calloc(1, sizeof(ongakukan_adp_data));
+	if (!data) goto fail;
+
+	data->sf = reopen_streamfile(sf, 0);
+	data->handle = boot_ongakukan_adpcm(data->sf, (long int)(data_offset), (long int)(data_size),
+		sample_needs_setup, sample_has_base_setup_from_the_start);
+	if (!data->handle) goto fail;
+
+	return data;
+fail:
+	free_ongakukan_adp(data);
+	return NULL;
+}
+
+void decode_ongakukan_adp(VGMSTREAM* vgmstream, sample_t* outbuf, int32_t samples_to_do)
+{
+	ongakukan_adp_data* data = vgmstream->codec_data;
+
+	data->samples_filled = (int32_t)grab_samples_filled_from_ongakukan_adp(data->handle);
+	data->samples_consumed = (int32_t)grab_samples_consumed_from_ongakukan_adp(data->handle);
+	data->samples = (int16_t*)grab_sample_hist_from_ongakukan_adp(data->handle);
+	while (data->samples_done < samples_to_do)
+	{
+		if (data->samples_filled)
+		{
+			data->getting_samples = data->samples_filled;
+			if (data->getting_samples > samples_to_do - data->samples_done)
+				data->getting_samples = samples_to_do - data->samples_done;
+
+			memcpy(outbuf + data->samples_done,
+				(void**)(data->samples) + data->samples_consumed,
+				data->getting_samples * sizeof(int16_t));
+			data->samples_done += data->getting_samples;
+
+			/* mark consumed samples. */
+			data->samples_consumed += data->getting_samples;
+			data->samples_filled -= data->getting_samples;
+
+			/* and keep the lib updated while doing so. */
+			send_samples_consumed_to_ongakukan_adp((long int)(data->samples_consumed), data->handle);
+			send_samples_filled_to_ongakukan_adp((long int)(data->samples_filled), data->handle);
+		}
+		else { decode_ongakukan_adp_data(data->handle);
+		data->samples_filled = (int32_t)grab_samples_filled_from_ongakukan_adp(data->handle);
+		data->samples_consumed = (int32_t)grab_samples_consumed_from_ongakukan_adp(data->handle);
+		data->samples = (int16_t*)grab_sample_hist_from_ongakukan_adp(data->handle); }
+	}
+}
+
+void reset_ongakukan_adp(ongakukan_adp_data* data)
+{
+	if (!data) return;
+	reset_all_ongakukan_adpcm(data->handle);
+}
+
+void seek_ongakukan_adp(ongakukan_adp_data* data, int32_t current_sample)
+{
+	if (!data) return;
+	seek_ongakukan_adpcm_pos(data->handle, current_sample);
+}
+
+void free_ongakukan_adp(ongakukan_adp_data* data)
+{
+	if (!data) return;
+	close_streamfile(data->sf);
+	free_all_ongakukan_adpcm(data->handle);
+	free(data->samples);
+	free(data);
+}
+
+int32_t ongakukan_adp_get_samples(ongakukan_adp_data* data)
+{
+	if (!data) return 0;
+	return (int32_t)(grab_num_samples_from_ongakukan_adp(data->handle));
+}

--- a/src/formats.c
+++ b/src/formats.c
@@ -893,6 +893,7 @@ static const coding_info coding_info_list[] = {
         {coding_ACM,                "InterPlay ACM"},
         {coding_CIRCUS_ADPCM,       "Circus 8-bit ADPCM"},
         {coding_UBI_ADPCM,          "Ubisoft 4/6-bit ADPCM"},
+        {coding_ONGAKUKAN_ADPCM,    "Ongakukan 4-bit ADPCM"},
 
         {coding_EA_MT,              "Electronic Arts MicroTalk"},
         {coding_CIRCUS_VQ,          "Circus VQ"},
@@ -1444,6 +1445,7 @@ static const meta_info meta_info_list[] = {
         {meta_VAS_ROCKSTAR,         "Rockstar .VAS header"},
         {meta_EA_SBK,               "Electronic Arts SBK header"},
         {meta_DSP_ASURA,            "Rebellion DSP header"},
+        {meta_ONGAKUKAN_RIFF_ADP,   "Ongakukan RIFF WAVE header"},
 };
 
 void get_vgmstream_coding_description(VGMSTREAM* vgmstream, char* out, size_t out_size) {

--- a/src/libvgmstream.vcxproj
+++ b/src/libvgmstream.vcxproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
@@ -85,6 +85,7 @@
     <ClInclude Include="api_helpers.h" />
     <ClInclude Include="api_streamfile.h" />
     <ClInclude Include="api_tags.h" />
+    <ClInclude Include="coding\libs\ongakukan_adp_lib.h" />
     <ClInclude Include="streamfile.h" />
     <ClInclude Include="streamtypes.h" />
     <ClInclude Include="util.h" />
@@ -206,7 +207,10 @@
     <ClInclude Include="util\zlib_vgmstream.h" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="coding\libs\ongakukan_adp_lib.c" />
+    <ClCompile Include="coding\ongakukan_adp_decoder.c" />
     <ClCompile Include="formats.c" />
+    <ClCompile Include="meta\adp_ongakukan.c" />
     <ClCompile Include="streamfile.c" />
     <ClCompile Include="util.c" />
     <ClCompile Include="vgmstream.c" />

--- a/src/libvgmstream.vcxproj.filters
+++ b/src/libvgmstream.vcxproj.filters
@@ -63,6 +63,15 @@
     <Filter Include="ext_libs\Header Files">
       <UniqueIdentifier>{20824073-8817-41CF-8A21-D54294A56050}</UniqueIdentifier>
     </Filter>
+    <Filter Include="coding\libs">
+      <UniqueIdentifier>{bda8b035-f70b-4601-b479-4403b1071fe4}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="coding\libs\Header Files">
+      <UniqueIdentifier>{eec1739b-a5e2-4202-98ff-e9fa2bd6ed00}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="coding\libs\Source Files">
+      <UniqueIdentifier>{5d980902-91bd-4e75-aa07-7da27edf5a99}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="api.h">
@@ -136,54 +145,6 @@
     </ClInclude>
     <ClInclude Include="coding\vorbis_custom_decoder.h">
       <Filter>coding\Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="coding\libs\circus_vq_data.h">
-      <Filter>coding\libs\Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="coding\libs\circus_vq_lib.h">
-      <Filter>coding\libs\Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="coding\libs\circus_vq_lzxpcm.h">
-      <Filter>coding\libs\Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="coding\libs\clhca.h">
-      <Filter>coding\libs\Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="coding\libs\compresswave_lib.h">
-      <Filter>coding\libs\Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="coding\libs\g7221_aes.h">
-      <Filter>coding\libs\Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="coding\libs\g7221_data.h">
-      <Filter>coding\libs\Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="coding\libs\g7221_lib.h">
-      <Filter>coding\libs\Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="coding\libs\icelib.h">
-      <Filter>coding\libs\Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="coding\libs\libacm.h">
-      <Filter>coding\libs\Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="coding\libs\nwa_lib.h">
-      <Filter>coding\libs\Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="coding\libs\relic_lib.h">
-      <Filter>coding\libs\Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="coding\libs\tac_data.h">
-      <Filter>coding\libs\Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="coding\libs\tac_lib.h">
-      <Filter>coding\libs\Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="coding\libs\tac_ops.h">
-      <Filter>coding\libs\Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="coding\libs\utkdec.h">
-      <Filter>coding\libs\Header Files</Filter>
     </ClInclude>
     <ClInclude Include="layout\layout.h">
       <Filter>layout\Header Files</Filter>
@@ -436,6 +397,57 @@
     </ClInclude>
     <ClInclude Include="util\zlib_vgmstream.h">
       <Filter>util\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="coding\libs\circus_vq_data.h">
+      <Filter>coding\libs\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="coding\libs\circus_vq_lib.h">
+      <Filter>coding\libs\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="coding\libs\circus_vq_lzxpcm.h">
+      <Filter>coding\libs\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="coding\libs\clhca.h">
+      <Filter>coding\libs\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="coding\libs\compresswave_lib.h">
+      <Filter>coding\libs\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="coding\libs\g7221_aes.h">
+      <Filter>coding\libs\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="coding\libs\g7221_data.h">
+      <Filter>coding\libs\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="coding\libs\g7221_lib.h">
+      <Filter>coding\libs\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="coding\libs\icelib.h">
+      <Filter>coding\libs\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="coding\libs\libacm.h">
+      <Filter>coding\libs\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="coding\libs\nwa_lib.h">
+      <Filter>coding\libs\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="coding\libs\ongakukan_adp_lib.h">
+      <Filter>coding\libs\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="coding\libs\relic_lib.h">
+      <Filter>coding\libs\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="coding\libs\tac_data.h">
+      <Filter>coding\libs\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="coding\libs\tac_lib.h">
+      <Filter>coding\libs\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="coding\libs\tac_ops.h">
+      <Filter>coding\libs\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="coding\libs\utkdec.h">
+      <Filter>coding\libs\Header Files</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
@@ -735,45 +747,6 @@
     </ClCompile>
     <ClCompile Include="coding\yamaha_decoder.c">
       <Filter>coding\Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="coding\libs\circus_vq_lib.c">
-      <Filter>coding\libs\Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="coding\libs\clhca.c">
-      <Filter>coding\libs\Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="coding\libs\compresswave_lib.c">
-      <Filter>coding\libs\Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="coding\libs\g7221_aes.c">
-      <Filter>coding\libs\Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="coding\libs\g7221_lib.c">
-      <Filter>coding\libs\Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="coding\libs\icelib.c">
-      <Filter>coding\libs\Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="coding\libs\libacm_decode.c">
-      <Filter>coding\libs\Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="coding\libs\libacm_util.c">
-      <Filter>coding\libs\Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="coding\libs\nwa_lib.c">
-      <Filter>coding\libs\Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="coding\libs\relic_lib.c">
-      <Filter>coding\libs\Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="coding\libs\relic_mixfft.c">
-      <Filter>coding\libs\Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="coding\libs\tac_lib.c">
-      <Filter>coding\libs\Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="coding\libs\utkdec.c">
-      <Filter>coding\libs\Source Files</Filter>
     </ClCompile>
     <ClCompile Include="layout\blocked.c">
       <Filter>layout\Source Files</Filter>
@@ -2229,6 +2202,54 @@
     </ClCompile>
     <ClCompile Include="util\text_reader.c">
       <Filter>util\Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="meta\adp_ongakukan.c">
+      <Filter>meta\Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="coding\ongakukan_adp_decoder.c">
+      <Filter>coding\Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="coding\libs\circus_vq_lib.c">
+      <Filter>coding\libs\Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="coding\libs\clhca.c">
+      <Filter>coding\libs\Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="coding\libs\compresswave_lib.c">
+      <Filter>coding\libs\Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="coding\libs\g7221_aes.c">
+      <Filter>coding\libs\Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="coding\libs\g7221_lib.c">
+      <Filter>coding\libs\Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="coding\libs\icelib.c">
+      <Filter>coding\libs\Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="coding\libs\libacm_decode.c">
+      <Filter>coding\libs\Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="coding\libs\libacm_util.c">
+      <Filter>coding\libs\Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="coding\libs\nwa_lib.c">
+      <Filter>coding\libs\Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="coding\libs\ongakukan_adp_lib.c">
+      <Filter>coding\libs\Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="coding\libs\relic_lib.c">
+      <Filter>coding\libs\Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="coding\libs\relic_mixfft.c">
+      <Filter>coding\libs\Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="coding\libs\tac_lib.c">
+      <Filter>coding\libs\Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="coding\libs\utkdec.c">
+      <Filter>coding\libs\Source Files</Filter>
     </ClCompile>
   </ItemGroup>
 </Project>

--- a/src/meta/adp_ongakukan.c
+++ b/src/meta/adp_ongakukan.c
@@ -1,0 +1,116 @@
+#include "meta.h"
+#include "../coding/coding.h"
+
+/* Ongakukan RIFF with "ADP" extension [Train Simulator - Midousuji-sen (PS2)] */
+VGMSTREAM* init_vgmstream_ongakukan_adp(STREAMFILE* sf)
+{
+	VGMSTREAM* vgmstream = NULL;
+	off_t start_offset;
+	size_t file_size;
+	int has_data_chunk = 0, has_fact_chunk = 0, found_start_offset = 0;
+	int loop_flag = 0;
+	int riff_wave_header_size = 0x2c;
+	char sound_is_adpcm = 0, sample_has_base_setup_from_the_start = 0;
+	/* ^ the entire RIFF WAVE header size, set to this fixed number
+	 * because *surprise* this is also how sound data begins. */
+	int32_t fmt_size, fmt_offset, offset_of_supposed_last_chunk;
+	int32_t sample_rate, bitrate, data_size;
+	int16_t num_channels, block_size;
+
+	/* RIFF+WAVE checks */
+	if (!is_id32be(0x00, sf, "RIFF")) goto fail;
+	if (!is_id32be(0x08, sf, "WAVE")) goto fail;
+	/* WAVE "fmt " check */
+	if (!is_id32be(0x0c, sf, "fmt ")) goto fail;
+	/* "adp" extension check (literally only one) */
+	if (!check_extensions(sf, "adp")) goto fail;
+	
+	/* catch adp file size from here and use it whenever needed. */
+	file_size = get_streamfile_size(sf);
+
+	/* RIFF size from adp file (e.g: 10MB) can go beyond actual adp file size (e.g: 2MB),
+	 * have vgmstream call it quits if the former is reported to be less than the latter. */
+	if (read_s32le(0x04, sf) < file_size) goto fail;
+
+	/* read entire WAVE "fmt " chunk. we start by reading fmt_size from yours truly and setting fmt_offset. */
+	fmt_size = read_s32le(0x10, sf);
+	fmt_offset = 0x14;
+	if ((fmt_size > 0x10) && (fmt_size < 0x13)) /* fmt_size is mostly 0x10, rarely 0x12 */
+	{
+		if (read_s16le(fmt_offset + 0, sf) != 1) goto fail; /* chunk reports codec number as signed little-endian PCM, couldn't be more wrong. */
+		num_channels = read_s16le(fmt_offset + 2, sf);
+		sample_rate = read_s32le(fmt_offset + 4, sf);
+		bitrate = read_s32le(fmt_offset + 8, sf);
+		/* ^ yes, this is technically correct, tho does not reflect actual data.
+		 * chunk reports bitrate as if it was a 16-bit PCM file. */
+		block_size = read_s16le(fmt_offset + 12, sf); /* mostly 2, rarely 4. */
+		if (read_s16le(fmt_offset + 14, sf) != 0x10) goto fail; /* bit depth as chunk reports it. */
+		/* additional checks, this time with bitrate field in the chunk. */
+		if (bitrate != (sample_rate * block_size)) goto fail;
+		/* if fmt_size == 0x12 there is an additional s16 field that goes unused. */
+	}
+	else {
+		goto fail;
+	}
+
+	/* now calc the var so we can read either "data" or "fact" chunk; */
+	offset_of_supposed_last_chunk = fmt_offset + fmt_size;
+
+	/* then read either one of the two chunks, both cannot co-exist it seems.
+	 * while there, we set start_offset by themselves instead of relying on both chunks to do so.
+	 * see comments for code handling both chunks below for more info. */
+	if (is_id32be(offset_of_supposed_last_chunk + 0, sf, "data")) has_data_chunk = 1;
+	if (is_id32be(offset_of_supposed_last_chunk + 0, sf, "fact")) has_fact_chunk = 1;
+
+	/* and because sound data *must* start at 0x2c, they have to bork both chunks too, so they're now essentially useless. 
+	 * well, except for trying to deduct how many samples a sound actually has*/
+	if (has_data_chunk)
+	{
+		/* RIFF adp files have borked "data" chunk so much it's not even remotely useful for... well, *anything*, really.
+		 * it doesn't report actual data size as RIFF WAVE files usually do, instead we're left with basically RIFF size with ~50 less numbers now. */
+		if (read_s32le(offset_of_supposed_last_chunk + 4, sf) < file_size) goto fail;
+		/* ^ reported data size is meant to be bigger than actual adp size, have vgmstream throw out the towel if it isn't. */
+	}
+
+	if (has_fact_chunk)
+	{
+		/* RIFF adp files also borked "fact" chunk so it no longer reports useful info.
+		 * instead it just leaves out a s16 field containing a static number. */
+		if (read_s16le(offset_of_supposed_last_chunk + 4, sf) != 4) goto fail;
+		/* ^ this number is supposed to be 4, have vgmstream ragequit if it isn't. */
+	}
+
+	/* set start_offset value to riff_wave_header_size
+	 * and calculate data_size by ourselves */
+	start_offset = riff_wave_header_size;
+	data_size = (int32_t)(file_size) - riff_wave_header_size;
+
+	/* Ongagukan games using this format just read it by checking "ADP" extension
+	 * in an provided file name of a programmer's own choosing,
+	 * and if it's there they just read the reported "number of samples" and sample_rate from RIFF WAVE "fmt " chunk 
+	 * based on an already-opened file with that same name.
+	 * they also calculate start_offset and data_size in much the same manner. */
+
+	 /* silly flags, needed to init our custom decoder. */
+	sound_is_adpcm = 1;
+	sample_has_base_setup_from_the_start = 1;
+
+	/* build the VGMSTREAM */
+	vgmstream = allocate_vgmstream(num_channels, loop_flag);
+	if (!vgmstream) goto fail;
+
+	vgmstream->meta_type = meta_ONGAKUKAN_RIFF_ADP;
+	vgmstream->sample_rate = sample_rate;
+	vgmstream->codec_data = init_ongakukan_adp(sf, start_offset, data_size, sound_is_adpcm, sample_has_base_setup_from_the_start);
+	if (!vgmstream->codec_data) goto fail;
+	vgmstream->coding_type = coding_ONGAKUKAN_ADPCM;
+	vgmstream->layout_type = layout_none;
+	vgmstream->num_samples = ongakukan_adp_get_samples(vgmstream->codec_data);
+
+	if (!vgmstream_open_stream(vgmstream, sf, start_offset))
+		goto fail;
+	return vgmstream;
+fail:
+	close_vgmstream(vgmstream);
+	return NULL;
+}

--- a/src/meta/meta.h
+++ b/src/meta/meta.h
@@ -1018,4 +1018,6 @@ VGMSTREAM* init_vgmstream_ea_sbk(STREAMFILE* sf);
 
 VGMSTREAM* init_vgmstream_dsp_asura_sfx(STREAMFILE* sf);
 
+VGMSTREAM* init_vgmstream_ongakukan_adp(STREAMFILE* sf);
+
 #endif /*_META_H*/

--- a/src/vgmstream.c
+++ b/src/vgmstream.c
@@ -533,6 +533,7 @@ init_vgmstream_t init_vgmstream_functions[] = {
     init_vgmstream_dsp_asura_ds2,
     init_vgmstream_dsp_asura_ttss,
     init_vgmstream_dsp_asura_sfx,
+    init_vgmstream_ongakukan_adp,
 
     /* lower priority metas (no clean header identity, somewhat ambiguous, or need extension/companion file to identify) */
     init_vgmstream_agsc,

--- a/src/vgmstream_types.h
+++ b/src/vgmstream_types.h
@@ -136,6 +136,7 @@ typedef enum {
     coding_ACM,             /* InterPlay ACM */
     coding_CIRCUS_ADPCM,    /* Circus 8-bit ADPCM */
     coding_UBI_ADPCM,       /* Ubisoft 4/6-bit ADPCM */
+    coding_ONGAKUKAN_ADPCM, /* Ongakukan 4-bit ADPCM */
 
     coding_EA_MT,           /* Electronic Arts MicroTalk (linear-predictive speech codec) */
     coding_CIRCUS_VQ,       /* Circus VQ */
@@ -710,6 +711,7 @@ typedef enum {
     meta_VAS_ROCKSTAR,
     meta_EA_SBK,
     meta_DSP_ASURA,
+    meta_ONGAKUKAN_RIFF_ADP,
 
 } meta_t;
 


### PR DESCRIPTION
Created by Ongakukan and used starting with Train Simuator Midousuji-hen on the PS2, it became their sound codec of choice for most of their PS2 and PSP games.

For various reasons, a custom decoder had to be created. Though I consider all work on this finished, it was a PITA to debug properly on VS2022 owing to some... creative decisions I had to take while making a decoder like this, plus I just couldn't debug libvgmstream project on it as I had vgmstream_cli set as the sole startup project on the whole vgmstream_full solution.

Some memory from the decoder also couldn't be freed as exception errors were plentiful while debugging in VS2022, despite the free function being called many times over.

I'm also currently aware of failed build tests happening except for Windows (Visual Studio) build and will be fixed shortly.

All of the above issues are my sole responsibility. That said, I'm currently welcoming some feedback into this one as this is my first time doing a large-scale PR like this.