### PR TITLE
Added UseDebugLibraries to VS projects

### DIFF
--- a/cli/vgmstream_cli.vcxproj
+++ b/cli/vgmstream_cli.vcxproj
@@ -29,6 +29,12 @@
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <UseDebugLibraries>true</UseDebugLibraries>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <UseDebugLibraries>true</UseDebugLibraries>
+  </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="PropertySheets">
     <Import Project="..\vgmstream_msvc.props" />

--- a/cli/vgmstream_cli.vcxproj.filters
+++ b/cli/vgmstream_cli.vcxproj.filters
@@ -19,17 +19,6 @@
     </Filter>
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="vgmstream_cli.h">
-      <Filter>Header Files</Filter>
-    </ClCompile>
-    <ClCompile Include="vjson.h">
-      <Filter>Header Files</Filter>
-    </ClCompile>
-    <ClCompile Include="wav_utils.h">
-      <Filter>Header Files</Filter>
-    </ClCompile>
-  </ItemGroup>
-  <ItemGroup>
     <ClCompile Include="vgmstream_cli.c">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -39,5 +28,16 @@
     <ClCompile Include="wav_utils.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="vgmstream_cli.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="vjson.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="wav_utils.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/ext_libs/Getopt/getopt.vcxproj
+++ b/ext_libs/Getopt/getopt.vcxproj
@@ -28,6 +28,12 @@
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <UseDebugLibraries>true</UseDebugLibraries>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <UseDebugLibraries>true</UseDebugLibraries>
+  </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="PropertySheets">
     <Import Project="..\..\vgmstream_msvc.props" />
@@ -36,7 +42,7 @@
   <ImportGroup Label="PropertySheets" />
   <PropertyGroup Label="UserMacros">
     <!-- overwrite (not in .. folder) -->
-    <VBuildCommandVersion/>
+    <VBuildCommandVersion />
   </PropertyGroup>
   <PropertyGroup>
     <_ProjectFileVersion>10.0.30319.1</_ProjectFileVersion>

--- a/fb2k/foo_input_vgmstream.vcxproj
+++ b/fb2k/foo_input_vgmstream.vcxproj
@@ -28,6 +28,12 @@
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <UseDebugLibraries>true</UseDebugLibraries>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <UseDebugLibraries>true</UseDebugLibraries>
+  </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="PropertySheets">
     <Import Project="..\vgmstream_msvc.props" />
@@ -66,7 +72,8 @@
     <Link>
       <AdditionalDependencies>$(VFooAdditionalDependencies32);%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <IgnoreSpecificDefaultLibraries>libcmt.lib;msvcrt.lib;libcmtd.lib</IgnoreSpecificDefaultLibraries>
+      <SubSystem>Windows</SubSystem>
+      <IgnoreSpecificDefaultLibraries>libcmtd.lib</IgnoreSpecificDefaultLibraries>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -78,7 +85,8 @@
     <Link>
       <AdditionalDependencies>$(VFooAdditionalDependencies64);%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <IgnoreSpecificDefaultLibraries>libcmt.lib;msvcrt.lib;libcmtd.lib</IgnoreSpecificDefaultLibraries>
+      <SubSystem>Windows</SubSystem>
+      <IgnoreSpecificDefaultLibraries>libcmtd.lib</IgnoreSpecificDefaultLibraries>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -93,7 +101,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
-      <IgnoreSpecificDefaultLibraries>libcmt.lib;libcmtd.lib;msvcrtd.lib</IgnoreSpecificDefaultLibraries>
+      <IgnoreSpecificDefaultLibraries>libcmt.lib</IgnoreSpecificDefaultLibraries>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -108,7 +116,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
-      <IgnoreSpecificDefaultLibraries>libcmt.lib;libcmtd.lib;msvcrtd.lib</IgnoreSpecificDefaultLibraries>
+      <IgnoreSpecificDefaultLibraries>libcmt.lib</IgnoreSpecificDefaultLibraries>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/winamp/in_vgmstream.vcxproj
+++ b/winamp/in_vgmstream.vcxproj
@@ -20,6 +20,9 @@
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <UseDebugLibraries>true</UseDebugLibraries>
+  </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="PropertySheets">
     <Import Project="..\vgmstream_msvc.props" />

--- a/winamp/in_vgmstream.vcxproj.filters
+++ b/winamp/in_vgmstream.vcxproj.filters
@@ -22,16 +22,16 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="sdk\in2.h">
-      <Filter>sdk\Header Files</Filter>
+      <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="sdk\ipc_pe.h">
-      <Filter>sdk\Header Files</Filter>
+      <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="sdk\out.h">
-      <Filter>sdk\Header Files</Filter>
+      <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="sdk\wa_ipc.h">
-      <Filter>sdk\Header Files</Filter>
+      <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/xmplay/xmp-vgmstream.vcxproj
+++ b/xmplay/xmp-vgmstream.vcxproj
@@ -20,6 +20,9 @@
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <UseDebugLibraries>true</UseDebugLibraries>
+  </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="PropertySheets">
     <Import Project="..\vgmstream_msvc.props" />

--- a/xmplay/xmp-vgmstream.vcxproj.filters
+++ b/xmplay/xmp-vgmstream.vcxproj.filters
@@ -1,26 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <ClCompile Include="xmp_streamfile.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="xmp_utils.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="xmp_vgmstream.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
+    <ClCompile Include="xmp_streamfile.c" />
+    <ClCompile Include="xmp_utils.c" />
+    <ClCompile Include="xmp_vgmstream.c" />
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="xmpfunc.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="xmpin.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="xmp_vgmstream.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
+    <ClInclude Include="xmpfunc.h" />
+    <ClInclude Include="xmpin.h" />
+    <ClInclude Include="xmp_vgmstream.h" />
   </ItemGroup>
   <ItemGroup>
     <None Include="xmpin.def" />


### PR DESCRIPTION
This adds UseDebugLibraries parameter to our VS projects which sets various missing defaults that you'd normally expect from Debug config.

This parameter is frequently missing on upgraded projects so it's important to check if it's set on old project files: https://ofekshilon.com/2014/06/23/usedebuglibraries-and-wrong-defaults-for-vc-project-properties/