### PR TITLE
coding_OKI_UM: clarify format

### DIFF
--- a/src/coding/oki_decoder.c
+++ b/src/coding/oki_decoder.c
@@ -232,6 +232,8 @@ void decode_oki4s(VGMSTREAMCHANNEL* stream, short* outbuf, int channelspacing, i
 
 
 /* OKI ADPCM variant seen in the UltraMarine (UM) sound lib, used various minor Japanese games.
+ * (Only used in later games that use streaming audio; earlier versions of the
+ * library only supported sequenced audio and used uncompressed PCM samples.)
  * Original code has mono and mono-interleaved variants. Reversed from UMUT.DLL (~2000).
  * Info: https://www7.big.or.jp/~suppoko/ultramarine/index.html
  */


### PR DESCRIPTION
This ADPCM format was introduced in newer versions of the UltraMarine player library. The original UltraMarine was a sequenced format which uses uncompressed PCM samples.

I've double checked the `UMUT.DLL` shipped with games using sequenced audio and confirmed ADPCM support is missing from those. It was added in the newer version of the driver shipped with games that use this ADPCM format.

I haven't been able to tell if this format is explicitly named anything to differentiate it from the earlier format. There is a version byte in the `.um` sidecar files that identifies this as a later version of the format. The "UltraMarine 2" name is used in a couple of PS2 games but it seems to be a slightly different format so I haven't identified this explicitly as "UltraMarine 2".

cc @bnnm 