### PR TITLE
Sony BNK: 0x23 codec fixes and ZLSD support

### DIFF
--- a/src/meta/bnk_sony.c
+++ b/src/meta/bnk_sony.c
@@ -1094,7 +1094,7 @@ static bool process_data(STREAMFILE* sf, bnk_header_t* h) {
 
             h->stream_size = read_u64(info_offset + 0x00,sf); /* after this offset */
             h->stream_size += 0x08 + stream_name_size + 0x08;
-            /* 0x08: 0/1 for PCM (Mono/Stereo?), 0/1/2/3 for ATRAC9 (channels/2 except mono=0?) */
+            /* 0x08: 0/1 for PCM (Mono/Stereo?), 0/1/2/3 for ATRAC9 (channels/2)? */
             subtype = read_u16(info_offset + 0x0a, sf);
             /* 0x0c: always 1 - using this to detect whether it's an SBlk or ZLSD/exteral sound for now */
             extradata_size = read_u64(info_offset + 0x10,sf) + 0x08 + stream_name_size + 0x18;
@@ -1206,7 +1206,11 @@ static bool process_zlsd(STREAMFILE* sf, bnk_header_t* h) {
     h->stream_size = read_u32(zlsd_table_entry_offset + 0x0C, sf);
 
     /* should be a switch case, but no other formats known yet */
-    if (!is_id32be(h->start_offset, sf, "XVAG")) goto fail;
+    if (!is_id32be(h->start_offset, sf, "XVAG")) {
+        /* maybe also a separate warning if XVAG returns more than 1 subsong? */
+        vgm_logi("BNK: unsupported ZLSD subtype found (report)\n");
+        goto fail;
+    }
 
     h->codec = XVAG_ATRAC9;
     h->channels = 1; /* dummy, real channels will be retrieved from xvag/riff */

--- a/src/meta/bnk_sony.c
+++ b/src/meta/bnk_sony.c
@@ -384,9 +384,10 @@ static bool process_tables(STREAMFILE* sf, bnk_header_t* h) {
             h->table2_suboffset = 0x00;
             break;
 
-        /* later version have a few more tables (some optional) and work slightly differently (header is part of wave) */
+        /* later versions have a few more tables (some optional) and work slightly differently (header is part of wave) */
         case 0x1a: /* Demon's Souls (PS5) */
         case 0x23: { /* The Last of Us (PC) */
+            uint32_t bank_name_offset = h->sblk_offset + (h->sblk_version <= 0x1a ? 0x1c : 0x20);
             uint32_t tables_offset = h->sblk_offset + (h->sblk_version <= 0x1a ? 0x120 : 0x128);
             uint32_t counts_offset = tables_offset + (h->sblk_version <= 0x1a ? 0x98 : 0xb0);
 
@@ -396,6 +397,8 @@ static bool process_tables(STREAMFILE* sf, bnk_header_t* h) {
           //h->sounds_entries   = read_u16(counts_offset+0x00,sf);
           //h->grains_entries   = read_u16(counts_offset+0x02,sf);
             h->stream_entries   = read_u16(counts_offset+0x06,sf);
+
+            read_string(h->bank_name, STREAM_NAME_SIZE, bank_name_offset, sf);
             break;
         }
 


### PR DESCRIPTION
- Moved bank/stream names to be read ASAP, per todo
- Added 0x23 PCM support
- ~~Skip 0x1A/0x23 dummy entries (mostly because it made adding ZLSD much easier)~~
- Added ZLSD chunk subsong support

Most if not all the ZLSD sounds appear to only have ~1s of actual audio, even if the duration is longer.  Guess these are intended to be as some sort of preload/cache for the real external XVAG sounds that are referenced in SBlk?

As for detecting whether it's an internal or external sound, for now the most reliable way I saw was the stream header having a pattern of 2x16-bit codec and channels/2 followed by a seemingly always constant 32-bit 0x01 which goes all the way back to v12.  And the earliest file I have on hand that contains ZLSD is v15.  For external streams it'd just read that value from the stream name of the next file, or 0x00 if it's the last one.  It may not be the "correct" way to do it, but it at least works for v35 files with both SBlk+ZLSD and ZLSD-only streams.
(You're probably meant to hash the external filenames and look it up in ZLSD by that, but eh.  There are typically way more SBlk external entries than there are ZLSD entries.  See vox-joel.bnk for example - 2516 total entries, 29 SBlk streams, 313 dummy, 2174 external references, 187 ZLSD streams)