### PR TITLE
mixing_macros.c: Fix integer division

### DIFF
--- a/src/base/mixing_macros.c
+++ b/src/base/mixing_macros.c
@@ -475,7 +475,7 @@ void mixing_macro_downmix(VGMSTREAM* vgmstream, int max /*, mapping_t output_map
     channel_mapping_t input_mapping, output_mapping;
     const double vol_max = 1.0;
     const double vol_sqrt = 1 / sqrt(2);
-    const double vol_half = 1 / 2;
+    const double vol_half = 0.5;
     double matrix[16][16] = {{0}};
 
 


### PR DESCRIPTION
Use literal `0.5` instead of flawed integer division which resulted in zero.