### PR TITLE
Update dependencies: Vorbis, Ogg, FFmpeg

### DIFF
--- a/cmake/dependencies/ffmpeg.cmake
+++ b/cmake/dependencies/ffmpeg.cmake
@@ -62,7 +62,7 @@ if(USE_FFMPEG)
 		FetchDependency(FFMPEG
 			DIR ffmpeg
 			GIT_REPOSITORY https://git.ffmpeg.org/ffmpeg.git
-			GIT_TAG n5.1.2
+			GIT_TAG n7.1.1
 		)
 
 		if(FFMPEG_PATH)
@@ -114,6 +114,7 @@ if(USE_FFMPEG)
 				--disable-nvdec
 				--disable-vdpau
 				--disable-vulkan
+				--disable-libdrm
 				--enable-parser=${FFMPEG_CONF_PARSER}
 				--enable-demuxer=${FFMPEG_CONF_DEMUXER}
 				--enable-decoder=${FFMPEG_CONF_DECODER}

--- a/cmake/dependencies/ogg.cmake
+++ b/cmake/dependencies/ogg.cmake
@@ -10,7 +10,8 @@ if(NOT WIN32 AND USE_VORBIS)
 		FetchDependency(OGG
 			DIR ogg
 			GIT_REPOSITORY https://gitlab.xiph.org/xiph/ogg
-			GIT_TAG v1.3.5
+			GIT_TAG fa80aae9d50096160f2b56ada35527d7aee3f746
+			GIT_UNSHALLOW ON
 		)
 		
 		if(OGG_PATH)

--- a/cmake/dependencies/vorbis.cmake
+++ b/cmake/dependencies/vorbis.cmake
@@ -10,7 +10,8 @@ if(NOT WIN32 AND USE_VORBIS)
 		FetchDependency(VORBIS
 			DIR vorbis
 			GIT_REPOSITORY https://gitlab.xiph.org/xiph/vorbis
-			GIT_TAG v1.3.7
+			GIT_TAG 2eac96b03ff67953354cb0a649c08aa3a23267ef
+			GIT_UNSHALLOW ON
 		)
 		
 		if(VORBIS_PATH)


### PR DESCRIPTION
- GitHub Actions updated to Cmake 4, which deprecated support for Cmake scripts older than version 3.5, update Vorbis and Ogg dependencies to versions that updated to support this change.
- Update FFmpeg, because the older version does not build on my system, additionally, disable libdrm on it.