### PR TITLE
MHWK: Fix segfault on MP2

### DIFF
--- a/src/meta/mhwk.c
+++ b/src/meta/mhwk.c
@@ -1,13 +1,19 @@
 #include "meta.h"
 #include "../coding/coding.h"
 
+/* Header size of the main file wrapper (MHWK + Size + WAVE) */
+#define MHWK_FILE_HEADER_SIZE 0x0C
+/* The 'Data' chunk starts with a 20-byte parameter header before audio begins */
+#define MHWK_DATA_HEADER_SIZE 0x14
+
 /* MHWK - Broderbund's Mohawk engine (.mhk) */
 VGMSTREAM* init_vgmstream_mhwk(STREAMFILE* sf) {
     VGMSTREAM* vgmstream = NULL;
     off_t start_offset = 0;
     int loop_flag = 0, channels = 0, sample_rate = 0, format = 0;
     int32_t num_samples = 0, loop_start = 0, loop_end = 0;
-    off_t current_offset;
+    off_t chunk_offset = 0;
+    off_t data_offset = 0;
     uint32_t chunk_id;
     uint32_t chunk_size;
 
@@ -22,18 +28,19 @@ VGMSTREAM* init_vgmstream_mhwk(STREAMFILE* sf) {
     if (!is_id32be(0x08, sf, "WAVE"))
         goto fail;
 
-    current_offset = 0x0C;
+    chunk_offset = MHWK_FILE_HEADER_SIZE;
 
-    while (current_offset < get_streamfile_size(sf)) {
-        chunk_id = read_u32be(current_offset, sf);
-        chunk_size = read_u32be(current_offset + 0x04, sf);
-        current_offset += 0x08;
+    while (chunk_offset < get_streamfile_size(sf)) {
+        chunk_id = read_u32be(chunk_offset, sf);
+        chunk_size = read_u32be(chunk_offset + 0x04, sf);
+        chunk_offset += 0x08;
 
         if (chunk_id == get_id32be("Data")) {
+            data_offset = chunk_offset;
             break;
         }
         else if (chunk_id == get_id32be("Cue#") || chunk_id == get_id32be("ADPC")) {
-            current_offset += chunk_size;
+            chunk_offset += chunk_size;
             continue;
         }
         else {
@@ -41,23 +48,26 @@ VGMSTREAM* init_vgmstream_mhwk(STREAMFILE* sf) {
         }
     }
 
+    if (!data_offset)
+        goto fail;
+
     /* Data chunk header */
 
     /* Header size is consistently 20 bytes from analysis */
-    sample_rate = read_u16be(current_offset + 0x00, sf);
-    num_samples = read_u32be(current_offset + 0x02, sf);
+    sample_rate = read_u16be(data_offset + 0x00, sf);
+    num_samples = read_u32be(data_offset + 0x02, sf);
     /* 0x06: sample width (1 byte), 0x07: channels (1 byte) */
-    channels = read_u8(current_offset + 0x07, sf);
-    format = read_u16be(current_offset + 0x08, sf);
+    channels = read_u8(data_offset + 0x07, sf);
+    format = read_u16be(data_offset + 0x08, sf);
 
-    if (read_u16be(current_offset + 0x0A, sf) == 0xFFFF) {
+    if (read_u16be(data_offset + 0x0A, sf) == 0xFFFF) {
         loop_flag = 1;
-        loop_start = read_u32be(current_offset + 0x0C, sf);
-        loop_end = read_u32be(current_offset + 0x10, sf);
+        loop_start = read_u32be(data_offset + 0x0C, sf);
+        loop_end = read_u32be(data_offset + 0x10, sf);
     }
 
     /* The actual audio data starts after the header's 20 bytes not 28 bytes */
-    start_offset = current_offset + 0x14;
+    start_offset = data_offset + MHWK_DATA_HEADER_SIZE;
 
     vgmstream = allocate_vgmstream(channels, loop_flag);
     if (!vgmstream)
@@ -91,7 +101,7 @@ VGMSTREAM* init_vgmstream_mhwk(STREAMFILE* sf) {
             vgmstream->codec_data = init_mpeg(sf, start_offset, &vgmstream->coding_type, vgmstream->channels);  // Uses MPEG-2 LSF variant.
 #elif defined(VGM_USE_FFMPEG)
             vgmstream->coding_type = coding_FFmpeg;
-            vgmstream->codec_data = init_ffmpeg_offset(sf, start_offset, chunk_size - 0x14);
+            vgmstream->codec_data = init_ffmpeg_offset(sf, start_offset, chunk_size - MHWK_DATA_HEADER_SIZE);
 #else
             goto fail;
 #endif


### PR DESCRIPTION
So the file from Riven uses the LSF variant which is 22.05khz.

[Sample](https://0x0.st/s/dWuTGWrPTUyW_bevEhZNng/K4OX.mhk)

Log:

```
vgmstream-cli -l 1 -f 0 -d 0 b_Sounds_MHK_bytram_1.mhk
decoding b_Sounds_MHK_bytram_1.mhk
sample rate: 22050 Hz
channels: 2
stream total samples: 881780 (0:39.990 seconds)
encoding: MPEG Layer II Audio (MP2)
layout: flat
metadata from: Broderbund MHWK header
bitrate: 95 kbps
sample type: float
play duration: 881780 samples (0:39.990 seconds)

Process finished with exit code 0
```