### PR TITLE
Add .bdm extension

### DIFF
--- a/src/formats.c
+++ b/src/formats.c
@@ -110,6 +110,7 @@ static const char* extension_list[] = {
     "bcstm",
     "bcwav",
     "bcv", //txth/reserved [The Bigs (PSP)]
+    "bdm", //txth/reserved [Ore to Imouto no Kounai Play (BD-J)]
     "bfstm",
     "bfwav",
     "bg00",


### PR DESCRIPTION
Source: [Ore to Imouto no Kounai Play - Imouto wa Dare ni mo Watasanai - BD Edition (BD-J) (2012-05-25)(MAGI)(BD-Game)[PC].7z](https://href.li/?https://pc.joshw.info/o/Ore%20to%20Imouto%20no%20Kounai%20Play%20-%20Imouto%20wa%20Dare%20ni%20mo%20Watasanai%20-%20BD%20Edition%20(BD-J)%20(2012-05-25)(MAGI)(BD-Game)[PC].7z)