### PR TITLE
cf_df: .SND, .SFX, .TRK improvements:

### DIFF
--- a/src/meta/cf_df.c
+++ b/src/meta/cf_df.c
@@ -130,8 +130,9 @@ static void read_name(STREAMFILE* sf, off_t entry, int name_max, df_name_t* dst)
     dst->name[len] = '\0';
 }
 
-/* Assembled track via segmented layout: play the given sequence of loop chunks once. */
-static VGMSTREAM* build_segmented(STREAMFILE* sf, df_chunk_t* chunks, int* seq, int count) {
+/* Assembled track via segmented layout: play the given sequence of loop chunks once.
+ * loop=1 marks the whole assembled track as an end-to-end loop (.trk/.sfx only; .mov/.snd excluded). */
+static VGMSTREAM* build_segmented(STREAMFILE* sf, df_chunk_t* chunks, int* seq, int count, int loop) {
     VGMSTREAM* v = NULL;
     segmented_layout_data* data = init_layout_segmented(count);
     if (!data) goto fail;
@@ -149,7 +150,7 @@ static VGMSTREAM* build_segmented(STREAMFILE* sf, df_chunk_t* chunks, int* seq, 
     if (!setup_layout_segmented(data))
         goto fail;
 
-    v = allocate_segmented_vgmstream(data, 0, -1, -1);
+    v = allocate_segmented_vgmstream(data, loop, 0, count - 1);
     if (!v) goto fail;
     return v;
 
@@ -222,6 +223,7 @@ VGMSTREAM* init_vgmstream_cf_df(STREAMFILE* sf) {
         return NULL;
 
     int is_mov = check_extensions(sf, "mov");
+    int loop_track = check_extensions(sf, "sfx,trk");
     int target = sf->stream_index;
     if (target == 0)
         target = 1;
@@ -372,7 +374,7 @@ VGMSTREAM* init_vgmstream_cf_df(STREAMFILE* sf) {
                 lo = 0;
                 hi = count - 1;
             }
-            vgmstream = build_segmented(sf, loop, seq + lo, hi - lo + 1);
+            vgmstream = build_segmented(sf, loop, seq + lo, hi - lo + 1, loop_track);
         }
         if (!vgmstream)
             goto fail;

--- a/src/meta/cf_df.c
+++ b/src/meta/cf_df.c
@@ -27,6 +27,16 @@
 #define DF_NAME_MAX     (32-1)  /* MOV identifiers; others use 15 */
 #define DF_MAX_CHUNKS   0x4000  /* sanity cap for table sizes */
 
+/* .snd "container-0" variant (HELP.SND/KID.SND): unlike the trk/sfx/mov container-1 loop block, the
+ * order list, track name and per-chunk names live in container 0. Offsets are relative to container 0.
+ * The order list holds 1-based container ids; the chunk-name table has one Pascal entry per chunk
+ * (entry k -> container k+1). */
+#define DF_SND_ORDER_COUNT  0x22   /* u16 */
+#define DF_SND_ORDER        0x26   /* u16[], 1-based container ids */
+#define DF_SND_TRACK_NAME   0xa6   /* Pascal string */
+#define DF_SND_CHUNK_NAMES  0xc2   /* Pascal entries, stride 0x18, one per chunk */
+#define DF_SND_NAME_STRIDE  0x18
+
 typedef struct {
     int container_id;
     int codec_flag;
@@ -131,7 +141,7 @@ static void read_name(STREAMFILE* sf, off_t entry, int name_max, df_name_t* dst)
 }
 
 /* Assembled track via segmented layout: play the given sequence of loop chunks once.
- * loop=1 marks the whole assembled track as an end-to-end loop (.trk/.sfx only; .mov/.snd excluded). */
+ * loop=1 marks the whole assembled track as an end-to-end loop (.snd/.sfx/.trk only; .mov excluded). */
 static VGMSTREAM* build_segmented(STREAMFILE* sf, df_chunk_t* chunks, int* seq, int count, int loop) {
     VGMSTREAM* v = NULL;
     segmented_layout_data* data = init_layout_segmented(count);
@@ -200,6 +210,142 @@ static VGMSTREAM* build_blocked(STREAMFILE* sf, df_chunk_t* loop, int loop_count
     return v;
 }
 
+/* DreamFactory v4 .snd "container-0" variant: the assembled theme's order list, track name and
+ * per-chunk names live in container 0, unlike the container 1 found in trk/sfx/mov.
+ * Builds the theme (subsong 1: order assembled in order, leading/trailing silence trimmed,
+ * end-to-end loop) plus every chunk as a named subsong. *handled is set once a valid container-0
+ * order is recognized, so the caller stops instead of falling through to the container-1 path. */
+static VGMSTREAM* build_snd_c0(STREAMFILE* sf, int containers, int* handled) {
+    VGMSTREAM* vgmstream = NULL;
+    df_chunk_t* chunks = NULL;
+    int* seq = NULL;
+    int* listed = NULL;
+    df_name_t* names = NULL;
+    char track_name[STREAM_NAME_SIZE];
+    char basename[STREAM_NAME_SIZE];
+    int order_count, listed_count = 0, subsongs, target;
+    bool has_track;
+    off_t fsize, c0;
+
+    *handled = 0;
+    track_name[0] = '\0';
+    get_streamfile_filename(sf, basename, sizeof(basename));
+    fsize = get_streamfile_size(sf);
+
+    c0 = read_u32le(DF_HEADER_SIZE + 0x00 * 0x04, sf);
+    if (c0 <= 0 || c0 + DF_SND_CHUNK_NAMES > fsize)
+        return NULL;
+    order_count = read_u16le(c0 + DF_SND_ORDER_COUNT, sf);
+    if (order_count <= 0 || order_count > DF_MAX_CHUNKS)
+        return NULL; /* no container-0 order -> not this variant; caller falls through */
+    if (c0 + DF_SND_ORDER + (off_t)order_count * 0x02 > fsize)
+        return NULL;
+
+    *handled = 1; /* a valid container-0 .snd from here -> NULL means parse failure, do not fall through */
+
+    chunks = calloc((size_t)containers, sizeof(df_chunk_t));
+    names  = calloc((size_t)containers, sizeof(df_name_t));
+    seq    = malloc((size_t)order_count * sizeof(int));
+    listed = malloc((size_t)containers * sizeof(int));
+    if (!chunks || !names || !seq || !listed)
+        goto fail;
+
+    for (int i = 0; i < containers; i++)
+        is_valid_chunk(sf, containers, i, &chunks[i]); /* fills chunks[i], sets .valid */
+
+    /* order list -> seq (1-based container ids); bail if any reference isn't a real audio chunk */
+    for (int i = 0; i < order_count; i++) {
+        int id = read_u16le(c0 + DF_SND_ORDER + (off_t)i * 0x02, sf);
+        if (id < 1 || id >= containers || !chunks[id].valid)
+            goto fail;
+        seq[i] = id;
+    }
+
+    /* per-chunk names: entry k (0-based) -> container k+1 */
+    for (int id = 1; id < containers; id++) {
+        off_t e = c0 + DF_SND_CHUNK_NAMES + (off_t)(id - 1) * DF_SND_NAME_STRIDE;
+        if (e + 1 > fsize)
+            break;
+        int ln = read_u8(e, sf);
+        if (ln <= 0 || ln > 15 || e + 1 + ln > fsize)
+            continue;
+        for (int k = 0; k < ln; k++)
+            names[id].name[k] = read_u8(e + 1 + k, sf);
+        names[id].name[ln] = '\0';
+    }
+
+    /* track name */
+    {
+        int tl = read_u8(c0 + DF_SND_TRACK_NAME, sf);
+        if (tl > 0 && tl <= DF_NAME_MAX && c0 + DF_SND_TRACK_NAME + 1 + tl <= fsize) {
+            for (int k = 0; k < tl; k++)
+                track_name[k] = read_u8(c0 + DF_SND_TRACK_NAME + 1 + k, sf);
+            track_name[tl] = '\0';
+        }
+    }
+
+    /* individual list: every valid audio chunk, kept (not folded) so each stays its own named subsong */
+    for (int i = 0; i < containers; i++)
+        if (chunks[i].valid)
+            listed[listed_count++] = i;
+
+    has_track = (order_count > 1); /* a single-step order is not a real assembled track */
+    subsongs = (has_track ? 1 : 0) + listed_count;
+    if (subsongs == 0)
+        goto fail;
+
+    target = sf->stream_index;
+    if (target == 0)
+        target = 1;
+    if (target < 0 || target > subsongs)
+        goto fail;
+
+    if (has_track && target == 1) {
+        /* subsong 1: assembled theme, leading/trailing silence trimmed, looped end-to-end */
+        int lo = 0, hi = order_count - 1;
+        while (lo <= hi && is_silent_chunk(sf, &chunks[seq[lo]]))
+            lo++;
+        while (hi >= lo && is_silent_chunk(sf, &chunks[seq[hi]]))
+            hi--;
+        if (lo > hi) { lo = 0; hi = order_count - 1; } /* all silent: keep so it isn't empty */
+
+        vgmstream = build_segmented(sf, chunks, seq + lo, hi - lo + 1, 1);
+        if (!vgmstream)
+            goto fail;
+        snprintf(vgmstream->stream_name, STREAM_NAME_SIZE, "%s", track_name[0] ? track_name : basename);
+    }
+    else {
+        int piece = target - (has_track ? 1 : 0); /* 1-based index into listed[] */
+        int id = listed[piece - 1];
+
+        vgmstream = allocate_vgmstream(1, 0);
+        if (!vgmstream)
+            goto fail;
+        config_chunk(vgmstream, &chunks[id]);
+        if (names[id].name[0])
+            snprintf(vgmstream->stream_name, STREAM_NAME_SIZE, "%s", names[id].name);
+        else
+            snprintf(vgmstream->stream_name, STREAM_NAME_SIZE, "%.*s#%d", STREAM_NAME_SIZE - (11 + 1 + 1), basename, piece);
+        if (!vgmstream_open_stream(vgmstream, sf, chunks[id].offset))
+            goto fail;
+    }
+
+    vgmstream->num_streams = subsongs;
+    free(chunks);
+    free(names);
+    free(seq);
+    free(listed);
+    return vgmstream;
+
+fail:
+    free(chunks);
+    free(names);
+    free(seq);
+    free(listed);
+    close_vgmstream(vgmstream);
+    return NULL;
+}
+
 VGMSTREAM* init_vgmstream_cf_df(STREAMFILE* sf) {
     VGMSTREAM* vgmstream = NULL;
     df_name_t* names = NULL;
@@ -222,8 +368,18 @@ VGMSTREAM* init_vgmstream_cf_df(STREAMFILE* sf) {
     if (containers <= 0 || containers > INT16_MAX)
         return NULL;
 
+    /* Most .snd files store the theme in container 0.
+     * A few rare .snd files may instead use a container 1 loop block
+     * and instead fall through to the shared path below. */
+    if (check_extensions(sf, "snd")) {
+        int handled = 0;
+        vgmstream = build_snd_c0(sf, containers, &handled);
+        if (handled)
+            return vgmstream;
+    }
+
     int is_mov = check_extensions(sf, "mov");
-    int loop_track = check_extensions(sf, "sfx,trk");
+    int loop_track = check_extensions(sf, "sfx,snd,trk");
     int target = sf->stream_index;
     if (target == 0)
         target = 1;


### PR DESCRIPTION
- Add loop support for TRK files
- Add SND names
- Add loop support for some SND/SFX files.

[Samples](https://files.catbox.moe/7pqlb8.zip).
[Logs](https://files.catbox.moe/oq6vtn.zip).