### PR TITLE
Add preliminary Nintendo Alarmo SHAA/SHSA support

### DIFF
--- a/src/formats.c
+++ b/src/formats.c
@@ -524,6 +524,8 @@ static const char* extension_list[] = {
     "sgb",
     "sgd",
     "sgt",
+    "shaa",
+    "shsa",
     "skx",
     "slb", //txth/reserved [THE Nekomura no Hitobito (PS2)]
     "sli",
@@ -1466,6 +1468,7 @@ static const meta_info meta_info_list[] = {
         {meta_XABP,                 "cavia XABp header"},
         {meta_I3DS,                 "Codemasters i3DS header"},
         {meta_AXHD,                 "Angel Studios AXHD header"},
+        {meta_SHAA,                 "Nintendo Alarmo SHAA header"}
 };
 
 void get_vgmstream_coding_description(VGMSTREAM* vgmstream, char* out, size_t out_size) {

--- a/src/libvgmstream.vcxproj
+++ b/src/libvgmstream.vcxproj
@@ -686,6 +686,7 @@
     <ClCompile Include="meta\sfh.c" />
     <ClCompile Include="meta\sfl.c" />
     <ClCompile Include="meta\sgxd.c" />
+    <ClCompile Include="meta\shaa.c" />
     <ClCompile Include="meta\silence.c" />
     <ClCompile Include="meta\skex.c" />
     <ClCompile Include="meta\sk_aud.c" />

--- a/src/libvgmstream.vcxproj.filters
+++ b/src/libvgmstream.vcxproj.filters
@@ -1888,6 +1888,9 @@
     <ClCompile Include="meta\sgxd.c">
       <Filter>meta\Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="meta\shaa.c">
+      <Filter>meta\Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="meta\silence.c">
       <Filter>meta\Source Files</Filter>
     </ClCompile>

--- a/src/meta/meta.h
+++ b/src/meta/meta.h
@@ -1028,4 +1028,6 @@ VGMSTREAM* init_vgmstream_skex(STREAMFILE* sf);
 
 VGMSTREAM* init_vgmstream_axhd(STREAMFILE* sf);
 
+VGMSTREAM* init_vgmstream_shaa(STREAMFILE* sf);
+
 #endif

--- a/src/meta/shaa.c
+++ b/src/meta/shaa.c
@@ -1,0 +1,66 @@
+#include "meta.h"
+#include "../coding/coding.h"
+
+/* SHAA/SHSA: Audio format for Nintendo Sound Clock: Alarmo */
+VGMSTREAM* init_vgmstream_shaa(STREAMFILE* sf) {
+    VGMSTREAM* vgmstream = NULL;
+    uint32_t start_offset, info_offset, adpcm_offset;
+    int channels, loop_flag, loop_start, loop_end, codec;
+
+    /* Validate header */
+    if (!is_id32be(0x00, sf, "SHAA"))
+        goto fail;
+
+    /* Validate extension */
+    if (!check_extensions(sf, "shaa,shsa"))
+        goto fail;
+
+    info_offset = 0x10;
+
+    codec = read_u8(info_offset + 0x00, sf);
+    channels = 1;   // Not sure if file is stereo or mono, so assuming mono for now
+
+    start_offset = read_u32le(0x08, sf);
+
+    /* Loop start and end points */
+    loop_start = read_s32le(info_offset + 0x14, sf);
+    loop_end = read_s32le(info_offset + 0x18, sf);
+    loop_flag = loop_start + loop_end;  // Loop flag is 0 if loop start and loop end are both 0
+
+    /* Alloc vgmstream */
+    vgmstream = allocate_vgmstream(channels, loop_flag);
+    if (!vgmstream) goto fail;
+
+    vgmstream->meta_type = meta_SHAA;
+
+    vgmstream->sample_rate = read_u16le(info_offset + 0x04, sf);
+    vgmstream->num_samples = read_s32le(info_offset + 0x08, sf);
+    vgmstream->loop_start_sample = loop_start;
+    vgmstream->loop_end_sample = loop_end;
+
+
+    vgmstream->layout_type = layout_none;
+    switch (codec) {
+    case 1: // PCM16LE: Seen in "factory" sound files
+        vgmstream->coding_type = coding_PCM16LE;
+        break;
+    case 2: // NGC DSP: Used for everything else
+        vgmstream->coding_type = coding_NGC_DSP;
+        break;
+    default:
+        goto fail;
+    }
+
+    if (vgmstream->coding_type == coding_NGC_DSP) {
+        adpcm_offset = read_u32le(info_offset + 0x0C, sf);
+        dsp_read_coefs_le(vgmstream, sf, adpcm_offset + 0x1C, 0);   // 0 spacing because there's only 1 channel
+    }
+
+    if (!vgmstream_open_stream(vgmstream, sf, start_offset))
+        goto fail;
+    return vgmstream;
+
+fail:
+    close_vgmstream(vgmstream);
+    return NULL;
+}

--- a/src/vgmstream_init.c
+++ b/src/vgmstream_init.c
@@ -518,6 +518,7 @@ init_vgmstream_t init_vgmstream_functions[] = {
     init_vgmstream_sdbs,
     init_vgmstream_skex,
     init_vgmstream_axhd,
+    init_vgmstream_shaa,
 
     /* lower priority metas (no clean header identity, somewhat ambiguous, or need extension/companion file to identify) */
     init_vgmstream_agsc,

--- a/src/vgmstream_types.h
+++ b/src/vgmstream_types.h
@@ -717,7 +717,7 @@ typedef enum {
     meta_XABP,
     meta_I3DS,
     meta_AXHD,
-
+    meta_SHAA           /* Nintendo Alarmo SHAA */
 } meta_t;
 
 #endif


### PR DESCRIPTION
This PR adds support for the SHAA audio format used by Nintendo Sound Clock: Alarmo, an alarm clock released by Nintendo in October of 2024.