### PR TITLE
fix: prevent stack buffer underflow in ps_find_padding on short reads

### DIFF
--- a/src/coding/psx_decoder.c
+++ b/src/coding/psx_decoder.c
@@ -406,6 +406,7 @@ size_t ps_find_padding(STREAMFILE* sf, off_t start_offset, size_t data_size, int
                 read_offset = 0; //?
             bytes = read_streamfile(buf, read_offset, sizeof(buf), sf);
             buf_pos = (bytes / frame_size * frame_size);
+            if (bytes < (int)frame_size) break;    /* not enough data for a full frame */
         }
 
         buf_pos -= frame_size;


### PR DESCRIPTION
Fixes #2000

When `ps_find_padding()` reads fewer than one full frame (`frame_size = 0x10`), `buf_pos` is set to 0 and then unconditionally decremented by `frame_size`, becoming negative. Subsequent reads from `buf + buf_pos` underflow the stack buffer.

Fix: add a guard that breaks out of the reverse scan loop when fewer than one full frame was read, before the `buf_pos -= frame_size` subtraction.

Reported-by: ni-liao