### PR TITLE
Fix build with FFmpeg 8.0

### DIFF
--- a/src/coding/ffmpeg_decoder.c
+++ b/src/coding/ffmpeg_decoder.c
@@ -918,7 +918,6 @@ static void free_ffmpeg_config(ffmpeg_codec_data* data) {
         data->frame = NULL;
     }
     if (data->codecCtx) {
-        avcodec_close(data->codecCtx);
         avcodec_free_context(&data->codecCtx);
         data->codecCtx = NULL;
     }


### PR DESCRIPTION
See https://github.com/FFmpeg/FFmpeg/commit/0d48da2db0b239d80c6e8b30e66211a977566588

The deprecation comment for `avcodec_close()` said:
> Do not use this function. Use avcodec_free_context() to destroy a
> codec context (either open or closed). Opening and closing a codec context
> multiple times is not supported anymore -- use multiple codec contexts
> instead.

---

Should be backwards compatible with older FFmpeg as original `avcodec_free_context()` (https://github.com/FFmpeg/FFmpeg/commit/fd056029f45a9f6d213d9fce8165632042511d4f) internally ran `avcodec_close()`
```c
void avcodec_free_context(AVCodecContext **pavctx)
{
    AVCodecContext *avctx = *pavctx;

    if (!avctx)
        return;

    avcodec_close(avctx);
```