### PR TITLE
vima aax etc

### DIFF
--- a/doc/FORMATS.md
+++ b/doc/FORMATS.md
@@ -366,10 +366,6 @@ different internally (encrypted, different versions, etc) and not always can be 
   - InterPlay ACM header [*ACM*]
   - *acm*: `.acm .tun .wavc`
   - Codecs: ACM
-- **mus_acm.c**
-  - InterPlay MUS ACM header [*MUS_ACM*]
-  - *mus_acm*: `.mus`
-    - Subfiles: *acm ogg_vorbis*
 - **vig_kces.c**
   - Konami .VIG header [*VIG_KCES*]
   - *vig_kces*: `.vig`
@@ -986,7 +982,7 @@ different internally (encrypted, different versions, etc) and not always can be 
 - **ea_schl_fixed.c**
   - Electronic Arts BNK header (fixed) [*EA_BNK_fixed*]
   - Electronic Arts SCHl header (fixed) [*EA_SCHL_fixed*]
-  - *ea_schl_fixed*: `.asf .lasf .cnk .dct`
+  - *ea_schl_fixed*: `.asf .lasf .cnk .dct .tgv .uv`
   - *ea_bnk_fixed*: `.bkh .vh + .bkd .vb`
   - *ea_patl*: `.pth + .ptd`
   - Codecs: PCM8 PCM16BE PCM16LE DVI_IMA PSX
@@ -1817,6 +1813,18 @@ different internally (encrypted, different versions, etc) and not always can be 
   - Square WD header [*WD*]
   - *wd*: `.wd`
   - Codecs: NGC_DSP PSX
+- **ps2p.c**
+  - THQ Australia PS2P header [*PS2P*]
+  - *ps2p*: `.sounds`
+    - Subfiles: *vag*
+- **gcsp.c**
+  - THQ Australia GCSP header [*GCSP*]
+  - *gcsp*: `.sounds`
+  - Codecs: NGC_DSP
+- **mus_acm.c**
+  - InterPlay MUS ACM header [*MUS_ACM*]
+  - *mus_acm*: `.mus`
+    - Subfiles: *acm ogg_vorbis*
 - **afc.c**
   - Nintendo .AFC header [*AFC*]
   - *afc*: `.afc .stx`
@@ -1949,6 +1957,10 @@ different internally (encrypted, different versions, etc) and not always can be 
   - *jaudio_bx*: `.bx`
   - *jaudio_baa*: `.baa`
   - Codecs: AFC AFC_2bit PCM8 PCM16BE
+- **bwav_warthog.c**
+  - Warthog .BWAV header [*BWAV_WARTHOG*]
+  - *bwav_warthog*: `.bwav`
+  - Codecs: PSX XBOX_IMA NGC_DSP
 - **pos.c**
   - RIFF WAVE header (.pos looping) [*RIFF_WAVE_POS*]
   - *pos*: `.pos + .wav`
@@ -2024,8 +2036,8 @@ different internally (encrypted, different versions, etc) and not always can be 
   - *rwsd*: `.brwsd .rwsd`
   - Codecs: PCM8 PCM16BE NGC_DSP
 - **ffmpeg.c**
-  - FFmpeg supported format (check log) [*FFMPEG_faulty*]
-  - FFmpeg supported format [*FFMPEG*]
+  - FFmpeg format (check log) [*FFMPEG_faulty*]
+  - FFmpeg format [*FFMPEG*]
   - *ffmpeg*: `.(any) .sbao .bao`
   - Codecs: FFmpeg(various)
 - **ea_eaac.c**

