### PR TITLE
MHWK: Fix ADPCM codec

### DIFF
--- a/src/meta/mhwk.c
+++ b/src/meta/mhwk.c
@@ -80,8 +80,8 @@ VGMSTREAM* init_vgmstream_mhwk(STREAMFILE* sf) {
             break;
 
         //Carmen Sandiego: Word Detective
-        case 0x0001: /* IMA ADPCM */
-            vgmstream->coding_type = coding_IMA;
+        case 0x0001: /* Intel DVI ADPCM */
+            vgmstream->coding_type = coding_DVI_IMA;
             vgmstream->layout_type = layout_none;
             break;
         //Riven DVD


### PR DESCRIPTION
Fix improper ADPCM codec.

[Sample](https://0x0.st/s/imnyIBpsnI3ET-C89VAhgw/8FqN.mhk).
[Output](https://0x0.st/s/_tmqF_tY565lEchfNYCo1A/8Fqc.mhk.wav).