### PR TITLE
fix: correct 'writting' to 'writing' typo in user-facing messages

### DIFF
--- a/cli/tools/txtp_maker.py
+++ b/cli/tools/txtp_maker.py
@@ -60,7 +60,7 @@ class Cli(object):
         p.add_argument('-s',  dest='subsong_start', help="Start subsong", type=int)
         p.add_argument('-S',  dest='subsong_end', help="End subsong", type=int)
         p.add_argument('-o',  dest='overwrite', help="Overwrite existing .txtp\n(beware when using with internal names alone)", action='store_true')
-        p.add_argument('-oi', dest='overwrite_ignore', help="Ignore repeated rather than overwritting .txtp\n", action='store_true')
+        p.add_argument('-oi', dest='overwrite_ignore', help="Ignore repeated rather than overwriting .txtp\n", action='store_true')
         p.add_argument('-or', dest='overwrite_rename', help="Rename rather than overwriting", action='store_true')
         p.add_argument('-os', dest='overwrite_suffix', help="Rename with a suffix")
         p.add_argument('-os2', dest='overwrite_suffix_2nd', help="Rename with a suffix not including first", action='store_true')

--- a/doc/BUILD-LIB.md
+++ b/doc/BUILD-LIB.md
@@ -24,7 +24,7 @@ REM set PATH=%PATH%;C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildToo
 On Windows 10, `curl` is included by default but you may need to get it first (or just manually download and unzip files).
 
 ### Tools and PATHs
-When using Mingw+Git you may add their location to Windows' `PATH` variable, so programs like `gcc.exe` work as-is in Windows CMD without writting the full path. This can be done temporarily by writting in the command line: `set PATH=C:\(path-to-mingw)\mingw32\bin;C:\Git\usr\bin;%PATH%` (for example), or in Windows' system variables panel.
+When using Mingw+Git you may add their location to Windows' `PATH` variable, so programs like `gcc.exe` work as-is in Windows CMD without writing the full path. This can be done temporarily by writing in the command line: `set PATH=C:\(path-to-mingw)\mingw32\bin;C:\Git\usr\bin;%PATH%` (for example), or in Windows' system variables panel.
 
 For MSYS2 commands should work (after installing relevant programs) by opening the `msys2/mingw32.exe` console.
 

--- a/doc/TXTP.md
+++ b/doc/TXTP.md
@@ -926,7 +926,7 @@ introC_2ch.at3
 mainC_2ch.at3
 
 # - group intro/main pairs as segments, starting from 1 and repeating for A/B/C
-# same as writting "group = -S2" x3
+# same as writing "group = -S2" x3
 group = S2R
 
 # - play all as layer (can't set loop_start_segment in this case)

--- a/vspf.py
+++ b/vspf.py
@@ -134,7 +134,7 @@ class ProjectFixer:
         out_name = self.prj_pathname
         if TEST_OUTPUT:
             out_name += '.test'
-        print("writting " + out_name)
+        print("writing " + out_name)
 
 
         with open(out_name, 'w', newline='\r\n', encoding='utf-8-sig') as f:


### PR DESCRIPTION
Correct 'writting' to 'writing' typo in 4 files:

- `vspf.py` line 137: `print("writting ", ...)` → user-facing status message
- `cli/tools/txtp_maker.py` line 63: CLI help text for `-oi` flag
- `doc/TXTP.md`: documentation typo
- `doc/BUILD-LIB.md`: documentation typo

Minimal fix, no other changes.