### PR TITLE
Improve handling of RFRM/CSMP files in Metroid Prime 4

### DIFF
--- a/src/meta/rfrm.c
+++ b/src/meta/rfrm.c
@@ -65,15 +65,15 @@ static VGMSTREAM* init_vgmstream_rfrm_mpr(STREAMFILE* sf) {
             goto fail;
     }
 
-
+    unsigned int channel_layout = 0;
     /* parse FMTA / DATA (fully interleaved standard DSPs) */
     if (version == 0x1F) {
         channels = read_8bit(fmta_offset + 0x00, sf);
     } else {
         channels = read_8bit(fmta_offset + 0x02, sf);
+        channel_layout = read_16bitLE(fmta_offset, sf);
     }
     if (channels == 0) goto fail; /* div by zero */
-    /* FMTA 0x08: channel mapping */
 
     header_offset = data_offset;
     start_offset = header_offset + 0x80 * channels;
@@ -124,6 +124,10 @@ static VGMSTREAM* init_vgmstream_rfrm_mpr(STREAMFILE* sf) {
     vgmstream->interleave_block_size = interleave;
     dsp_read_coefs(vgmstream, sf, header_offset + 0x1C, 0x80, 0);
     dsp_read_hist (vgmstream, sf, header_offset + 0x40, 0x80, 0);
+
+    if (channel_layout) {
+        vgmstream->channel_layout = channel_layout;
+    }
 
     if (!vgmstream_open_stream(vgmstream, sf, start_offset))
         goto fail;


### PR DESCRIPTION
This PR improves parsing of CSMP files from Metroid Prime Remastered and Metroid Prime 4. The code is somewhat simplified, yet it now parses _all_ files from both games without issues. The main issue was that the chunk size field was simply wrong, but this is fixed now.

In addition, CSMP files from Metroid Prime 4 include a channel layout field, this is now parsed by the meta module too.

I'm not sure if the “skip unknown chunk” is a valid choice here, but this should only ever affect CSMP files with a format version of MPR/MP4 according to the header, so I _think_ this should be fine.