### PR TITLE
Fix plugin accept_unknown regression

### DIFF
--- a/src/base/plugins.c
+++ b/src/base/plugins.c
@@ -17,7 +17,7 @@ int vgmstream_ctx_is_valid(const char* filename, vgmstream_ctx_valid_cfg *cfg) {
     bool reject_extensionless = cfg && cfg->reject_extensionless;
     bool skip_standard = cfg && cfg->skip_standard;
     bool accept_common = cfg && cfg->accept_common;
-    bool accept_unknown = cfg && cfg->accept_common;
+    bool accept_unknown = cfg && cfg->accept_unknown;
 
     if (is_extension) {
         extension = filename;


### PR DESCRIPTION
This was introduced in 00a8ee7, and caused accept_unknown to be reading accept_common instead. This broke reading TXTHs for unknown file extensions, especially for Audacious where accept_common isn't configurable in the GUI.