### PR TITLE
MSF/VAG additions

### DIFF
--- a/src/formats.c
+++ b/src/formats.c
@@ -279,6 +279,7 @@ static const char* extension_list[] = {
     "is14",
     "isb",
     "isd",
+    "ish",
     "isws",
     "itl",
     "ivaud",
@@ -361,7 +362,7 @@ static const char* extension_list[] = {
     "mdsp",
     "med",
     "mhk",
-    "mjb",
+    "mjh",
     "mi4", //fake extension for .mib (renamed, to be removed)
     "mib",
     "mic",
@@ -725,7 +726,7 @@ static const char* extension_list[] = {
     "wvp", //txth/semi [Virtua Cop 2 (PC)]
     "wvs",
     "wvx",
-    "wxd",
+    "wxh",
     "wxv",
 
     "x",

--- a/src/meta/msf.c
+++ b/src/meta/msf.c
@@ -49,8 +49,7 @@ VGMSTREAM* init_vgmstream_msf(STREAMFILE* sf) {
      * 0x10 often goes with 0x01 but not always (Castlevania HoD); Malicious PS3 uses flag 0x2 instead */
     loop_flag = (flags != 0xffffffff) && ((flags & 0x01) || (flags & 0x02));
 
-    /* loop offset markers: marker N = 0x18 + N * (0x08), but in practice only marker 0 is used
-     * (Saints Row 2 saves original filename in 0x28) */
+    /* loop offset markers: marker N = 0x18 + N * (0x08), but in practice only marker 0 is used */
     if (loop_flag) {
         loop_start = read_u32be(0x18,sf);
         loop_end = read_u32be(0x1C,sf); /* loop duration */
@@ -66,6 +65,10 @@ VGMSTREAM* init_vgmstream_msf(STREAMFILE* sf) {
     vgmstream->sample_rate = sample_rate;
     if (vgmstream->sample_rate == 0) /* some MSFv1 (PS-ADPCM only?) [Megazone 23 - Aoi Garland (PS3)] */
         vgmstream->sample_rate = 48000;
+
+    /* rare MSFv0 only? [Jak and Daxter Collection (PS3, PS-ADPCM), Saints Row 2 (PS3, ATRAC3)] */
+    if (/*read_u8(0x03, sf) == '0' &&*/ read_u32be(0x28, sf) != 0xFFFFFFFF)
+        read_string(vgmstream->stream_name, 0x18, 0x28, sf); /* 0x18th byte (at 0x3F) is always 0xFF in SR2 */
 
     switch (codec) {
         case 0x00:   /* PCM (Big Endian) [MSEnc tests] */

--- a/src/meta/vag.c
+++ b/src/meta/vag.c
@@ -29,8 +29,9 @@ VGMSTREAM* init_vgmstream_vag(STREAMFILE* sf) {
      * .svg: ModernGroove: Ministry of Sound Edition (PS2)
      * (extensionless): The Urbz (PS2), The Sims series (PS2)
      * .wav: Sniper Elite (PS2), The Simpsons Game (PS2/PSP) 
-     * .msv: Casper and the Ghostly Trio (PS2), Earache Extreme Metal Racing (PS2) */
-    if (!check_extensions(sf,"vag,swag,str,vig,l,r,vas,xa2,snd,svg,,wav,lwav,msv"))
+     * .msv: Casper and the Ghostly Trio (PS2), Earache Extreme Metal Racing (PS2)
+     * .eng,fre,ger,int,ita,jap,spa: Jak and Daxter (PS2) (Preview build) */
+    if (!check_extensions(sf,"vag,swag,str,vig,l,r,vas,xa2,snd,svg,,wav,lwav,msv,eng,fre,ger,int,ita,jap,spa"))
         return NULL;
 
     file_size = get_streamfile_size(sf);

--- a/src/meta/xwb_xsb.h
+++ b/src/meta/xwb_xsb.h
@@ -11,7 +11,7 @@
 //#define XSB_XACT2_2_MAX   25  // 0x19 // XeDK 2.0.1332.0-v25
 #define XSB_XACT2_3_MAX     28  // 0x1C // XeDK 2.0.1434.0, Full Auto (X360, 2005-04-27)-v27, XeDK 2.0.1538.0-v28
 #define XSB_XACT2_4_MAX     34  // 0x22 // Amped 3-v31, Table Tennis-v34
-//#define XSB_XACT25_MAX    38  // 0x26 // Prey (v38) // v39 too?
+//#define XSB_XACT2_5_MAX   38  // 0x26 // Prey (v38) // v39 too?
 #define XSB_XACT2_6_MAX     41  // 0x29 // other PC/X360 games
 
 
@@ -791,7 +791,7 @@ static bool parse_xsb(xsb_header* xsb, STREAMFILE* sf, char* xwb_wavebank_name) 
         xsb->index_size             = 0x14;
         xsb->entry_size             = 0x14;
     }
-    // TOD), although not much of a point since these XACT builds
+    // TODO, although not much of a point since these XACT builds
     // strictly force XWB stream names to be always enabled
     //else if (xsb->version <= XSB_XACT2_0_MAX) {}
     //else if (xsb->version <= XSB_XACT2_1_MAX) {}


### PR DESCRIPTION
* MSF: display rarely used stream name [Jak and Daxter Collection (PS3), Saints Row 2 (PS3)]
* VAG: add .eng,fre,ger,int,ita,jap,spa extensions [Jak and Daxter: The Precursor Legacy (PS2) (Preview build)]