### PR TITLE
Implement RFRM/CSMP support for version 0x2E (Metroid Prime 4)

### DIFF
--- a/src/meta/rfrm.c
+++ b/src/meta/rfrm.c
@@ -1,7 +1,7 @@
 #include "meta.h"
 #include "../coding/coding.h"
 
-/* RFTM - Retro Studios format [Metroid Prime Remastered] */
+/* RFTM - Retro Studios format [Metroid Prime Remastered, Metroid Prime 4] */
 static VGMSTREAM* init_vgmstream_rfrm_mpr(STREAMFILE* sf) {
     VGMSTREAM* vgmstream = NULL;
     off_t fmta_offset = 0, data_offset = 0, ras3_offset = 0, header_offset, start_offset;
@@ -19,7 +19,8 @@ static VGMSTREAM* init_vgmstream_rfrm_mpr(STREAMFILE* sf) {
     if (!check_extensions(sf, "csmp"))
         goto fail;
 
-    if (read_32bitLE(0x18,sf) != 0x1F) /* assumed, also at 0x1c */
+    uint32_t version = read_32bitLE(0x18,sf);
+    if (version != 0x1F && version != 0x2E) /* assumed, also at 0x1c */
         goto fail;
 
 
@@ -36,6 +37,9 @@ static VGMSTREAM* init_vgmstream_rfrm_mpr(STREAMFILE* sf) {
                 case 0x464D5441: /* "FMTA" */
                     fmta_offset = chunk_offset + 0x18;
                     chunk_offset += 5 + 0x18 + chunk_size;
+                    if (version == 0x2E) {
+                        chunk_offset--;
+                    }
                     break;
                 case 0x44415441: /* "DATA" */
                     data_offset = chunk_offset + 0x18;
@@ -45,7 +49,11 @@ static VGMSTREAM* init_vgmstream_rfrm_mpr(STREAMFILE* sf) {
                     break;
                 case 0x52415333: /* "RAS3" */
                     ras3_offset = chunk_offset + 0x18;
-                    chunk_offset += 60;
+                    if (version == 0x1F) {
+                        chunk_offset += 60;
+                    } else {
+                        chunk_offset += 62;
+                    }
                     break;
                 case 0x43524D53: /* CRMS */
                     chunk_offset += 9 + 0x18 + chunk_size + read_32bitLE(chunk_offset + 0x18 + chunk_size + 5, sf);
@@ -61,7 +69,11 @@ static VGMSTREAM* init_vgmstream_rfrm_mpr(STREAMFILE* sf) {
 
 
     /* parse FMTA / DATA (fully interleaved standard DSPs) */
-    channels = read_8bit(fmta_offset + 0x00, sf);
+    if (version == 0x1F) {
+        channels = read_8bit(fmta_offset + 0x00, sf);
+    } else {
+        channels = read_8bit(fmta_offset + 0x02, sf);
+    }
     if (channels == 0) goto fail; /* div by zero */
     /* FMTA 0x08: channel mapping */
 
@@ -156,6 +168,9 @@ VGMSTREAM* init_vgmstream_rfrm(STREAMFILE* sf) {
         big_endian = 0;
     }
     else if (version == 0x1F000000) { /* Metroid Prime Remastered */
+        return init_vgmstream_rfrm_mpr(sf);
+    }
+    else if (version == 0x2E000000) { /* Metroid Prime 4: Beyond */
         return init_vgmstream_rfrm_mpr(sf);
     }
     else {


### PR DESCRIPTION
Metroid Prime 4: Beyond uses a newer version (0x2E) of the RFRM/CSMP format which is slightly different than in the previous game (Metroid Prime Remastered). This PR adds the necessary bits to support version 0x2E.