### PR TITLE
Increase XA interleaved channels limit to 128

### DIFF
--- a/src/meta/xa.c
+++ b/src/meta/xa.c
@@ -216,7 +216,10 @@ fail:
 }
 
 
-#define XA_MAX_CHANNELS 32 /* usually 08-16, seen ~24 in Langrisser V (PS1) */
+/* usually 08-16; Digimon Rumble Arena uses ~120. We use 255 to support many
+ * interleaved channels while excluding 0xFF, as it is commonly used for
+ * null/silence sectors in games like Yu-Gi-Oh! FM, Ace Combat, etc. */
+#define XA_MAX_CHANNELS 255
 
 typedef struct {
    uint32_t info;

--- a/src/meta/xa.c
+++ b/src/meta/xa.c
@@ -41,8 +41,9 @@ VGMSTREAM* init_vgmstream_xa(STREAMFILE* sf) {
      * .no: Incredible Crisis (PS1)
      * (extensionless): bigfiles [Castlevania: Symphony of the Night (PS1)]
      * .xai: Quake II (PS1)
-     * .ixa: Wild Arms (PS1) */
-    if (!check_extensions(sf,"xa,str,pxa,grn,an2,no,,xai,ixa"))
+     * .ixa: Wild Arms (PS1)
+     * .xap: Digimon Rumble Arena (PS1) */
+    if (!check_extensions(sf,"xa,str,pxa,grn,an2,no,,xai,ixa,xap"))
         return NULL;
 
     /* Proper XA comes in raw (BIN 2352 mode2/form2) CD sectors, that contain XA subheaders.
@@ -216,10 +217,7 @@ fail:
 }
 
 
-/* usually 08-16; Digimon Rumble Arena uses ~120. We use 255 to support many
- * interleaved channels while excluding 0xFF, as it is commonly used for
- * null/silence sectors in games like Yu-Gi-Oh! FM, Ace Combat, etc. */
-#define XA_MAX_CHANNELS 255
+#define XA_MAX_CHANNELS 128 /* usually 08-16, seen ~120 in Digimon Rumble Arena (PS1) */
 
 typedef struct {
    uint32_t info;
@@ -285,6 +283,12 @@ static int xa_read_subsongs(STREAMFILE* sf, int target_subsong, uint32_t start, 
         bool is_audio = !(xa_submode & 0x08) && (xa_submode & 0x04) && !(xa_submode & 0x02);
         bool is_eof = (xa_submode & 0x80);
         bool is_target = false;
+
+        // padding/silent sectors [Yu-Gi-Oh! Forbidden Memories (PS1)]
+        if (xa_chan == 0xFF) {
+            offset += sector_size;
+            continue;
+        }
 
         if (xa_chan >= XA_MAX_CHANNELS) {
             VGM_LOG("XA: too many channels: %x\n", xa_chan);


### PR DESCRIPTION
This PR increases the `XA_MAX_CHANNELS` constant from 32 to 255.

**Context:**
While most PS1 titles use between 8 and 16 interleaved channels, some specific games like _Digimon Rumble Arena_ use up to ~120 channels. The current limit of 32 causes these files to be ignored by the metadata parser.

**Technical Choice:**
The limit is set to 255 instead of 256 to maintain the existing validation logic. Since `xa_chan` is a `uint8_t`, this change allows the parser to process all channels up to 254 while still treating `0xFF` (255) as an invalid/null channel. This is important for games like _Yu-Gi-Oh! Forbidden Memories_, _Ace Combat_, etc., which use `0xFF` for padding/silent sectors.