### PR TITLE
ext misc

### DIFF
--- a/src/coding/ffmpeg_decoder_utils.c
+++ b/src/coding/ffmpeg_decoder_utils.c
@@ -609,6 +609,9 @@ fail:
 /* Makes a XMA1/2 RIFF header using a "fmt " chunk (XMAWAVEFORMAT/XMA2WAVEFORMATEX) or "XMA2" chunk (XMA2WAVEFORMAT), as a base:
  * Useful to preserve the stream layout */
 static int ffmpeg_make_riff_xma_chunk(STREAMFILE* sf, uint8_t* buf, int buf_size, uint32_t data_size, uint32_t chunk_offset, uint32_t chunk_size, int* p_is_xma1) {
+    if (chunk_size <= 0)
+        return 0;
+
     int buf_max = (0x04 * 2 + 0x04) + (0x04 * 2 + chunk_size) + (0x04 * 2);
     if (buf_max > buf_size)
         return 0;

--- a/src/formats.c
+++ b/src/formats.c
@@ -412,6 +412,7 @@ static const char* extension_list[] = {
     "nfx",
     "nub",
     "nub2",
+    "nusnub",
     "nus3audio",
     "nus3bank",
     "nwa",
@@ -529,6 +530,7 @@ static const char* extension_list[] = {
     "sdf",
     "sdt",
     "se",
+    "se3", //txth/reserved (.nub container) [Tales of Vesperia (X360/PS3), Tales of Graces f (PS3)]
     "seb",
     "sed",
     "seg",
@@ -567,6 +569,8 @@ static const char* extension_list[] = {
     "spm",
     "sps",
     "spsd",
+    "spsis14",
+    "spsis22",
     "spw",
     "srcd",
     "sre",
@@ -613,6 +617,8 @@ static const char* extension_list[] = {
     "tra",
     "trk",
     "trs", //txth/semi [Kamiwaza (PS2), Shinobido (PS2)]
+    "tsdse3", //txth/reserved [Tales of Xillia (PS3)-nub container]
+    "tsdse4", //txth/reserved [Tales of Xillia (PS3)-nub container]
     "tun",
     "txth",
     "txtp",

--- a/src/formats.c
+++ b/src/formats.c
@@ -198,7 +198,6 @@ static const char* extension_list[] = {
     "ezw",
 
     "fag",
-    "fcb", //FFmpeg/not parsed (BINK AUDIO)
     "fda",
     "filp",
     "fish",

--- a/src/meta/bnsf.c
+++ b/src/meta/bnsf.c
@@ -25,9 +25,12 @@ VGMSTREAM* init_vgmstream_bnsf(STREAMFILE* sf) {
 
     /* checks */
     if (!is_id32be(0x00,sf, "BNSF"))
-        goto fail;
-    if (!check_extensions(sf,"bnsf"))
-        goto fail;
+        return NULL;
+    /* .bnsf: header id only?
+     * .spsis14/spsis22: TLFILE archives [Tales of Zestiria/Berseria (PS3)] (hashed filenames, but from debug/unhashed strings this seems the intended extension)
+     */
+    if (!check_extensions(sf,"bnsf,spsis14,spsis22"))
+        return NULL;
 
     bnsf_size = read_u32be(0x04,sf);
     codec = read_u32be(0x08,sf);
@@ -35,7 +38,7 @@ VGMSTREAM* init_vgmstream_bnsf(STREAMFILE* sf) {
     if (codec != get_id32be("IS22")) /* uses full size */
         bnsf_size += 0x08;
     if (bnsf_size != get_streamfile_size(sf))
-        goto fail;
+        return NULL;
 
     {
         enum {

--- a/src/meta/bnsf_keys.h
+++ b/src/meta/bnsf_keys.h
@@ -5,7 +5,7 @@ typedef struct {
     const char* key;
 } bnsfkey_info;
 
-/* Known keys, from games' exe (iM@S, near "nus" strings) or files (Tales, config in audio bigfiles).
+/* Known keys, from games' exe (iM@S, near "nus" strings) or files (Tales, SPLOCBIN in audio bigfiles).
  *
  * In memdumps, first 16 chars of key can be found XORed with "Ua#oK3P94vdxX,ft" after AES 'Td'
  * mix tables (that end with 8D4697A3 A38D4697 97A38D46 4697A38D), then can be cross referenced
@@ -15,10 +15,10 @@ static const bnsfkey_info s14key_list[] = {
         /* THE iDOLM@STER 2 (PS3/X360) */
         {"haruka17imas"},
 
-        /* Tales of Zestiria (PS3) */
+        /* Tales of Zestiria (PS3/PC) */
         {"TO12_SPSLoc"},
 
-        /* Tales of Berseria (PS3) */
+        /* Tales of Berseria (PS3/PS4/PC) */
         {"SPSLOC13"},
 
         /* THE iDOLM@STER: One For All (PS3) */
@@ -26,4 +26,4 @@ static const bnsfkey_info s14key_list[] = {
 
 };
 
-#endif /*_BNSF_KEYS_H_*/
+#endif

--- a/src/meta/ea_schl_standard.c
+++ b/src/meta/ea_schl_standard.c
@@ -41,8 +41,9 @@ VGMSTREAM* init_vgmstream_ea_schl(STREAMFILE* sf) {
      * .xsf: 007 - Agent Under Fire (Xbox)
      * .gsf: 007 - Everything or Nothing (GC)
      * (extensionless): SSX (PS2) (inside .big)
-     * .r: The Sims 2: Pets (PSP) (not l/r, shorter "res") */
-    if (!check_extensions(sf, "asf,lasf,str,chk,eam,exa,sng,aud,sx,xa,strm,stm,hab,xsf,gsf,,r"))
+     * .r: The Sims 2: Pets (PSP) (not l/r, shorter "res")
+     * .snd: Command & Conquer 3: Tiberum Sun (PC) videos */
+    if (!check_extensions(sf, "asf,lasf,str,chk,eam,exa,sng,aud,sx,xa,strm,stm,hab,xsf,gsf,,r,snd"))
         return NULL;
 
     /* check header */

--- a/src/meta/xwb_xsb.h
+++ b/src/meta/xwb_xsb.h
@@ -891,12 +891,10 @@ static bool parse_xsb(xsb_header* xsb, STREAMFILE* sf, char* xwb_wavebank_name) 
 static STREAMFILE* open_xsb_filename_pair(STREAMFILE* sf_xwb) {
     STREAMFILE* sf_xsb = NULL;
 
-    //TODO: remove most of these and use .txtm
+    //TODO: check if those are widely used + remove excess and use .txtm
     /* .xwb to .xsb name conversion, since often they don't match */
     static const char* const filename_pairs[][2] = {
-            {"MUSIC.xwb","Everything.xsb"},             /* Unreal Championship (Xbox) */
             {"Music.xwb","Sound Bank.xsb"},             /* Stardew Valley (Vita) */
-            {"Ambiences_intro.xwb","Ambiences.xsb"},    /* Arx Fatalis (Xbox) */
             {"Wave*.xwb","Sound*.xsb"},                 /* XNA/MonoGame games? */
             {"*MusicBank.xwb","*SoundBank.xsb"},        /* NFL Fever 2004 (Xbox) */
             {"*_xwb","*_xsb"},                          /* Ikaruga (PC) */
@@ -906,14 +904,6 @@ static STREAMFILE* open_xsb_filename_pair(STREAMFILE* sf_xwb) {
             {"StreamBank_*.xwb","SoundBank_*.xsb"},     /* Ginga Force (X360) */
             {"WaveBank_*.xwb","SoundBank_*.xsb"},       /* Ginga Force (X360) */
             {"*_WB.xwb","*_SB.xsb"},                    /* Ninja Blade (X360) */
-            {"cache_dvdstr.xwb","cache.xsb"},           /* SpongeBob: Lights Camera Pants (Xbox) */
-            {"cache_hddstr.xwb","cache.xsb"},           /* SpongeBob: Lights Camera Pants (Xbox) */
-            {"cache_mem.xwb","cache.xsb"},              /* SpongeBob: Lights Camera Pants (Xbox) */
-            {"CA_NightMusic.xwb","CAMusic.xsb"},        /* Psychonauts (Xbox) */
-            {"CAJAMusic.xwb","CAMusic.xsb"},            /* "" */
-            {"STFX.xwb","CommonMusic.xsb"},             /* "" */
-            {"CALI_NightFX.xwb","CAFX.xsb"},            /* "" */
-            /* Psychonauts has a bunch more pairs for sfx too, improve */
             {"*.xwb","*.xsb"},                          /* default */
     };
     int pair_count = (sizeof(filename_pairs) / sizeof(filename_pairs[0]));


### PR DESCRIPTION
- Fix some .nub [Tales of Vesperia (X360)]
- Add .spsis14/spsis22 for BNSF [Tales of Zestiria/Berseria (PS3)]
- Add .nusnub/se3/tsdse3/tsdse4 extensions [Tales of Graces/Xillia (PS3)]
- Add .snd extension for EA SCHl [Command & Conquer 3: Tiberum Sun (PC) videos]
- Remove .fcb fake extension (use .binka)
- Remove rarely used .xwb+xsb pairs (use .TXTM)
- xsb: fix more variation counts
