### PR TITLE
Implement Sonic Racing CrossWorlds Keys

### DIFF
--- a/src/meta/adx_keys.h
+++ b/src/meta/adx_keys.h
@@ -282,6 +282,9 @@ static const adxkey_info adxkey9_list[] = {
         // Bungo Stray Dogs: Mayoi Inu Kaikitan (iOS/Android)
         {0x0000,0x0000,0x0000, NULL,1655728931134731873},   // 16FA54B0C09F7661
 
+        // Sonic Racing CrossWorlds (multi)
+        {0x0000,0x0000,0x0000, NULL,32105414741057402},     // 00720FB46101DF7A
+
 };
 
 static const int adxkey8_list_count = sizeof(adxkey8_list) / sizeof(adxkey8_list[0]);

--- a/src/meta/hca_keys.h
+++ b/src/meta/hca_keys.h
@@ -1577,6 +1577,9 @@ static const hcakey_info hcakey_list[] = {
 
     // Aether Gazer (multi)
     {1578660190369042886},      // 15E887143BFF51C6
+
+    // Sonic Racing CrossWorlds (multi)
+    {32105414741057402},        // 00720FB46101DF7A
 };
 
 #endif


### PR DESCRIPTION
Implements the key found within the Sonic Racing CrossWorlds Steam executable found by [SuperSonic16](https://github.com/thesupersonic16). All other functions should remain identical.