### PR TITLE
Fix processing of unmodified 3DS BCSTM streams from Camelot

### DIFF
--- a/src/layout/interleave.c
+++ b/src/layout/interleave.c
@@ -147,6 +147,13 @@ void render_vgmstream_interleave(sample_t * buffer, int32_t sample_count, VGMSTR
                 }
             }
 
+            if (vgmstream->broken_interleave_sample_count != 0 && vgmstream->current_sample == vgmstream->broken_interleave_sample_pos) {
+                samples_per_frame = samples_per_frame_d;
+                for (ch = 0; ch < vgmstream->channels; ch++) {
+                    vgmstream->ch[ch].offset += vgmstream->broken_interleave_sample_count / samples_per_frame;
+                }
+            }
+
             vgmstream->samples_into_block = 0;
         }
     }

--- a/src/vgmstream.h
+++ b/src/vgmstream.h
@@ -173,6 +173,10 @@ typedef struct {
     size_t interleave_last_block_size; /* smaller interleave for last block */
     size_t frame_size;              /* for codecs with configurable size */
 
+    /* offset hacks */
+    size_t broken_interleave_sample_pos;    /* Data offset at which to skip over faulty samples (used with Camelot 3DS bcstm streams) */
+    size_t broken_interleave_sample_count;  /* Number of faulty bytes to skip (used with Camelot 3DS bcstm streams) */
+
     /* subsong config */
     int num_streams;                /* for multi-stream formats (0=not set/one stream, 1=one stream) */
     int stream_index;               /* selected subsong (also 1-based) */


### PR DESCRIPTION
This PR properly addresses the audio corruption issues that take place in Camelot's BCSTM format (notably with Mario Golf: World Tour). Previously, the code for this hacked around the original loop points to not-so-successfully dodge misaligned interleave issues in Mario Golf, additionally affecting other less problematic games like Mario Tennis Open as a result. I've tested this PR against every single stream from both games and have confirmed that every single one loops correctly, and while using their original loop points.

This PR contains a couple of drawbacks that may require additional consideration:
- This adds two new fields to the `VGMSTREAM` struct, as I personally didn't have any good ideas on how to implement a fix without making changes to it. Any better suggestions are welcome!
- Mario Golf: World Tour's BCSTM rip on the joshw frontend has been modified some time ago with streams that remove the problematic data (which I admittedly didn't know about before I investigated this). When/if this gets merged, that rip will need to be re-updated to use the unmodified streams.