### PR TITLE
build: fix build without vorbis and mpeg

### DIFF
--- a/src/coding/vorbis_custom_decoder.h
+++ b/src/coding/vorbis_custom_decoder.h
@@ -52,13 +52,12 @@ int vorbis_custom_parse_packet_ogl(VGMSTREAMCHANNEL* stream, vorbis_custom_codec
 int vorbis_custom_parse_packet_sk(VGMSTREAMCHANNEL* stream, vorbis_custom_codec_data* data);
 int vorbis_custom_parse_packet_vid1(VGMSTREAMCHANNEL* stream, vorbis_custom_codec_data* data);
 int vorbis_custom_parse_packet_awc(VGMSTREAMCHANNEL* stream, vorbis_custom_codec_data* data);
-#endif/* VGM_USE_VORBIS */
 
 /* other utils to make/parse vorbis stuff */
 int build_header_comment(uint8_t* buf, int bufsize);
 int build_header_identification(uint8_t* buf, int bufsize, vorbis_custom_config* cfg);
 void load_blocksizes(vorbis_custom_config* cfg, int blocksize_short, int blocksize_long);
 bool load_header_packet(STREAMFILE* sf, vorbis_custom_codec_data* data, uint32_t packet_size, int packet_skip, uint32_t* p_offset);
-
+#endif/* VGM_USE_VORBIS */
 
 #endif/*_VORBIS_CUSTOM_DECODER_H_ */

--- a/src/meta/awc_streamfile.h
+++ b/src/meta/awc_streamfile.h
@@ -181,6 +181,7 @@ static uint32_t get_block_repeated_size(STREAMFILE* sf, awc_block_info_t* bi, in
             /* when data repeats seems to clone the last (super-)frame */
             return bi->blk[channel].frame_size;
 
+#ifdef VGM_USE_MPEG
         case 0x07: { /* MPEG */
             /* first super-frame will repeat N VBR old sub-frames, without crossing frame_size.
              * In GTA5 repeated sub-frames seems to match exactly repeated samples, while RDR seems to match 1 full frame (like RAGE-aud).
@@ -218,7 +219,7 @@ static uint32_t get_block_repeated_size(STREAMFILE* sf, awc_block_info_t* bi, in
 
             return skip_size; /* skip_size fills frame size */
         }
-
+#endif
         case 0x0D: /* OPUS */
         case 0x0F: /* ATRAC9 */
         default: 

--- a/src/meta/rage_aud_streamfile.h
+++ b/src/meta/rage_aud_streamfile.h
@@ -162,6 +162,7 @@ static uint32_t get_block_repeated_size(STREAMFILE* sf, rage_aud_block_info_t* b
             return bi->blk[channel].frame_size;
         }
 
+#ifdef VGM_USE_MPEG
         case 0x0100: { /* MPEG */
             /* first super-frame will repeat N VBR old sub-frames, without crossing frame_size.
              * ex. repeated frames' size could be set to 0x774 (7 sub-frames) if adding 1 more would take >0x800.
@@ -189,7 +190,7 @@ static uint32_t get_block_repeated_size(STREAMFILE* sf, rage_aud_block_info_t* b
 
             return skip_size; /* skip_size fills frame size */
         }
-
+#endif
         default: 
             ;VGM_LOG("RAGE_AUD: found channel skip in codec %x\n", bi->codec); /* not seen */
             return 0;


### PR DESCRIPTION
Prevent code that uses optional library from being compiled.