### PR TITLE
BAF: various fixes

### DIFF
--- a/src/meta/baf.c
+++ b/src/meta/baf.c
@@ -4,27 +4,25 @@
 
 
 /* .BAF - Bizarre Creations bank file [Blur (PS3), Project Gotham Racing 4 (X360), Geometry Wars (PC)] */
-VGMSTREAM * init_vgmstream_baf(STREAMFILE *sf) {
-    VGMSTREAM * vgmstream = NULL;
+VGMSTREAM* init_vgmstream_baf(STREAMFILE* sf) {
+    VGMSTREAM* vgmstream = NULL;
+    char bank_name[0x22+1], stream_name[0x20+1], file_name[STREAM_NAME_SIZE];
     off_t start_offset, header_offset, name_offset;
     size_t stream_size;
     uint32_t channel_count, sample_rate, num_samples, version, codec, tracks;
-    int loop_flag, total_subsongs, target_subsong = sf->stream_index;
+    int big_endian, loop_flag, total_subsongs, target_subsong = sf->stream_index;
     read_u32_t read_u32;
 
     /* checks */
     if (!is_id32be(0x00, sf, "BANK"))
-        goto fail;
+        return NULL;
 
     if (!check_extensions(sf, "baf"))
-        goto fail;
+        return NULL;
 
     /* use BANK size to check endianness */
-    if (guess_endian32(0x04,sf)) {
-        read_u32 = read_u32be;
-    } else {
-        read_u32 = read_u32le;
-    }
+    big_endian = guess_endian32(0x04, sf);
+    read_u32 = big_endian ? read_u32be : read_u32le;
 
     /* 0x04: bank size */
     version = read_u32(0x08,sf);
@@ -69,7 +67,7 @@ VGMSTREAM * init_vgmstream_baf(STREAMFILE *sf) {
     tracks = 0;
 
     switch(codec) {
-        case 0x03: /* PCM16LE */
+        case 0x03: /* PCM16 */
             switch(version) {
                 case 0x03: /* Geometry Wars (PC) */
                     sample_rate     = read_u32(header_offset+0x38, sf);
@@ -81,7 +79,13 @@ VGMSTREAM * init_vgmstream_baf(STREAMFILE *sf) {
                 case 0x04: /* Project Gotham Racing 4 (X360) */
                     sample_rate     = read_u32(header_offset+0x3c, sf);
                     channel_count   = read_u32(header_offset+0x44, sf);
-                    loop_flag       = read_u8(header_offset+0x4b, sf);
+                    loop_flag       =  read_u8(header_offset+0x4b, sf);
+                    break;
+
+                case 0x05: /* Blur 2 (X360) */
+                    sample_rate     = read_u32(header_offset+0x40, sf);
+                    channel_count   = read_u32(header_offset+0x48, sf);
+                    loop_flag       =  read_u8(header_offset+0x50, sf) != 0;
                     break;
 
                 default:
@@ -93,14 +97,14 @@ VGMSTREAM * init_vgmstream_baf(STREAMFILE *sf) {
 
         case 0x07: /* PSX ADPCM (0x21 frame size) */
             if (version == 0x04 && read_u32(header_offset + 0x3c, sf) != 0) {
-                /* Blur (Prototype) (PS3) */
+                /* The Club (PS3), Blur (Prototype) (PS3) */
                 sample_rate     = read_u32(header_offset+0x3c, sf);
                 channel_count   = read_u32(header_offset+0x44, sf);
                 loop_flag       =  read_u8(header_offset+0x4b, sf);
 
                 /* mini-header at the start of the stream */
-                num_samples     = read_u32le(start_offset+0x04, sf) / 0x02; /* PCM size? */
-                start_offset   += read_u32le(start_offset+0x00, sf);
+                num_samples     = read_u32le(start_offset+0x04, sf) / channel_count;
+                start_offset   += read_u32le(start_offset+0x00, sf); /* 0x08 */
                 break;
             }
 
@@ -117,6 +121,7 @@ VGMSTREAM * init_vgmstream_baf(STREAMFILE *sf) {
                         channel_count = channel_count * tracks;
                     }
                     break;
+
                 default:
                     goto fail;
             }
@@ -131,6 +136,25 @@ VGMSTREAM * init_vgmstream_baf(STREAMFILE *sf) {
                     break;
 
                 case 0x05: /* James Bond 007: Blood Stone (X360) */
+                    sample_rate     = read_u32(header_offset+0x40, sf);
+                    channel_count   = read_u32(header_offset+0x48, sf);
+                    loop_flag       =  read_u8(header_offset+0x58, sf) != 0;
+                    break;
+
+                default:
+                    goto fail;
+            }
+            break;
+
+        case 0x09: /* XMA2 */
+            switch(version) {
+                case 0x04: /* Blur (X360) */
+                    sample_rate     = read_u32(header_offset+0x3c, sf);
+                    channel_count   = read_u32(header_offset+0x44, sf);
+                    loop_flag       =  read_u8(header_offset+0x54, sf) != 0;
+                    break;
+
+                case 0x05: /* Blur 2 (X360) */
                     sample_rate     = read_u32(header_offset+0x40, sf);
                     channel_count   = read_u32(header_offset+0x48, sf);
                     loop_flag       =  read_u8(header_offset+0x58, sf) != 0;
@@ -160,7 +184,7 @@ VGMSTREAM * init_vgmstream_baf(STREAMFILE *sf) {
 
     switch(codec) {
         case 0x03:
-            vgmstream->coding_type = coding_PCM16LE;
+            vgmstream->coding_type = big_endian ? coding_PCM16BE : coding_PCM16LE;
             vgmstream->layout_type = layout_interleave;
             vgmstream->interleave_block_size = 0x02;
 
@@ -179,7 +203,7 @@ VGMSTREAM * init_vgmstream_baf(STREAMFILE *sf) {
             vgmstream->loop_end_sample = num_samples;
             break;
 
-    #ifdef VGM_USE_FFMPEG
+#ifdef VGM_USE_FFMPEG
         case 0x08: {
             vgmstream->codec_data = init_ffmpeg_xma1_raw(sf, start_offset, stream_size, vgmstream->channels, vgmstream->sample_rate, 0);
             if (!vgmstream->codec_data) goto fail;
@@ -195,13 +219,28 @@ VGMSTREAM * init_vgmstream_baf(STREAMFILE *sf) {
                 msd.data_offset  = start_offset;
                 msd.data_size    = stream_size;
                 msd.loop_flag    = loop_flag;
-                msd.loop_start_b = read_u32(header_offset+0x4c, sf);
-                msd.loop_end_b   = read_u32(header_offset+0x50, sf);
-                msd.loop_start_subframe  = (read_u8(header_offset+0x55, sf) >> 0) & 0x0f;
-                msd.loop_end_subframe    = (read_u8(header_offset+0x55, sf) >> 4) & 0x0f;
+
+                switch(version) {
+                    case 0x04:
+                        msd.loop_start_b = read_u32(header_offset+0x4c, sf);
+                        msd.loop_end_b   = read_u32(header_offset+0x50, sf);
+                        msd.loop_start_subframe  = (read_u8(header_offset+0x55, sf) >> 0) & 0x0f;
+                        msd.loop_end_subframe    = (read_u8(header_offset+0x55, sf) >> 4) & 0x0f;
+                        break;
+
+                    case 0x05:
+                        msd.loop_start_b = read_u32(header_offset+0x50, sf);
+                        msd.loop_end_b   = read_u32(header_offset+0x54, sf);
+                        msd.loop_start_subframe  = (read_u8(header_offset+0x59, sf) >> 0) & 0x0f;
+                        msd.loop_end_subframe    = (read_u8(header_offset+0x59, sf) >> 4) & 0x0f;
+                        break;
+
+                    default:
+                        goto fail;
+                }
                 xma_get_samples(&msd, sf);
 
-                vgmstream->num_samples = msd.num_samples; /* also at 0x58, but unreliable? */
+                vgmstream->num_samples = msd.num_samples; /* also at 0x58(v4)/0x5C(v5), but unreliable? */
                 vgmstream->loop_start_sample = msd.loop_start_sample;
                 vgmstream->loop_end_sample = msd.loop_end_sample;
             }
@@ -209,14 +248,53 @@ VGMSTREAM * init_vgmstream_baf(STREAMFILE *sf) {
             xma_fix_raw_samples_ch(vgmstream, sf, start_offset, stream_size, channel_count, 1,1);
             break;
         }
-    #endif
+
+        case 0x09: {
+            int block_size = 0x800;
+            int seek_count = 0;
+
+            switch(version) {
+                case 0x04:
+                    seek_count = read_u32(header_offset+0x58, sf);
+                    vgmstream->num_samples = read_u32(header_offset+0x5c + (seek_count-1) * 4, sf);
+                    vgmstream->loop_start_sample = read_u32(header_offset+0x4c, sf);
+                    vgmstream->loop_end_sample   = read_u32(header_offset+0x50, sf);
+                    break;
+
+                case 0x05:
+                    seek_count = read_u32(header_offset+0x5c, sf);
+                    vgmstream->num_samples = read_u32(header_offset+0x60 + (seek_count-1) * 4, sf);
+                    vgmstream->loop_start_sample = read_u32(header_offset+0x50, sf);
+                    vgmstream->loop_end_sample   = read_u32(header_offset+0x54, sf);
+                    break;
+
+                default:
+                    goto fail;
+            }
+
+            vgmstream->codec_data = init_ffmpeg_xma2_raw(sf, start_offset, stream_size, vgmstream->num_samples, vgmstream->channels, vgmstream->sample_rate, block_size, 0);
+            if (!vgmstream->codec_data) goto fail;
+            vgmstream->coding_type = coding_FFmpeg;
+            vgmstream->layout_type = layout_none;
+
+            xma_fix_raw_samples(vgmstream, sf, start_offset, stream_size, 0, 0, 1);
+            break;
+        }
+#endif
 
         default:
             VGM_LOG("BAF: unknown codec %x\n", codec);
             goto fail;
     }
 
-    read_string(vgmstream->stream_name,0x20+1, name_offset,sf);
+    read_string(bank_name, sizeof(bank_name), version == 0x03 ? 0x12 : 0x11, sf);
+    read_string(stream_name, sizeof(stream_name), name_offset, sf);
+    get_streamfile_basename(sf, file_name, STREAM_NAME_SIZE);
+
+    if (bank_name[0] && strcmp(file_name, bank_name) != 0)
+        snprintf(vgmstream->stream_name, STREAM_NAME_SIZE, "%s/%s", bank_name, stream_name);
+    else
+        snprintf(vgmstream->stream_name, STREAM_NAME_SIZE, "%s", stream_name);
 
 
     if (!vgmstream_open_stream(vgmstream, sf, start_offset))

--- a/src/meta/baf.c
+++ b/src/meta/baf.c
@@ -221,16 +221,17 @@ VGMSTREAM* init_vgmstream_baf(STREAMFILE* sf) {
                 }
                 xma_get_samples(&msd, sf);
 
-                vgmstream->codec_data = is_xma1
-                    ? init_ffmpeg_xma1_raw(sf, start_offset, stream_size, vgmstream->channels, vgmstream->sample_rate, 0)
-                    : init_ffmpeg_xma2_raw(sf, start_offset, stream_size, vgmstream->num_samples, vgmstream->channels, vgmstream->sample_rate, block_size, 0);
-                if (!vgmstream->codec_data) goto fail;
                 vgmstream->coding_type = coding_FFmpeg;
                 vgmstream->layout_type = layout_none;
 
                 vgmstream->num_samples = msd.num_samples; /* also at 0x58(v4)/0x5C(v5) for XMA1, but unreliable? */
                 vgmstream->loop_start_sample = msd.loop_start_sample;
                 vgmstream->loop_end_sample = msd.loop_end_sample;
+
+                vgmstream->codec_data = is_xma1
+                    ? init_ffmpeg_xma1_raw(sf, start_offset, stream_size, vgmstream->channels, vgmstream->sample_rate, 0)
+                    : init_ffmpeg_xma2_raw(sf, start_offset, stream_size, vgmstream->num_samples, vgmstream->channels, vgmstream->sample_rate, block_size, 0);
+                if (!vgmstream->codec_data) goto fail;
             }
 
             xma_fix_raw_samples_ch(vgmstream, sf, start_offset, stream_size, channel_count, 1,1);

--- a/src/meta/baf.c
+++ b/src/meta/baf.c
@@ -189,7 +189,7 @@ VGMSTREAM* init_vgmstream_baf(STREAMFILE* sf) {
         case 0x08:
         case 0x09: {
             int is_xma1 = (codec == 0x08);
-            int block_size = 0x800;
+            int block_size = 0x10000;
 
             /* need to manually find sample offsets, it was a thing with XMA1 */
             {

--- a/src/meta/bnk_sony.c
+++ b/src/meta/bnk_sony.c
@@ -724,8 +724,10 @@ static bool process_names(STREAMFILE* sf, bnk_header_t* h) {
                 /* searches the chunk until it finds the target name/index, or breaks at empty name */
                 while (read_u8(stream_name_offset, sf)) {
                     /* in case it goes somewhere out of bounds unexpectedly */
-                    if (((read_u8(stream_name_offset + 0x00, sf) + read_u8(stream_name_offset + 0x04, sf) +
-                          read_u8(stream_name_offset + 0x08, sf) + read_u8(stream_name_offset + 0x0C, sf)) & 0x1F) != i)
+                    if (((read_u8(stream_name_offset + 0x00, sf)
+                        + read_u8(stream_name_offset + 0x04, sf)
+                        + read_u8(stream_name_offset + 0x08, sf)
+                        + read_u8(stream_name_offset + 0x0C, sf)) & 0x1F) != i)
                         goto fail;
                     if (read_u16(stream_name_offset + 0x10, sf) == table4_entry_id) {
                         read_string(h->stream_name, STREAM_NAME_SIZE, stream_name_offset, sf);
@@ -735,7 +737,7 @@ static bool process_names(STREAMFILE* sf, bnk_header_t* h) {
                     stream_name_offset += 0x14;
                 }
             }
-            //goto fail; /* didn't find any valid index? */
+            goto fail; /* didn't find any valid index? */
         loop_break:
             break;
 

--- a/src/meta/vag.c
+++ b/src/meta/vag.c
@@ -28,8 +28,9 @@ VGMSTREAM* init_vgmstream_vag(STREAMFILE* sf) {
      * .snd: Alien Breed (Vita)
      * .svg: ModernGroove: Ministry of Sound Edition (PS2)
      * (extensionless): The Urbz (PS2), The Sims series (PS2)
-     * .wav: Sniper Elite (PS2), The Simpsons Game (PS2/PSP) */
-    if (!check_extensions(sf,"vag,swag,str,vig,l,r,vas,xa2,snd,svg,,wav,lwav"))
+     * .wav: Sniper Elite (PS2), The Simpsons Game (PS2/PSP) 
+     * .msv: Casper and the Ghostly Trio (PS2), Earache Extreme Metal Racing (PS2) */
+    if (!check_extensions(sf,"vag,swag,str,vig,l,r,vas,xa2,snd,svg,,wav,lwav,msv"))
         return NULL;
 
     file_size = get_streamfile_size(sf);


### PR DESCRIPTION
- BAF: Add XMA2 support [PGR4 (X360), Blur (X360)]
- BAF: Add PCM v5 support [Blur 2 (X360)]
- BAF: Fix PCM BE audio [GW:RE2 (X360), PGR4 (X360)]
- BAF: Fix XMA1 v5 loops [Blur 2 (X360)]
- BAF: Fix early v4 PS-ADPCM mono streams [The Club (PS3)]
- BAF: Display bank name if different from filename
- VAG: .MSV extension [Data Design Interactive titles (PS2)]
- Sony BNK: Fail on v3 invalid name index
---
For my own sanity, can you confirm or deny whether the XMA2 WAVE chunk metadata is completely wrong and screwed up, or if I'm just not understanding something.  [Here's a sample](https://github.com/user-attachments/files/18925363/test.zip) from PGR4 + some leftover files of testing I did.
The 1st BAF commit is where I attempted to utilise the given data.  Unlike XMA1, in XMA2 there's what looks like a seek table starting at 0x58(v4)/0x5C(v5).  The last value in there seemed to always match the loop end value for sounds that loop all the way through, so I took that as the final sample count.  However the amount of (what I presumed to be) "samples" are more than double than what actually seems to be present(?) so there's a ton of silence at the end of each stream.
In the end I just resorted to doing the same thing XMA1 does, because with raw TXTH it seemed correct.