### PR TITLE
Srcd v2

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -12,3 +12,6 @@
 *.bat text eol=crlf
 *.vcxproj text eol=crlf
 *.vcxproj.filters text eol=crlf
+
+#Fixes CRLF/LF conflict.
+* text=auto

--- a/src/formats.c
+++ b/src/formats.c
@@ -558,6 +558,7 @@ static const char* extension_list[] = {
     "spsd",
     "spw",
     "srsa",
+    "srcd",
     "ss2",
     "ssd", //txth/reserved [Zack & Wiki (Wii)]
     "ssf",
@@ -1479,6 +1480,7 @@ static const meta_info meta_info_list[] = {
         {meta_AUDIOPKG,             "Inevitable .AUDIOPKG header"},
         {meta_SWAR,                 "Nintendo SWAR header"},
         {meta_IVB,                  "Metro IVB header"},
+        {meta_SRCD,                 "Capcom SRCD header"}
 };
 
 void get_vgmstream_coding_description(VGMSTREAM* vgmstream, char* out, size_t out_size) {

--- a/src/libvgmstream.vcxproj
+++ b/src/libvgmstream.vcxproj
@@ -226,6 +226,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="formats.c" />
+    <ClCompile Include="meta\srcd.c" />
     <ClCompile Include="streamfile.c" />
     <ClCompile Include="util.c" />
     <ClCompile Include="vgmstream.c" />

--- a/src/libvgmstream.vcxproj.filters
+++ b/src/libvgmstream.vcxproj.filters
@@ -2401,5 +2401,8 @@
     <ClCompile Include="util\vorbis_codebooks.c">
       <Filter>util\Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="meta\srcd.c">
+      <Filter>meta\Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
 </Project>

--- a/src/meta/meta.h
+++ b/src/meta/meta.h
@@ -1035,4 +1035,6 @@ VGMSTREAM* init_vgmstream_swar(STREAMFILE* sf);
 
 VGMSTREAM* init_vgmstream_ivb(STREAMFILE* sf);
 
+VGMSTREAM* init_vgmstream_srcd(STREAMFILE* sf);
+
 #endif

--- a/src/meta/srcd.c
+++ b/src/meta/srcd.c
@@ -1,0 +1,124 @@
+#include "meta.h"
+#include "../coding/coding.h"
+
+/* srcd - Capcom RE Engine */
+VGMSTREAM* init_vgmstream_srcd(STREAMFILE* sf) {
+    VGMSTREAM* vgmstream = NULL;
+    STREAMFILE* subfile = NULL;
+    off_t start_offset = 0;
+    int loop_flag = 0;
+    int32_t loop_start_sample = 0, loop_end_sample = 0;
+    uint32_t container_type;
+    const char* extension = NULL;
+    VGMSTREAM* (*init_vgmstream_function)(STREAMFILE*) = NULL;
+
+    if (!check_extensions(sf, "srcd,asrc,14,21,26,31"))
+        goto fail;
+
+    if (!is_id32be(0x00, sf, "srcd"))
+        goto fail;
+
+    {
+        enum versions { VERSION_31, VERSION_21_26, VERSION_14, VERSION_UNKNOWN };
+        enum versions ver = VERSION_UNKNOWN;
+
+        //v31 - AJ_AAT
+        if (read_u32le(0x18, sf) > 0x02) {
+            ver = VERSION_31;
+        }
+        //v21 - CAS2
+        else if (read_u32le(0x41, sf) == 0x49) {
+            ver = VERSION_21_26;
+        }
+        //v26 - GTPD
+        else if (read_u32le(0x46, sf) == 0x4E) {
+            ver = VERSION_21_26;
+        }
+        //v14 - CAS
+        else if (read_u8(0x3A, sf) == 0x42) {
+            ver = VERSION_14;
+        }
+
+        switch (ver) {
+            case VERSION_31:
+                loop_flag         = read_u8(0x34, sf);
+                loop_start_sample = read_u32le(0x35, sf);
+                loop_end_sample   = read_u32le(0x39, sf);
+                break;
+
+            case VERSION_21_26:
+                loop_flag         = read_u8(0x2C, sf);
+                loop_start_sample = read_u32le(0x2D, sf);
+                loop_end_sample   = read_u32le(0x31, sf);
+                break;
+
+            case VERSION_14:
+                loop_flag         = read_u8(0x28, sf);
+                loop_start_sample = read_u32le(0x29, sf);
+                loop_end_sample   = read_u32le(0x2D, sf);
+                break;
+
+            default:
+                VGM_LOG("SRCD: Unknown version, disabling loop\n", loop_start_sample, loop_end_sample);
+                loop_flag = 0;
+                break;
+        }
+    }
+
+    container_type = read_u32be(0x0C, sf);
+    {
+        const off_t scan_start = 0x40;
+        const size_t scan_size = 0x100; //Should be small
+        off_t current_offset;
+        uint32_t magic_to_find = 0;
+
+        if (container_type == get_id32be("wav ")) {
+            magic_to_find = get_id32be("RIFF");
+        } else if (container_type == get_id32be("ogg ")) {
+            magic_to_find = get_id32be("OggS");
+        }
+
+        if (magic_to_find) {
+            for (current_offset = scan_start; current_offset < scan_start + scan_size; current_offset++) {
+                if (read_u32be(current_offset, sf) == magic_to_find) {
+                    start_offset = current_offset;
+                    break;
+                }
+            }
+        }
+    }
+
+    if (start_offset == 0)
+        goto fail;
+
+
+    /* Select the appropriate init function and extension based on container type */
+    if (container_type == get_id32be("wav ")) {
+        extension = "wav";
+        init_vgmstream_function = init_vgmstream_riff;
+    } else if (container_type == get_id32be("ogg ")) {
+        extension = "ogg";
+        init_vgmstream_function = init_vgmstream_ogg_vorbis;
+    } else {
+        VGM_LOG("SRCD: Codec not recognized");
+        goto fail;
+    }
+
+    subfile = setup_subfile_streamfile(sf, start_offset, get_streamfile_size(sf) - start_offset, extension);
+    if (!subfile) goto fail;
+
+    vgmstream = init_vgmstream_function(subfile);
+    if (!vgmstream) goto fail;
+
+    vgmstream->meta_type = meta_SRCD;
+
+    vgmstream_force_loop(vgmstream, loop_flag, loop_start_sample, loop_end_sample);
+
+    close_streamfile(subfile);
+    return vgmstream;
+
+fail:
+    close_streamfile(subfile);
+    close_vgmstream(vgmstream);
+    return NULL;
+}

--- a/src/vgmstream_init.c
+++ b/src/vgmstream_init.c
@@ -512,6 +512,7 @@ init_vgmstream_t init_vgmstream_functions[] = {
     init_vgmstream_audiopkg,
     init_vgmstream_swar,
     init_vgmstream_ivb,
+    init_vgmstream_srcd,
 
     /* lower priority metas (no clean header identity, somewhat ambiguous, or need extension/companion file to identify) */
     init_vgmstream_agsc,

--- a/src/vgmstream_types.h
+++ b/src/vgmstream_types.h
@@ -721,6 +721,7 @@ typedef enum {
     meta_AUDIOPKG,
     meta_SWAR,
     meta_IVB,
+    meta_SRCD
 } meta_t;
 
 #endif


### PR DESCRIPTION
Version 2 of Capcom RE Engine srcd.

- Fixed CR/LF warning.
- Add support to some extensions. (*.asrc)
- Use vgmstream_force_loop instead of manually checking loop flags.

Ref: #1736