--- a/src/coding/coding.h
+++ b/src/coding/coding.h
@@ -494,7 +494,6 @@ mpeg_codec_data* init_mpeg_custom(STREAMFILE* sf, off_t start_offset, coding_t* 
 int mpeg_get_sample_rate(mpeg_codec_data* data);
 long mpeg_bytes_to_samples(long bytes, const mpeg_codec_data* data);
 
-uint32_t mpeg_get_tag_size(STREAMFILE* sf, uint32_t offset, uint32_t header);
 bool test_ahx_key(STREAMFILE* sf, off_t offset, crikey_t* crikey);
 #endif
 
@@ -509,6 +508,7 @@ typedef struct {
 } mpeg_frame_info;
 bool mpeg_get_frame_info(STREAMFILE* sf, off_t offset, mpeg_frame_info* info);
 bool mpeg_get_frame_info_h(uint32_t header, mpeg_frame_info* info);
+uint32_t mpeg_get_tag_size(STREAMFILE* sf, uint32_t offset, uint32_t header);
 size_t mpeg_get_samples(STREAMFILE* sf, off_t start_offset, size_t bytes);
 int32_t mpeg_get_samples_clean(STREAMFILE* sf, off_t start, size_t size, uint32_t* p_loop_start, uint32_t* p_loop_end, int is_vbr);
 

--- a/src/formats.c
+++ b/src/formats.c
@@ -536,6 +536,7 @@ static const char* extension_list[] = {
     "sdp", //txth/reserved [Metal Gear Arcade (AC)]
     "sdf",
     "sdt",
+    "sdx", //txth/reserved [Anarchy Reigns (multi)]
     "se",
     "se3", //txth/reserved (.nub container) [Tales of Vesperia (X360/PS3), Tales of Graces f (PS3)]
     "seb",

--- a/src/formats.c
+++ b/src/formats.c
@@ -1678,7 +1678,8 @@ void get_vgmstream_meta_description(VGMSTREAM* vgmstream, char* out, size_t out_
     }
 
 #ifdef VGM_USE_FFMPEG
-    if (vgmstream->coding_type ==  coding_FFmpeg) {
+    // include FFmpeg's format description for the generic ffmpeg.c parser
+    if (vgmstream->coding_type == coding_FFmpeg && vgmstream->meta_type == meta_FFMPEG) {
         const char* description_ffmpeg = ffmpeg_get_format_name(vgmstream->codec_data);
         if (description_ffmpeg != NULL) {
             snprintf(out, out_size, "%s (%s)", description, description_ffmpeg);

--- a/src/layout/blocked_ea_schl.c
+++ b/src/layout/blocked_ea_schl.c
@@ -111,11 +111,13 @@ void block_update_ea_schl(off_t block_offset, VGMSTREAM * vgmstream) {
 
             /* id, size, samples, IMA hist, stereo/mono data */
             case coding_DVI_IMA:
-                for(i = 0; i < vgmstream->channels; i++) {
+                for (i = 0; i < vgmstream->channels; i++) {
                     off_t header_offset = block_offset + 0xc + i*4;
                     vgmstream->ch[i].adpcm_history1_32 = read_16bitLE(header_offset+0x00, vgmstream->ch[i].streamfile);
                     vgmstream->ch[i].adpcm_step_index  = read_16bitLE(header_offset+0x02, vgmstream->ch[i].streamfile);
-                    vgmstream->ch[i].offset = block_offset + 0xc + (4*vgmstream->channels);
+
+                    // mono in schl_fixed .asf, rare [Triple Play 97 (PC)]
+                    vgmstream->ch[i].offset = block_offset + 0x0c + 0x04*2;
                 }
 
                 break;
@@ -135,7 +137,7 @@ void block_update_ea_schl(off_t block_offset, VGMSTREAM * vgmstream) {
                     interleave = is_interleaved ? (block_samples / 28 * 0x0f) : 0;
 
                     /* NOT channels*0x04, as seen in Superbike 2000 (PC) EA-XA v1 mono vids */
-                    vgmstream->ch[i].offset = block_offset + 0x0c + 2*0x04 + i*interleave;
+                    vgmstream->ch[i].offset = block_offset + 0x0c + 0x04*2 + i*interleave;
                 }
 
                 break;
@@ -146,7 +148,8 @@ void block_update_ea_schl(off_t block_offset, VGMSTREAM * vgmstream) {
                 vgmstream->current_block_samples = -1;
                 break;
         }
-    } else {
+    }
+    else {
         switch(vgmstream->coding_type) {
             /* id, size, samples, offsets-per-channel, flag (0x01 = data start), data */
             case coding_EA_MT:

--- a/src/layout/blocked_ea_schl.c
+++ b/src/layout/blocked_ea_schl.c
@@ -1,22 +1,22 @@
 #include "layout.h"
 #include "../coding/coding.h"
 #include "../vgmstream.h"
+#include "../util/endianness.h"
 
 /* parse EA style blocks, id+size+samples+data */
-void block_update_ea_schl(off_t block_offset, VGMSTREAM * vgmstream) {
-    STREAMFILE* streamFile = vgmstream->ch[0].streamfile;
-    int i;
+void block_update_ea_schl(off_t block_offset, VGMSTREAM* vgmstream) {
+    STREAMFILE* sf = vgmstream->ch[0].streamfile;
     size_t block_size, block_samples;
-    int32_t (*read_32bit)(off_t,STREAMFILE*) = vgmstream->codec_endian ? read_32bitBE : read_32bitLE;
+    read_u32_t read_u32 = get_read_u32(vgmstream->codec_endian);
 
     uint32_t flag_lang = (vgmstream->codec_config >> 16) & 0xFFFF;
-    int flag_be = (vgmstream->codec_config & 0x02);
-    int flag_adpcm = (vgmstream->codec_config & 0x01);
-    int flag_offsets = (vgmstream->codec_config & 0x04);
+    bool flag_adpcm = (vgmstream->codec_config & 0x01);
+    bool flag_be = (vgmstream->codec_config & 0x02);
+    bool flag_offsets = (vgmstream->codec_config & 0x04);
 
 
     /* EOF reads: signal we have nothing and let the layout fail */
-    if (block_offset >= get_streamfile_size(streamFile)) {
+    if (block_offset >= get_streamfile_size(sf)) {
         vgmstream->current_block_offset = block_offset;
         vgmstream->next_block_offset = block_offset;
         vgmstream->current_block_samples = -1;
@@ -25,26 +25,26 @@ void block_update_ea_schl(off_t block_offset, VGMSTREAM * vgmstream) {
 
     /* read a single block */
     {
-        uint32_t block_id = read_32bitBE(block_offset+0x00,streamFile);
+        uint32_t block_id = read_u32be(block_offset+0x00,sf);
 
-        if (flag_be) /* size is always LE, except in early SS/MAC */
-            block_size = read_32bitBE(block_offset + 0x04,streamFile);
+        // size is always LE, except in early SS/MAC
+        if (flag_be)
+            block_size = read_u32be(block_offset + 0x04,sf);
         else
-            block_size = read_32bitLE(block_offset + 0x04,streamFile);
+            block_size = read_u32le(block_offset + 0x04,sf);
 
-        if (block_id == 0x5343446C || block_id == (0x53440000 | flag_lang)) {
-            /* "SCDl" or "SDxx" audio chunk */
+        // accept "SCDl" or "SDxx" audio chunk and ignore others (audio "SCHl/SCCl/...", non-target lang, video "pIQT/MADk/...", etc)
+        if (block_id == get_id32be("SCDl") || block_id == (get_id32be("SD\0\0") | flag_lang)) {
             if (vgmstream->coding_type == coding_PSX)
-                block_samples = ps_bytes_to_samples(block_size-0x10, vgmstream->channels);
+                block_samples = ps_bytes_to_samples(block_size - 0x10, vgmstream->channels);
             else
-                block_samples = read_32bit(block_offset+0x08,streamFile);
+                block_samples = read_u32(block_offset+0x08,sf);
         }
         else {
-            /* ignore other chunks (audio "SCHl/SCCl/...", non-target lang, video "pIQT/MADk/...", etc) */
-            block_samples = 0; /* layout ignores this */
+            block_samples = 0; // layout ignores this
         }
 
-        if (block_id == 0x00000000 || block_id == 0xFFFFFFFF || block_id == 0x5343456C) { /* EOF */
+        if (block_id == 0x00000000 || block_id == 0xFFFFFFFF || block_id == get_id32be("SCEl")) { // EOF
             vgmstream->current_block_samples = -1;
             return;
         }
@@ -64,28 +64,29 @@ void block_update_ea_schl(off_t block_offset, VGMSTREAM * vgmstream) {
     /* set new channel offsets and ADPCM history */
     /* ADPCM hist could be considered part of the stream/decoder (some EAXA decoders call it "EAXA R1" when it has hist), and BNKs
      * (with no blocks) may also have them in the first offset, but also may not. To simplify we just read them here. */
-    if (!flag_offsets) { /* v0 doesn't provide channel offsets, they need to be calculated */
+    if (!flag_offsets) {
+        // v0 doesn't provide channel offsets, they need to be calculated
         switch (vgmstream->coding_type) {
             /* id, size, samples, data */
             case coding_PCM8_int:
-                for (i = 0; i < vgmstream->channels; i++) {
-                    vgmstream->ch[i].offset = block_offset + 0x0c + (i*0x01);
+                for (int i = 0; i < vgmstream->channels; i++) {
+                    vgmstream->ch[i].offset = block_offset + 0x0c + (0x01 * i);
                 }
 
                 break;
 
             /* id, size, samples, data */
             case coding_PCM16_int:
-                for (i = 0; i < vgmstream->channels; i++) {
-                    vgmstream->ch[i].offset = block_offset + 0x0c + (i*0x02);
+                for (int i = 0; i < vgmstream->channels; i++) {
+                    vgmstream->ch[i].offset = block_offset + 0x0c + (0x02 * i);
                 }
 
                 break;
 
             /* id, size, samples, data */
             case coding_PCM8:
-                for (i = 0; i < vgmstream->channels; i++) {
-                    vgmstream->ch[i].offset = block_offset + 0x0c + (block_samples*i*0x01);
+                for (int i = 0; i < vgmstream->channels; i++) {
+                    vgmstream->ch[i].offset = block_offset + 0x0c + (0x01 * i * block_samples);
                 }
 
                 break;
@@ -93,31 +94,31 @@ void block_update_ea_schl(off_t block_offset, VGMSTREAM * vgmstream) {
             /* id, size, samples, data */
             case coding_PCM16LE:
             case coding_PCM16BE:
-                for (i = 0; i < vgmstream->channels; i++) {
-                    vgmstream->ch[i].offset = block_offset + 0x0c + (block_samples*i*0x02);
+                for (int i = 0; i < vgmstream->channels; i++) {
+                    vgmstream->ch[i].offset = block_offset + 0x0c + (0x02 * i * block_samples);
                 }
 
                 break;
 
             /* id, size, unk1, unk2, interleaved data */
             case coding_PSX:
-                for (i = 0; i < vgmstream->channels; i++) {
-                    size_t interleave = (block_size-0x10) / vgmstream->channels;
-                    vgmstream->ch[i].offset = block_offset + 0x10 + i*interleave;
+                for (int i = 0; i < vgmstream->channels; i++) {
+                    size_t interleave = (block_size - 0x10) / vgmstream->channels;
+                    vgmstream->ch[i].offset = block_offset + 0x10 + interleave * i;
                 }
-                /* 0x08/0x0c: unknown (doesn't look like hist or offsets, as 1ch files has them too) */
+                // 0x08/0x0c: unknown (doesn't look like hist or offsets, as 1ch files has them too)
 
                 break;
 
             /* id, size, samples, IMA hist, stereo/mono data */
             case coding_DVI_IMA:
-                for (i = 0; i < vgmstream->channels; i++) {
+                for (int i = 0; i < vgmstream->channels; i++) {
                     off_t header_offset = block_offset + 0xc + i*4;
-                    vgmstream->ch[i].adpcm_history1_32 = read_16bitLE(header_offset+0x00, vgmstream->ch[i].streamfile);
-                    vgmstream->ch[i].adpcm_step_index  = read_16bitLE(header_offset+0x02, vgmstream->ch[i].streamfile);
+                    vgmstream->ch[i].adpcm_history1_32 = read_s16le(header_offset+0x00, vgmstream->ch[i].streamfile);
+                    vgmstream->ch[i].adpcm_step_index  = read_s16le(header_offset+0x02, vgmstream->ch[i].streamfile);
 
-                    // mono in schl_fixed .asf, rare [Triple Play 97 (PC)]
-                    vgmstream->ch[i].offset = block_offset + 0x0c + 0x04*2;
+                    // full header, seen in mono in schl_fixed .asf [Triple Play 97 (PC)]
+                    vgmstream->ch[i].offset = block_offset + 0x0c + (0x04 * 2);
                 }
 
                 break;
@@ -125,19 +126,18 @@ void block_update_ea_schl(off_t block_offset, VGMSTREAM * vgmstream) {
             /* id, size, samples, hists-per-channel, stereo/interleaved data */
             case coding_EA_XA:
             case coding_EA_XA_int:
-                for (i = 0; i < vgmstream->channels; i++) {
-                    int is_interleaved = vgmstream->coding_type == coding_EA_XA_int;
-                    size_t interleave;
+                for (int i = 0; i < vgmstream->channels; i++) {
+                    bool is_interleaved = vgmstream->coding_type == coding_EA_XA_int;
 
                     /* read ADPCM history from all channels before data (not actually read in sx.exe) */
-                    //vgmstream->ch[i].adpcm_history1_32 = read_16bit(block_offset + 0x0C + (i*0x04) + 0x00,streamFile);
-                    //vgmstream->ch[i].adpcm_history2_32 = read_16bit(block_offset + 0x0C + (i*0x04) + 0x02,streamFile);
+                    //vgmstream->ch[i].adpcm_history1_32 = read_s16le(block_offset + 0x0C + (i*0x04) + 0x00,sf);
+                    //vgmstream->ch[i].adpcm_history2_32 = read_s16le(block_offset + 0x0C + (i*0x04) + 0x02,sf);
 
-                    /* the block can have padding so find the channel size from num_samples */
-                    interleave = is_interleaved ? (block_samples / 28 * 0x0f) : 0;
+                    // the block can have padding so find the channel size from num_samples
+                    size_t interleave = is_interleaved ? (block_samples / 28 * 0x0f) : 0;
 
-                    /* NOT channels*0x04, as seen in Superbike 2000 (PC) EA-XA v1 mono vids */
-                    vgmstream->ch[i].offset = block_offset + 0x0c + 0x04*2 + i*interleave;
+                    // full header, seen in EA-XA v1 mono vids [Superbike 2000 (PC)]
+                    vgmstream->ch[i].offset = block_offset + 0x0c + (0x04 * 2) + interleave * i;
                 }
 
                 break;
@@ -153,12 +153,12 @@ void block_update_ea_schl(off_t block_offset, VGMSTREAM * vgmstream) {
         switch(vgmstream->coding_type) {
             /* id, size, samples, offsets-per-channel, flag (0x01 = data start), data */
             case coding_EA_MT:
-                for (i = 0; i < vgmstream->channels; i++) {
-                    off_t channel_start = read_32bit(block_offset + 0x0C + (0x04*i),streamFile);
-                    vgmstream->ch[i].offset = block_offset + 0x0C + (0x04*vgmstream->channels) + channel_start + 0x01;
+                for (int i = 0; i < vgmstream->channels; i++) {
+                    off_t channel_start = read_u32(block_offset + 0x0C + (0x04*i),sf);
+                    vgmstream->ch[i].offset = block_offset + 0x0C + (0x04 * vgmstream->channels) + channel_start + 0x01;
                 }
 
-                /* flush decoder in every block change */
+                // flush decoder in every block change
                 flush_ea_mt(vgmstream);
                 break;
 
@@ -169,32 +169,32 @@ void block_update_ea_schl(off_t block_offset, VGMSTREAM * vgmstream) {
             case coding_MPEG_layer2:
             case coding_MPEG_layer3:
             case coding_MPEG_ealayer3:
-                for (i = 0; i < vgmstream->channels; i++) {
+                for (int i = 0; i < vgmstream->channels; i++) {
                     off_t channel_start;
 
-                    /* EALayer3 6ch uses 1ch*6 with offsets, no flag in header [Medal of Honor 2010 (PC) movies] */
+                    // EALayer3 6ch uses 1ch*6 with offsets, no flag in header [Medal of Honor 2010 (PC) movies]
                     if (vgmstream->channels > 2) {
-                        channel_start = read_32bit(block_offset + 0x0C + 0x04*i,streamFile);
+                        channel_start = read_u32(block_offset + 0x0C + 0x04 * i,sf);
                     } else {
-                        channel_start = read_32bit(block_offset + 0x0C,streamFile);
+                        channel_start = read_u32(block_offset + 0x0C,sf);
                     }
 
-                    vgmstream->ch[i].offset = block_offset + 0x0C + (0x04*vgmstream->channels) + channel_start;
+                    vgmstream->ch[i].offset = block_offset + 0x0C + (0x04 * vgmstream->channels) + channel_start;
                 }
                 break;
 #endif
             /* id, size, samples, offsets-per-channel, interleaved data (w/ optional hist per channel) */
             default:
-                for (i = 0; i < vgmstream->channels; i++) {
-                    off_t channel_start = read_32bit(block_offset + 0x0C + (0x04*i),streamFile);
-                    vgmstream->ch[i].offset = block_offset + 0x0C + (0x04*vgmstream->channels) + channel_start;
+                for (int i = 0; i < vgmstream->channels; i++) {
+                    off_t channel_start = read_u32(block_offset + 0x0C + (0x04*i),sf);
+                    vgmstream->ch[i].offset = block_offset + 0x0C + (0x04 * vgmstream->channels) + channel_start;
                 }
 
-                /* read ADPCM history before each channel if needed (not actually read in sx.exe) */
+                // read ADPCM history before each channel if needed (not actually read in sx.exe)
                 if (flag_adpcm) {
-                    for (i = 0; i < vgmstream->channels; i++) {
-                        //vgmstream->ch[i].adpcm_history1_32 = read_16bit(vgmstream->ch[i].offset+0x00,streamFile);
-                        //vgmstream->ch[i].adpcm_history3_32 = read_16bit(vgmstream->ch[i].offset+0x02,streamFile);
+                    for (int i = 0; i < vgmstream->channels; i++) {
+                        //vgmstream->ch[i].adpcm_history1_32 = read_s16le(vgmstream->ch[i].offset+0x00,sf);
+                        //vgmstream->ch[i].adpcm_history3_32 = read_s16le(vgmstream->ch[i].offset+0x02,sf);
                         vgmstream->ch[i].offset += 0x04;
                     }
                 }

--- a/src/layout/blocked_ws_aud.c
+++ b/src/layout/blocked_ws_aud.c
@@ -3,22 +3,20 @@
 
 /* set up for the block at the given offset */
 void block_update_ws_aud(off_t block_offset, VGMSTREAM * vgmstream) {
-    int i;
+    STREAMFILE* sf = vgmstream->ch[0].streamfile;
+
+    uint16_t block_size = read_u16le(block_offset + 0x00, sf);
+    uint16_t pcm_size   = read_u16le(block_offset + 0x02, sf); // typically 0x800 except in last block
+
     vgmstream->current_block_offset = block_offset;
-    vgmstream->current_block_size = read_16bitLE(
-            vgmstream->current_block_offset,
-            vgmstream->ch[0].streamfile);
-    vgmstream->next_block_offset = vgmstream->current_block_offset +
-        vgmstream->current_block_size + 8;
+    vgmstream->current_block_size = block_size;
+    vgmstream->next_block_offset = block_offset + block_size + 0x08;
 
     if (vgmstream->coding_type == coding_WS) {
-        vgmstream->ws_output_size = read_16bitLE(
-                vgmstream->current_block_offset+2,
-                vgmstream->ch[0].streamfile);
+        vgmstream->ws_output_size = pcm_size;
     }
 
-    for (i=0;i<vgmstream->channels;i++) {
-        vgmstream->ch[i].offset = vgmstream->current_block_offset +
-            8 + vgmstream->current_block_size*i;
+    for (int i = 0; i < vgmstream->channels; i++) {
+        vgmstream->ch[i].offset = block_offset + 0x08 + block_size * i;
     }
 }

--- a/src/libvgmstream.h
+++ b/src/libvgmstream.h
@@ -5,12 +5,22 @@
 /* libvgmstream: vgmstream's public API
  *
  * Basic usage (also see api_example.c):
+ *   - libstreamfile_open_*(...)        // fopen FILE wrapper
+ *   - libvgmstream_create(...)         // init + setup + open format
+ *   - libvgmstream_render(...)         // main decode
+ *   - output samples + repeat libvgmstream_render until 'done' flag is set
+ *   - libvgmstream_free(...)           // lib cleanup
+ *   - libstreamfile_close(...)         // fclose FILE wrapper
+ * 
+ * This can be used instead of the libvgmstream_create(...) wrapper:
  *   - libvgmstream_init(...)           // create context
  *   - libvgmstream_setup(...)          // setup config (if needed)
- *   - libvgmstream_open_stream(...)    // open format
- *   - libvgmstream_render(...)         // main decode
- *   - output samples + repeat libvgmstream_render until 'done' is set
- *   - libvgmstream_free(...)           // cleanup
+ *   - libvgmstream_open_stream(...)    // open subsong
+ *   - ...
+ *   - libvgmstream_close_stream(...)   // close subsong (optional)
+ * 
+ * Note that the 'libstreamfile' must be opened and closed separately from libvgmstream.
+ * This is by design, to behave similarly to a FILE.
  *
  * By default vgmstream behaves like a decoder (returns samples until stream end), but you can configure
  * it to loop N times or even downmix. In other words, it also behaves a bit like a player.
@@ -208,7 +218,7 @@ LIBVGMSTREAM_API void libvgmstream_setup(libvgmstream_t* lib, libvgmstream_confi
  * - will close currently loaded song if needed
  * - libsf (custom IO) is not needed after _open and should be closed, as vgmstream re-opens as needed
  * - subsong can be 1..N or 0 = default/first
- *   ** to check if a file has subsongs, _open default + check format->total_subsongs (then _open Nth)
+ *   ** to check if a file has subsongs, _open_stream default + check format->subsong_count (then _open_stream Nth)
  */
 LIBVGMSTREAM_API int libvgmstream_open_stream(libvgmstream_t* lib, libstreamfile_t* libsf, int subsong);
 

--- a/src/libvgmstream_streamfile.h
+++ b/src/libvgmstream_streamfile.h
@@ -48,7 +48,8 @@ typedef struct libstreamfile_t {
 /* helper (same as libsf->close(libsf)) */
 LIBVGMSTREAM_API void libstreamfile_close(libstreamfile_t* libsf);
 
-/* base libstreamfile using STDIO (cached) */
+/* base libstreamfile using STDIO (cached). 
+ * Note that this must be closed with libstreamfile_close(...) */
 LIBVGMSTREAM_API libstreamfile_t* libstreamfile_open_from_stdio(const char* filename);
 
 /* base libstreamfile using a FILE (cached); the filename is needed as metadata */

--- a/src/meta/aifc.c
+++ b/src/meta/aifc.c
@@ -246,7 +246,14 @@ VGMSTREAM* init_vgmstream_aifc(STREAMFILE* sf) {
                             case 0x76696D61: {  /* "vima" [Star Wars Anakin's Speedway (PC), Star Wars Early Learning Activity Center (PC)] */
                                 /* "Variable IMA 16 bit" */
                                 coding_type = coding_IMUSE;
-                                sample_rate = 22050; // field has garbage (like part of the name) consistently
+
+                                // sample rate has garbage (part of text) consistently
+                                if (sample_size != 16) {
+                                    // supposedly, from decomp: 12 = 11025, 14 = 44100, other = 22050
+                                    VGM_LOG("AIFC: unknown VIMA sample rate\n");
+                                    goto fail;
+                                }
+                                sample_rate = 22050;
                                 break;
                             }
 

--- a/src/meta/csb.c
+++ b/src/meta/csb.c
@@ -17,19 +17,19 @@ VGMSTREAM* init_vgmstream_csb(STREAMFILE* sf) {
 
     /* checks */
     if (!is_id32be(0x00,sf, "@UTF"))
-        goto fail;
+        return NULL;
     /* .csb: standard
      * .cxb: Dariusburst - Another Chronicle (AC) */
     if (!check_extensions(sf, "csb,cxb"))
-        goto fail;
+        return NULL;
 
     /* .csb is an early, simpler version of .acb+awk (see acb.c) used until ~2013?
      * Can stream from .cpk but this only loads memory data. */
     {
         int rows, sdl_rows, sdl_row, i;
-        const char *name;
-        const char *row_name;
-        const char *sdl_name;
+        const char* name;
+        const char* row_name;
+        const char* sdl_name;
         uint32_t sdl_offset, sdl_size, offset, size;
         uint32_t table_offset = 0x00;
         uint8_t ttype;
@@ -171,12 +171,12 @@ VGMSTREAM* init_vgmstream_utf_dsp(STREAMFILE* sf) {
 
     /* checks */
     if (!is_id32be(0x00,sf, "@UTF"))
-        goto fail;
+        return NULL;
 
     /* .aax: assumed
      * (extensionless): extracted names inside csb/cpk often don't have extensions */
     if (!check_extensions(sf, "aax,"))
-        goto fail;
+        return NULL;
 
     /* contains a simple UTF table with one row and various columns being header info */
     {
@@ -258,12 +258,12 @@ VGMSTREAM* init_vgmstream_utf_ahx(STREAMFILE* sf) {
 
     /* checks */
     if (!is_id32be(0x00,sf, "@UTF"))
-        goto fail;
+        return NULL;
 
     /* .aax: assumed
      * (extensionless): extracted names inside csb/cpk often don't have extensions */
     if (!check_extensions(sf, "aax,"))
-        goto fail;
+        return NULL;
 
     /* contains a simple UTF table with one row and offset+size info */
     {

--- a/src/meta/ea_schl_fixed.c
+++ b/src/meta/ea_schl_fixed.c
@@ -42,8 +42,9 @@ VGMSTREAM* init_vgmstream_ea_schl_fixed(STREAMFILE* sf) {
 
     /* .asf: original [NHK 97 (PC)]
      * .lasf: fake for plugins
-     * .cnk/dct: ps1 [NBA Live 97 (PS1)] */
-    if (!check_extensions(sf, "asf,lasf,cnk,dct"))
+     * .cnk/dct: ps1 [NBA Live 97 (PS1)]
+     * .tgv/uv: PC videos [NBA Live 97 (PC)] */
+    if (!check_extensions(sf, "asf,lasf,cnk,dct,tgv,uv"))
         return NULL;
 
     /* see ea_schl.c for more info about blocks */

--- a/src/meta/ea_schl_map_mpf_mus.c
+++ b/src/meta/ea_schl_map_mpf_mus.c
@@ -22,13 +22,13 @@ VGMSTREAM* init_vgmstream_ea_map_mus(STREAMFILE* sf) {
     off_t section_offset;
     int target_stream = sf->stream_index;
 
-    /* check extension */
+    /* checks */
+    if (!is_id32be(0x00, sf, "PFDx"))
+        return NULL;
+
     if (!check_extensions(sf, "map,lin,mpf"))
         return NULL;
 
-    /* always big endian */
-    if (!is_id32be(0x00, sf, "PFDx"))
-        return NULL;
 
     version = read_u8(0x04, sf);
     if (version > 1) goto fail;

--- a/src/util/sf_utils.c
+++ b/src/util/sf_utils.c
@@ -5,10 +5,42 @@
 #include "log.h"
 
 
+static bool is_uppercase(const char* str) {
+    if (str == NULL || str[0] == '\0')
+        return false;
+
+    while (str[0] != '\0') {
+        char c = str[0];
+        if (c < 'A' || c > 'Z')
+            return false;
+        str++;
+    }
+
+    return true;
+}
+
+static void make_uppercase(char* str) {
+    if (str == NULL)
+        return;
+
+    while (str[0] != '\0') {
+        char c = str[0];
+        if (c >= 'a' && c <= 'z') {
+            str[0] = c - 0x20;
+        }
+        str++;
+    }
+}
+
+
 /* change pathname's extension to another (or add it if extensionless) */
 static void swap_extension(char* pathname, /*size_t*/ int pathname_len, const char* swap) {
     char* extension = (char*)filename_extension(pathname);
-    //todo safeops
+    if (!extension)
+        return;
+    bool ext_upper = is_uppercase(extension);
+
+    //TODO: safeops
     if (extension[0] == '\0') {
         if (swap[0] != '\0') {
             strcat(pathname, ".");
@@ -22,6 +54,11 @@ static void swap_extension(char* pathname, /*size_t*/ int pathname_len, const ch
             extension--;
             extension[0] = '\0';
         }
+    }
+
+    // try to match original case so Linux/Mac may work
+    if (ext_upper) {
+        make_uppercase(extension);
     }
 }
 


### PR DESCRIPTION
- Add .afc VIMA variation [Star Wars: The Gungan Frontier (PC)]
- Add SCHl_fixed .tgv/uv videos [NBA Live 97 (PC)]
- Keep case when opening companion files by ext for Linux/Mac
- Fix .csb with empty .aax [Anarchy Reigns (multi)]
- Fix mono .asf DVI_IMA [Triple Play 97 (PC)]
- Fix broken format info
- Fix compiling without MPG123
