### PR TITLE
misc11

### DIFF
--- a/cli/api_example.c
+++ b/cli/api_example.c
@@ -138,7 +138,7 @@ static int api_example(const char* infile) {
 
     // process done
     libvgmstream_free(lib);
-    fclose(outfile);
+    if (outfile) fclose(outfile);
     free(fill_pcm16);
 
     printf("done\n");
@@ -146,7 +146,7 @@ static int api_example(const char* infile) {
 fail:
     // process failed
     libvgmstream_free(lib);
-    fclose(outfile);
+    if (outfile) fclose(outfile);
     free(fill_pcm16);
 
     printf("failed!\n");

--- a/cli/vgmstream_cli_utils.c
+++ b/cli/vgmstream_cli_utils.c
@@ -6,97 +6,135 @@
 #include "../src/libvgmstream.h"
 
 
-static void clean_filename(char* dst, int clean_paths) {
-    for (int i = 0; i < strlen(dst); i++) {
-        char c = dst[i];
+// strscpy like copy with char filtering; returns -1 on error or truncation (see string_utils.c)
+static int strcpy_filter(char* dst, size_t dst_size, const char* src, bool clean_paths) {
+    if (dst == NULL || dst_size == 0)
+        return 0;
+
+    if (src == NULL) {
+        dst[0] = '\0';
+        return -1;
+    }
+
+    size_t copy_len = 0;
+    size_t copy_max = dst_size - 1; // for null
+    while (copy_len < copy_max && src[copy_len] != '\0') {
+        char c = src[copy_len];
+
         bool is_badchar = (clean_paths && (c == '\\' || c == '/'))
             || c == '*' || c == '?' || c == ':' /*|| c == '|'*/ || c == '<' || c == '>';
         if (is_badchar)
-            dst[i] = '_';
+            c = '_';
+
+        dst[copy_len] = c;
+        copy_len++;
     }
+    dst[copy_len] = '\0';
+
+    // truncation
+    if (copy_len == copy_max && src[copy_len] != '\0')
+        return -1;
+
+    return (int)copy_len;
 }
 
-/* replaces a filename with "?n" (stream name), "?f" (infilename) or "?s" (subsong) wildcards
- * ("?" was chosen since it's not a valid Windows filename char and hopefully nobody uses it on Linux) */
-bool cli_replace_filename(char* dst, size_t dstsize, cli_config_t* cfg, libvgmstream_t* vgmstream) {
-    int subsong;
-    char stream_name[CLI_PATH_LIMIT];
-    char buf[CLI_PATH_LIMIT];
-    char tmp[CLI_PATH_LIMIT];
 
+/* Reads a output filename string like "blah_?n.wav" and does controlled replaces of wilcards:
+ * "?n" = stream name, "?f" = infilename, "?s" = subsong, "?0ns" = 0-padded subsong
+ * ("?" was chosen since it's not a valid Windows filename char and hopefully nobody uses it on Linux)
+ * ?s is 'CLI current subsong's index' (-s X -S Y) and not just vgmstream's.
+ */
+bool cli_replace_filename(char* dst, size_t dst_size, cli_config_t* cfg, libvgmstream_t* vgmstream) {
+    const char* fmt = cfg->outfilename_config;
 
-    /* file has a "%" > temp replace for snprintf */
-    int n = snprintf(buf, sizeof(buf), "%s", cfg->outfilename_config);
-    if (n <= 0 || n >= sizeof(buf)) // truncation
+    if (!dst || dst_size == 0 || !fmt || fmt[0] == '\0') // || !cfg || !vgmstream
         return false;
 
-    int buf_len = strlen(buf);
-    for (int i = 0; i < buf_len; i++) {
-        if (buf[i] == '%')
-            buf[i] = '|'; /* non-valid filename, not used in format */
-    }
+    size_t dst_i = 0;
+    size_t dst_max = dst_size - 1; // for null
+    while (dst_i < dst_max && fmt[0] != '\0') {
 
-    /* init config */
-    subsong = vgmstream->format->subsong_index;
-    if (subsong > vgmstream->format->subsong_count || subsong != cfg->subsong_current_index) {
-        subsong = 0; /* for games without subsongs / bad config */
-    }
+        if (fmt[0] != '?') {
+            // (non-? char): copy as-is
 
-    if (vgmstream->format->stream_name[0] != '\0') {
-        snprintf(stream_name, sizeof(stream_name), "%s", vgmstream->format->stream_name);
-        clean_filename(stream_name, 1); /* clean subsong name's subdirs */
-    }
-    else {
-        snprintf(stream_name, sizeof(stream_name), "%s", cfg->infilename);
-        clean_filename(stream_name, 0); /* don't clean user's subdirs */
-    }
+            dst[dst_i] = fmt[0];
 
-    /* do controlled replaces of each wildcard (in theory could appear N times) */
-    do {
-        char* pos = strchr(buf, '?');
-        if (!pos)
-            break;
-
-        /* use buf as format and copy formatted result to tmp (assuming snprintf's format must not overlap with dst) */
-        if (pos[1] == 'n') {
-            pos[0] = '%';
-            pos[1] = 's'; /* use %s */
-            snprintf(tmp, sizeof(tmp), buf, stream_name);
-        }
-        else if (pos[1] == 'f') {
-            pos[0] = '%';
-            pos[1] = 's'; /* use %s */
-            snprintf(tmp, sizeof(tmp), buf, cfg->infilename);
-        }
-        else if (pos[1] == 's') {
-            pos[0] = '%';
-            pos[1] = 'i'; /* use %i */
-            snprintf(tmp, sizeof(tmp), buf, subsong);
-        }
-        else if ((pos[1] == '0' && pos[2] >= '1' && pos[2] <= '9' && pos[3] == 's')) {
-            pos[0] = '%';
-            pos[3] = 'i'; /* use %0Ni */
-            snprintf(tmp, sizeof(tmp), buf, subsong);
-        }
-        else {
-            /* not recognized */
-            // TO-DO: should move buf or swap "?" with "_"? may happen with non-ascii on Windows; for now break to avoid infinite loops
-            break;
+            dst_i += 1;
+            fmt += 1;
+            continue;
         }
 
-        /* copy result to buf again, so it can be used as format in next replace
-         * (can be optimized with some pointer swapping but who cares about a few extra nanoseconds) */
-        snprintf(buf, sizeof(buf), "%s", tmp);
-    }
-    while (1);
+        // fmt below can's overread since it's null-terminated and fmt[n] == x will short-circuit if \0 is encountered
 
-    /* replace % back */
-    for (int i = 0; i < strlen(buf); i++) {
-        if (buf[i] == '|')
-            buf[i] = '%';
+        if (fmt[1] == 'n') {
+            // ?n: copy stream name
+            const char* src = vgmstream->format->stream_name[0] != '\0' ?
+                vgmstream->format->stream_name :
+                cfg->infilename;
+
+            int n = strcpy_filter(&dst[dst_i], dst_size - dst_i, src, true); // clean stream name's subdirs
+            if (n < 0)
+                return false;
+
+            dst_i += n;
+            fmt += 2;
+            continue;
+        }
+
+        if (fmt[1] == 'f') {
+            // ?f: copy filename
+            const char* src = cfg->infilename;
+
+            int n = strcpy_filter(&dst[dst_i], dst_size - dst_i, src, false); // don't clean user's subdirs
+            if (n < 0)
+                return false;
+
+            dst_i += n;
+            fmt += 2;
+            continue;
+        }
+
+        if (fmt[1] == 's') {
+            // ?s: copy subsong
+            int subsong = vgmstream->format->subsong_index;
+            if (subsong > vgmstream->format->subsong_count || subsong != cfg->subsong_current_index)
+                subsong = 0;
+
+            int n = snprintf(&dst[dst_i], dst_size - dst_i, "%d", subsong);
+            if (n < 0 || n >= dst_size - dst_i)
+                return false;
+
+            dst_i += n;
+            fmt += 2;
+            continue;
+        }
+
+        if ((fmt[1] == '0' && fmt[2] >= '1' && fmt[2] <= '9' && fmt[3] == 's')) {
+            // ?0*s: copy 0-padded subsong
+            int subsong = vgmstream->format->subsong_index;
+            if (subsong > vgmstream->format->subsong_count || subsong != cfg->subsong_current_index)
+                subsong = 0;
+
+            char tmp[5+1] = { '%', fmt[1], fmt[2], 'd', '\0' }; // "%0*d"
+            int n = snprintf(&dst[dst_i], dst_size - dst_i, tmp, subsong);
+            if (n < 0 || n >= dst_size - dst_i)
+                return false;
+
+            dst_i += n;
+            fmt += 4;
+            continue;
+        }
+
+        // ?x not recognized, or ?\0: return error for now
+        return false;
     }
 
-    snprintf(dst, dstsize, "%s", buf);
+    dst[dst_i] = '\0'; // all cpys above null-terminate but just in case
+
+    // detect truncation
+    if (dst_i == 0 || (dst_i == dst_max && fmt[0] != '\0'))
+        return false;
+
     return true;
 }
 
@@ -149,6 +187,7 @@ void print_info(libvgmstream_t* vgmstream, cli_config_t* cfg) {
     }
 }
 
+
 void print_tags(cli_config_t* cfg) {
     libvgmstream_tags_t* tags = NULL;
     libstreamfile_t* sf_tags = NULL;
@@ -174,6 +213,7 @@ void print_tags(cli_config_t* cfg) {
     libstreamfile_close(sf_tags);
 }
 
+
 void print_title(libvgmstream_t* vgmstream, cli_config_t* cfg) {
     char title[1024];
     libvgmstream_title_t tcfg = {0};
@@ -190,6 +230,7 @@ void print_title(libvgmstream_t* vgmstream, cli_config_t* cfg) {
 
     printf("title: %s\n", title);
 }
+
 
 void print_json_version(const char* vgmstream_version) {
     int extension_list_len = 0;

--- a/doc/USAGE.md
+++ b/doc/USAGE.md
@@ -544,41 +544,54 @@ music01.bfstm #C3,4
 A text file named `.txtm` for some formats with companion files. It lists
 name combos determining which companion files to load for each main file.
 
-It is needed for formats where name combos are hardcoded, so vgmstream doesn't
-know which companion file(s) to load if its name doesn't match the main file.
-Note that companion file order is usually important.
+Typically vgmstream loads companion files by extension (bgm.awb -> bgm.ac),
+but some games hardcode name combos, and vgmstream doesn't know which companion
+file(s) to load if its name doesn't match the main file.
 
 Usage example (used when opening files in the left part of the list):
+
+**.mpf + .mus**
 ```
 # Harry Potter and the Chamber of Secrets (PS2)
 exterior.mpf: exterior.mus,ext_o.mus
 willow.mpf: willow.mus,willow_o.mus
 ```
+**.awb + .acb**
 ```
-# Metal Gear Solid: Snake Eater 3D (3DS) names for .awb
+# Metal Gear Solid: Snake Eater 3D (3DS)
 bgm_2_streamfiles.awb: bgm_2.acb
 ```
+**.xwb + .xsb**
 ```
-# hashes of SE1_Common_BGM + SRSA/SRST [Hyrule Warriors: Age of Calamity (Switch)]
-# (more exactly "R_SRSA［SE1_Common_BGM］" and "R_SRST［SE1_Common_BGM］")
+# Psyconauts (Xbox)
+CA_NightMusic.xwb: CAMusic.xsb
+CAJAMusic.xwb: CAMusic.xsb
+```
+**.srsa + .srst**
+```
+# Hyrule Warriors: Age of Calamity (Switch)
+# hash of SE1_Common_BGM + SRSA/SRST (more exactly "R_SRSA［SE1_Common_BGM］" and "R_SRST［SE1_Common_BGM］")
 0x3a160928.srsa: 0x272c6efb.srst
 ```
+
+
+The header bank may refer to N streams by ID, so they are comma-separated:
 ```
-# Snack World (Switch) names for .awb (single .acb for all .awb, order matters)
+# stream ID 0, 1
+exterior.mpf: exterior.mus, ext_o.mus
+```
+
+Similarly, `.awb` allows multiple files to be mapped againts a single `.acb`. In those cases
+define them in the order `.acb` expects them (bank ID 0, 1, 2...). ID resets when `.acb` changes.
+You may insert 'dummy' entries to alter or break the order.
+```
+# Snack World (Switch)
+#  awb bank ID 0 
 bgm.awb: bgm.acb
+#  awb bank ID 1
 bgm_DLC1.awb: bgm.acb
-```
-In rare cases you need to setup some extra flags
-```
-event_stream2.awb: event_stream2.acb
-event_stream2_dlc1.awb: event_stream2.acb
-event_stream2_dlc2.awb: event_stream2.acb
-event_stream2_dlc3.awb: event_stream2.acb
-# next "flag" allows both effect.acb and even_stream2.acb in the same file
-#@reset-pos
-effect.awb: effect.acb
-effect_dlc2.awb: effect.acb
-effect_dlc3.awb: effect.acb
+# awb bank ID 0 (ID resets when .acb changes)
+se.awb: se.acb
 ```
 
 #### GENH

--- a/src/base/info.c
+++ b/src/base/info.c
@@ -1,12 +1,11 @@
-#include <ctype.h>
 #include "info.h"
 #include "mixing.h"
 #include "play_state.h"
 #include "../coding/coding.h"
 #include "../layout/layout.h"
 #include "../util/channel_mappings.h"
-#include "../util/sf_utils.h"
 #include "../util/string_utils.h"
+#include "../util/hashes.h"
 
 #define TEMPSIZE (256+32)
 
@@ -218,22 +217,6 @@ typedef struct {
     int count_max;
 } bitrate_info_t;
 
-static uint32_t hash_sf(STREAMFILE* sf) {
-    char path[PATH_LIMIT];
-
-    get_streamfile_name(sf, path, sizeof(path));
-
-    /* our favorite garbo hash a.k.a FNV-1 32b */
-    uint32_t hash = 2166136261;
-    int i = 0;
-    while (path[i] != '\0') {
-        char c = tolower(path[i]);
-        hash = (hash * 16777619) ^ (uint8_t)c;
-        i++;
-    }
-
-    return hash;
-}
 
 /* average bitrate helper to get STREAMFILE for a channel, since some codecs may use their own */
 static STREAMFILE* get_vgmstream_average_bitrate_channel_streamfile(VGMSTREAM* vgmstream, int channel) {

--- a/src/coding/ffmpeg_decoder_utils.c
+++ b/src/coding/ffmpeg_decoder_utils.c
@@ -616,12 +616,10 @@ static bool ffmpeg_fmt_chunk_swap_endian(uint8_t* buf, size_t buf_size, uint32_t
 /* Makes a XMA1/2 RIFF header using a "fmt " chunk (XMAWAVEFORMAT/XMA2WAVEFORMATEX) or "XMA2" chunk (XMA2WAVEFORMAT), as a base:
  * Useful to preserve the stream layout */
 static int ffmpeg_make_riff_xma_chunk(STREAMFILE* sf, uint8_t* buf, size_t buf_size, uint32_t data_size, uint32_t chunk_offset, uint32_t chunk_size, int* p_is_xma1) {
-    if (chunk_size <= 0)
+    const int min_size = 0x04 * 2 + 0x04 + 0x04 * 2 + 0x04 * 2; // 0x1c = RIFF + fmt + data
+    if (chunk_size <= 0 || chunk_size > buf_size - min_size)
         return 0;
 
-    int buf_max = (0x04 * 2 + 0x04) + (0x04 * 2 + chunk_size) + (0x04 * 2);
-    if (buf_max > buf_size)
-        return 0;
 
     if (read_streamfile(buf+0x14, chunk_offset, chunk_size, sf) != chunk_size)
         return 0;
@@ -640,8 +638,11 @@ static int ffmpeg_make_riff_xma_chunk(STREAMFILE* sf, uint8_t* buf, size_t buf_s
         is_xma1 = codec == 0x0165 || codec == 0x6501;
     }
 
+    int buf_max = min_size + chunk_size;
+    uint32_t riff_size = min_size - (0x04 * 2) + chunk_size + data_size; 
+
     memcpy   (buf+0x00, "RIFF", 0x04);
-    put_u32le(buf+0x04, buf_max - (0x04 * 2)+ data_size); /* riff size */
+    put_u32le(buf+0x04, riff_size);
     memcpy   (buf+0x08, "WAVE", 0x04);
     memcpy   (buf+0x0c, is_xma2_old ? "XMA2" : "fmt ", 0x04);
     put_u32le(buf+0x10, chunk_size);

--- a/src/coding/libs/binka_dec.c
+++ b/src/coding/libs/binka_dec.c
@@ -414,7 +414,7 @@ static int decode_frame(binka_decoder_t* dec, unsigned char* src, int src_size, 
     // OG lib checks the bitreader's initial *src vs current *src (padded).
     // in multichannel there may be more data beyond (aligned).
     bl_align(is, 32);
-    int bytes_done = is->b_off / 8;
+    int bytes_done = bl_pos(is) / 8;
     return bytes_done;
 }
 

--- a/src/coding/libs/clhca.c
+++ b/src/coding/libs/clhca.c
@@ -11,6 +11,8 @@
  *     https://gist.github.com/kode54/ce2bf799b445002e125f06ed833903c0
  * - Cleaned up and re-reverse engineered for HCA v3 by bnnm, using Thealexbarney's VGAudio decoder as reference
  *     https://github.com/Thealexbarney/VGAudio
+ * - Ambisonics info by Youjose
+ *     https://github.com/Youjose/CriCodecs
  */
 
 /* TODO:
@@ -18,7 +20,6 @@
  * - simplify DCT4 code
  * - add extra validations: encoder_delay/padding < sample_count, etc
  * - intensity should memset if intensity is 15 or set in reset? (no games hit 15?)
- * - check mdct + tables, add floats
  * - simplify bitreader to use in decoder only (no need to read +16 bits)
  */
 
@@ -43,6 +44,9 @@
  * - Ver.2.06.05 2018-12 [scramble subkey API]
  * - Ver.2.06.07 2020-02, 2021-02
  * - Ver.3.01.00 2020-11 [decoding updates]
+ * - Ver.3.02.02 ~2021-07 [ambisonic support]
+ * - Ver.3.04.01 ~2024-04
+ * - Ver.3.10.00 ~2025-06
  * Same version rebuilt gets a newer date, and new APIs change header strings, but header versions
  * only change when decoder does. Despite the name, no "Integer" version seems to exist.
  */
@@ -65,6 +69,10 @@
 
 #define HCA_MIN_CHANNELS  1
 #define HCA_MAX_CHANNELS  16            /* internal max (in practice only 8 can be encoded) */
+//#define HCA_MAX_CHANNELS  255         /* libs seems to allow max for ambisonics support (less in hca-mx?),
+//                                       * no known cases and tools only seem to define 4/9/16 Nth order */
+#define HCA_CHANNEL_CONFIG_FLAG_AMBISONICS 0x80
+
 #define HCA_MIN_SAMPLE_RATE  1          /* assumed */
 #define HCA_MAX_SAMPLE_RATE  0x7FFFFF   /* encoder max seems 48000 */
 
@@ -317,7 +325,9 @@ int clHCA_getInfo(clHCA* hca, clHCA_stInfo* info) {
     info->loopStartSample = info->loopStartBlock * info->samplesPerBlock - info->encoderDelay + info->loopStartDelay;
     info->loopEndSample = info->loopEndBlock * info->samplesPerBlock - info->encoderDelay + (info->samplesPerBlock - info->loopEndPadding);
 
-    return 0;
+    info->ambisonics = (hca->channel_config & HCA_CHANNEL_CONFIG_FLAG_AMBISONICS) != 0;
+
+    return HCA_RESULT_OK;
 }
 
 //HCADecoder_DecodeBlockInt32
@@ -605,7 +615,8 @@ static void setup_channel_types(int channels, int track_count, int channel_confi
                     if (channel_config == 0) {
                         ct[2] = STEREO_PRIMARY;
                         ct[3] = STEREO_SECONDARY;
-                    } else {
+                    }
+                    else {
                         ct[2] = DISCRETE;
                         ct[3] = DISCRETE;
                     }
@@ -617,7 +628,8 @@ static void setup_channel_types(int channels, int track_count, int channel_confi
                     if (channel_config <= 2) {
                         ct[3] = STEREO_PRIMARY;
                         ct[4] = STEREO_SECONDARY;
-                    } else {
+                    }
+                    else {
                         ct[3] = DISCRETE;
                         ct[4] = DISCRETE;
                     }
@@ -649,18 +661,25 @@ static void setup_channel_types(int channels, int track_count, int channel_confi
                     ct[6] = STEREO_PRIMARY;
                     ct[7] = STEREO_SECONDARY;
                     break;
-                default:
+
+                default: {
+                    int ch;
                     /* all 0 (DISCRETE) */
-                    //for (ch = 0; ch < channels_per_track; ch++) {
-                    //    ct[i] = DISCRETE;
-                    //}
+                    for (ch = 0; ch < channels_per_track; ch++) {
+                        ct[i] = DISCRETE;
+                    }
                     break;
+                }
             }
         }
     }
 
     /* lib sets to 0 after channels_per_track * track_count 
      * (implicit here since channel_types is init'd to 0) */
+
+    /* channel_config & 0x80 means ambisonics, but this function doesn't seem to do detection,
+     * probably because Nth order ambisonics would be discrete and wouldn't set stereo bands */
+
 }
 
 int clHCA_DecodeHeader(clHCA* hca, const void* data, unsigned int size) {
@@ -1216,8 +1235,12 @@ static void clHCA_DecodeBlock_transform(clHCA* hca) {
     unsigned int subframe, ch;
 
     for (subframe = 0; subframe < HCA_SUBFRAMES; subframe++) {
+        int hfr_channels = hca->channel_config & HCA_CHANNEL_CONFIG_FLAG_AMBISONICS ? /* v3.02+ */
+            1 :
+            hca->channels;
+
         /* restore missing bands from spectra */
-        for (ch = 0; ch < hca->channels; ch++) {
+        for (ch = 0; ch < hfr_channels; ch++) {
             reconstruct_noise(&hca->channel[ch], hca->min_resolution, hca->ms_stereo, &hca->random, subframe);
 
             reconstruct_high_frequency(&hca->channel[ch], hca->hfr_group_count, hca->bands_per_hfr_group,

--- a/src/coding/libs/clhca.h
+++ b/src/coding/libs/clhca.h
@@ -47,6 +47,7 @@ typedef struct clHCA_stInfo {
     unsigned int sampleCount;
     unsigned int loopStartSample;
     unsigned int loopEndSample;
+    int ambisonics;
 } clHCA_stInfo;
 
 /* Retrieves header information for decoding and playback (it's the caller's responsability

--- a/src/coding/mtaf_decoder.c
+++ b/src/coding/mtaf_decoder.c
@@ -6,6 +6,8 @@
  * Thanks to X_Tra (http://metalgear.in/) for pointing me to the step size table.
  *
  * Layout: N tracks of 0x10 header + 0x80*2 (always 2ch; multichannels uses 4ch = 2ch track0 + 2ch track1 xN).
+ *
+ * Internally the codec seems to be named simply MTA.
  */
 
 static const int mtaf_step_indexes[16] = {

--- a/src/coding/vorbis_custom_utils_vid1.c
+++ b/src/coding/vorbis_custom_utils_vid1.c
@@ -100,24 +100,23 @@ static int get_packet_header(STREAMFILE* sf, uint32_t* offset, uint32_t* size) {
     uint32_t size_bits;
 
 
-    if (read_streamfile(ibuf,(*offset),ibufsize, sf) != ibufsize)
+    if (read_streamfile(ibuf, (*offset), ibufsize, sf) != ibufsize)
         goto fail;
 
     bl_setup(&ib, ibuf, ibufsize);
 
     /* read using Vorbis weird LSF */
-    bl_get(&ib,  4,&size_bits);
-    bl_get(&ib,  (size_bits+1),(uint32_t*)size);
+    size_bits = bl_read(&ib,  4);
+    *size = bl_read(&ib, size_bits + 1);
 
     /* special meaning, seen in silent frames */
-    if (size_bits == 0 && *size == 0 && (uint8_t)read_8bit(*offset, sf) == 0x80) {
+    if (size_bits == 0 && *size == 0 && read_u8(*offset, sf) == 0x80) {
         *size = 0x01;
     }
 
     /* pad and convert to byte offset */
-    if (ib.b_off % 8)
-        ib.b_off += 8 - (ib.b_off % 8);
-    *offset += (ib.b_off/8);
+    bl_align(&ib, 8);
+    *offset += bl_pos(&ib) / 8;
 
     return 1;
 fail:

--- a/src/coding/vorbis_custom_utils_wwise.c
+++ b/src/coding/vorbis_custom_utils_wwise.c
@@ -261,13 +261,13 @@ static size_t rebuild_packet(uint8_t* obuf, size_t obufsize, wpacket_t* wp, STRE
     ok = ww2ogg_generate_vorbis_packet(&ow, &iw, wp, data);
     if (!ok) return 0;
 
-    if (ow.b_off % 8 != 0) {
-        //VGM_LOG("Wwise Vorbis: didn't write exactly audio packet: 0x%lx + %li bits\n", ow.b_off / 8, ow.b_off % 8);
+    int ow_bitpos = bl_pos(&ow);
+    if (ow_bitpos % 8 != 0) {
+        //VGM_LOG("Wwise Vorbis: didn't write exactly audio packet: 0x%lx + %li bits\n", ow_bitpos / 8, ow_bitpos % 8);
         return 0;
     }
 
-
-    return ow.b_off / 8;
+    return ow_bitpos / 8;
 }
 
 /* Transforms a Wwise setup packet into a real Vorbis one (depending on config). */
@@ -286,54 +286,23 @@ static size_t rebuild_setup(uint8_t* obuf, size_t obufsize, wpacket_t* wp, STREA
     bl_setup(&ow, obuf, obufsize);
     bl_setup(&iw, ibuf, ibufsize);
 
-    ok = ww2ogg_generate_vorbis_setup(&ow,&iw, data, wp->packet_size, sf);
+    ok = ww2ogg_generate_vorbis_setup(&ow, &iw, data, wp->packet_size, sf);
     if (!ok) return 0;
 
-    if (ow.b_off % 8 != 0) {
-        //VGM_LOG("Wwise Vorbis: didn't write exactly setup packet: 0x%lx + %li bits\n", ow.b_off / 8, ow.b_off % 8);
+    int ow_bitpos = bl_pos(&ow);
+    if (ow_bitpos % 8 != 0) {
+        //VGM_LOG("Wwise Vorbis: didn't write exactly setup packet: 0x%lx + %li bits\n", ow_bitpos / 8, ow_bitpos % 8);
         return 0;
     }
 
-
-    return ow.b_off / 8;
+    return ow_bitpos / 8;
 }
 
 /* copy packet bytes, where input/output bufs may not be byte-aligned (so no memcpy) */
 static int copy_bytes(bitstream_t* ob, bitstream_t* ib, uint32_t bytes) {
 
-#if 0
-    /* in theory this would be faster, but not clear results; maybe default is just optimized by compiler */
-    for (int i = 0; i < bytes / 4; i++) {
-        uint32_t c = 0;
-
-        bl_get(ib, 32, &c);
-        bl_put(ob, 32,  c);
-    }
-
-    for (int i = 0; i < bytes % 4; i++) {
-        uint32_t c = 0;
-
-        bl_get(ib,  8, &c);
-        bl_put(ob,  8,  c);
-    }
-#endif
-
-#if 0
-    /* output bits are never(?) byte aligned but input always is, yet this doesn't seem any faster */
-    if (ib->b_off % 8 == 0) {
-        int iw_pos = ib->b_off / 8;
-
-        for (int i = 0; i < bytes; i++, iw_pos++) {
-            uint32_t c = ib->buf[iw_pos];
-
-          //bl_get(ib,  8, &c);
-            bl_put(ob,  8,  c);
-        }
-
-        ib->b_off += bytes * 8;
-        return true;
-    }
-#endif
+    // Could try to read+write 32-bits at once (except tail) but doesn't seem faster (optimized out?).
+    // Same trying to do buf-aligned input reads (since input is always byte-aligned)
 
     for (int i = 0; i < bytes; i++) {
         uint32_t c = 0;
@@ -414,20 +383,17 @@ static int ww2ogg_generate_vorbis_packet(bitstream_t* ow, bitstream_t* iw, wpack
         copy_bytes(ow, iw, wp->packet_size - 1);
 
         /* remove trailing garbage bits (probably unneeded) */
-        if (ow->b_off % 8 != 0) {
-            uint32_t padding = 0;
-            int padding_bits = 8 - (ow->b_off % 8);
-
-            bl_put(ow,  padding_bits,  padding);
-        }
+        bl_pad(ow, 8);
     }
     else {
         /* normal packets */
 
         /* can directly copy (much, much faster), but least common case vs the above... */
-        memcpy(ow->buf + ow->b_off / 8, iw->buf + iw->b_off / 8, wp->packet_size);
-        ow->b_off += wp->packet_size * 8;
-        iw->b_off += wp->packet_size * 8;
+        uint32_t iw_bytes = bl_pos(iw) / 8;
+        uint32_t ow_bytes = bl_pos(ow) / 8;
+        memcpy(ow->buf + ow_bytes, iw->buf + iw_bytes, wp->packet_size);
+        bl_skip(iw, wp->packet_size * 8);
+        bl_skip(ow, wp->packet_size * 8);
     }
 
 
@@ -702,9 +668,10 @@ static int ww2ogg_codebook_library_rebuild(bitstream_t* ow, bitstream_t* iw, siz
 
 
     /* check that we used exactly all bytes */
-    /* note: if all bits are used in the last byte there will be one extra 0 byte */
-    if ( 0 != cb_size && iw->b_off/8+1 != cb_size ) {
-        //VGM_LOG("Wwise Vorbis: codebook size mistach (expected 0x%x, wrote 0x%lx)\n", cb_size, iw->b_off/8+1);
+    // note: if all bits are used in the last byte there will be one extra 0 byte
+    uint32_t iw_bytes = bl_pos(iw) / 8 + 1;
+    if (cb_size != 0 && iw_bytes != cb_size) {
+        //VGM_LOG("Wwise Vorbis: codebook size mistach (expected 0x%x, wrote 0x%lx)\n", cb_size, iw_bytes);
         return false;
     }
 
@@ -738,7 +705,7 @@ static int ww2ogg_generate_vorbis_setup(bitstream_t* ow, bitstream_t* iw, vorbis
     /* packet header */
     put_u8(ow->buf+0x00, 0x05);            /* packet_type (setup) */
     memcpy(ow->buf+0x01, "vorbis", 6);     /* id */
-    ow->b_off += (1+6) * 8; /* bit offset of output (Vorbis) setup, after fake type + id */
+    bl_skip(ow, (1 + 6) * 8); // bit offset of output (Vorbis) setup, after fake type + id
 
 
     /* Codebooks */
@@ -783,13 +750,13 @@ static int ww2ogg_generate_vorbis_setup(bitstream_t* ow, bitstream_t* iw, vorbis
     if (data->setup_type == WWV_FULL_SETUP) {
         /* rest of setup is untouched, copy bits */
         uint32_t bitly = 0;
-        uint32_t total_bits_read = iw->b_off;
+        uint32_t total_bits_read = bl_pos(iw);
         uint32_t setup_packet_size_bits = packet_size * 8;
 
         while (total_bits_read < setup_packet_size_bits) {
             bl_get(iw,  1,&bitly);
             bl_put(ow,  1, bitly);
-            total_bits_read = iw->b_off;
+            total_bits_read = bl_pos(iw);
         }
     }
     else {
@@ -1103,12 +1070,7 @@ static int ww2ogg_generate_vorbis_setup(bitstream_t* ow, bitstream_t* iw, vorbis
     }
 
     /* remove trailing garbage bits */
-    if (ow->b_off % 8 != 0) {
-        uint32_t padding = 0;
-        int padding_bits = 8 - (ow->b_off % 8);
-
-        bl_put(ow,  padding_bits,  padding);
-    }
+    bl_pad(ow, 8);
 
 
     return true;

--- a/src/formats.c
+++ b/src/formats.c
@@ -421,6 +421,7 @@ static const char* extension_list[] = {
     "npsf", //fake extension/header id for .nps (in bigfiles)
     "nsa",
     "nsopus",
+    "nst",
     "nfx",
     "nub",
     "nub2",
@@ -604,6 +605,7 @@ static const char* extension_list[] = {
     "ssp",
     "sspr",
     "sss",
+    "ste",
     "ster",
     "sth",
     "stm",

--- a/src/formats.c
+++ b/src/formats.c
@@ -945,7 +945,7 @@ static const coding_info coding_info_list[] = {
         {coding_NDS_PROCYON,        "Procyon Studio Digital Sound Elements NDS 4-bit APDCM"},
         {coding_LEVEL5,             "Level-5 4-bit ADPCM"},
         {coding_LSF,                "Gizmondo Studios Helsingborg LSF 4-bit ADPCM"},
-        {coding_MTAF,               "Konami MTAF 4-bit ADPCM"},
+        {coding_MTAF,               "Konami MTA 4-bit ADPCM"},
         {coding_MTA2,               "Konami MTA2 4-bit ADPCM"},
         {coding_MPC3,               "Paradigm MPC3 3-bit ADPCM"},
         {coding_FADPCM,             "FMOD FADPCM 4-bit ADPCM"},

--- a/src/libvgmstream.h
+++ b/src/libvgmstream.h
@@ -100,7 +100,7 @@ typedef enum {
 
 /* current song info, may be copied around (values are info-only) */
 typedef struct {
-    /* main (always set) */
+    /* main (always set and can't be 0/negative) */
     int channels;                           // output channels
     int sample_rate;                        // output sample rate
     libvgmstream_sfmt_t sample_format;      // output buffer's sample type

--- a/src/libvgmstream.vcxproj
+++ b/src/libvgmstream.vcxproj
@@ -227,6 +227,7 @@
     <ClInclude Include="util\cri_keys.h" />
     <ClInclude Include="util\cri_utf.h" />
     <ClInclude Include="util\endianness.h" />
+    <ClInclude Include="util\hashes.h" />
     <ClInclude Include="util\io_callback.h" />
     <ClInclude Include="util\io_callback_sf.h" />
     <ClInclude Include="util\layout_utils.h" />
@@ -899,6 +900,7 @@
     <ClCompile Include="util\companion_files.c" />
     <ClCompile Include="util\cri_keys.c" />
     <ClCompile Include="util\cri_utf.c" />
+    <ClCompile Include="util\hashes.c" />
     <ClCompile Include="util\io_callback_sf.c" />
     <ClCompile Include="util\layout_utils.c" />
     <ClCompile Include="util\log.c" />

--- a/src/libvgmstream.vcxproj.filters
+++ b/src/libvgmstream.vcxproj.filters
@@ -515,6 +515,9 @@
     <ClInclude Include="util\endianness.h">
       <Filter>util\Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="util\hashes.h">
+      <Filter>util\Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="util\io_callback.h">
       <Filter>util\Header Files</Filter>
     </ClInclude>
@@ -2525,6 +2528,9 @@
       <Filter>util\Source Files</Filter>
     </ClCompile>
     <ClCompile Include="util\cri_utf.c">
+      <Filter>util\Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="util\hashes.c">
       <Filter>util\Source Files</Filter>
     </ClCompile>
     <ClCompile Include="util\io_callback_sf.c">

--- a/src/meta/9tav.c
+++ b/src/meta/9tav.c
@@ -18,13 +18,14 @@ VGMSTREAM* init_vgmstream_9tav(STREAMFILE* sf) {
 
 
     /* checks */
-    if (!is_id32be(0x00,sf, "9TAV"))
+    if (!is_id32be(0x00,sf, "9TAV")) // actually "VAT9" LE
         return NULL;
-    /* .9tav: header id */
+    /* .9tav: header id (data replaces original block payloads, so .mta/stv/etc
+    *   could be considered the original extensions) */
     if (!check_extensions(sf, "9tav"))
         return NULL;
 
-    /* 0x04: always 0x09 (codec?) */
+    // 0x04: codec (always 0x09)
     channels        = read_u16le(0x08,sf);
     track_count     = read_u16le(0x0a,sf); /* MGS3 uses multitracks */
     sample_rate     = read_s32le(0x0c,sf);

--- a/src/meta/awb.c
+++ b/src/meta/awb.c
@@ -9,7 +9,7 @@ typedef struct {
     VGMSTREAM* (*init_vgmstream_subkey)(STREAMFILE* sf, uint16_t subkey);
     const char* extension;
     bool load_loops;
-    bool use_riff_size;
+    uint32_t subfile_size;
 } meta_info_t;
 
 static bool load_meta_type(meta_info_t* meta, STREAMFILE* sf, uint32_t subfile_offset);
@@ -120,8 +120,8 @@ VGMSTREAM* init_vgmstream_awb_memory(STREAMFILE* sf, STREAMFILE* sf_acb) {
             goto fail;
         }
 
-        if (meta.use_riff_size) {
-            subfile_size = read_u32le(subfile_offset + 0x04,sf) + 0x08;
+        if (meta.subfile_size) {
+            subfile_size = meta.subfile_size;
         }
 
         if (!temp_sf) {
@@ -198,13 +198,18 @@ static bool load_meta_type(meta_info_t* meta, STREAMFILE* sf, uint32_t subfile_o
     if (is_id32be(subfile_offset,sf, "RIFF")) {
         meta->init_vgmstream = init_vgmstream_riff;
         meta->extension = "wav";
-        meta->use_riff_size = true; // padded size, use RIFF's
+
+        // padded size, use RIFF's
+        meta->subfile_size = read_u32le(subfile_offset + 0x04,sf) + 0x08;
         return true;
     }
 
     if (is_id32be(subfile_offset,sf, "CWAV")) {
         meta->init_vgmstream = init_vgmstream_bcwav;
         meta->extension = "bcwav";
+
+        // sometimes padded [Mario & Sonic at the Rio 2016 Olympic Games (3DS)]
+        meta->subfile_size = read_u32le(subfile_offset + 0x0c,sf);
         return true;
     }
 

--- a/src/meta/crid.c
+++ b/src/meta/crid.c
@@ -3,6 +3,7 @@
 #include "../util/cri_utf.h"
 #include "../util/cri_keys.h"
 #include "../util/companion_files.h"
+#include "../util/string_utils.h"
 #include "crid_streamfile.h"
 
 static uint32_t get_sfa_header_offset(STREAMFILE* sf, int chno);
@@ -22,8 +23,8 @@ VGMSTREAM* init_vgmstream_crid(STREAMFILE* sf) {
         return NULL;
 
     /* .USM info:
-     * - starts with a 'CRID' audio header and UTF header at 0x20 (with info about used streams)
-     * - has xN @SFA (audio) and @SFV (video) chunks with regular payload (hca, adx, m2v, etc)
+     * - starts with a 'CRID' video header and UTF header at 0x20 (with info about used streams)
+     * - has xN @SFA (audio), @SFV (video) and @SBT (subtitles, rare) chunks with regular payload (hca, adx, m2v, etc)
      * - chunks can be of types: data=0, header=1, comment=2, seek=3
      * - chunks may be partially encrypted (internal .hca may be encrypted instead as well)
      * - chunks have an associated stream (chno)
@@ -89,7 +90,6 @@ VGMSTREAM* init_vgmstream_crid(STREAMFILE* sf) {
 
         if (!utf_query_u8(utf_sfa, 0, "audio_codec", &audio_codec))
             goto fail;
-        // possibly useful? "channel_config" "ambisonic"
     }
 
     /* find decryption key */
@@ -113,7 +113,7 @@ VGMSTREAM* init_vgmstream_crid(STREAMFILE* sf) {
     }
 
     {
-        VGMSTREAM* (*init_vgmstream)(STREAMFILE* sf);
+        init_vgmstream_t init_vgmstream;
         const char* ext = NULL;
 
         // could also get first data chunk
@@ -141,9 +141,10 @@ VGMSTREAM* init_vgmstream_crid(STREAMFILE* sf) {
         if (!vgmstream) goto fail;
 
         vgmstream->num_streams = total_subsongs;
-        snprintf(vgmstream->stream_name, STREAM_NAME_SIZE-1, "%s", stream_name);
+        strcpy_v(vgmstream->stream_name, STREAM_NAME_SIZE, stream_name);
 
-        //TODO: mch HCA seem to be encoded like L R SL SR FC LFE
+        //TODO: mch HCA seem to be encoded like L R SL SR FC LFE (might need reordering)
+        // (also ignore channel layout if u8 'ambisonics' is set to 1)
     }
 
 

--- a/src/meta/crid_streamfile.h
+++ b/src/meta/crid_streamfile.h
@@ -89,13 +89,17 @@ static void decrypt_callback(uint8_t* dst, crid_io_data* data, size_t block_pos,
 static void block_callback(STREAMFILE* sf, crid_io_data* data) {
     uint32_t offset = data->physical_offset;
 
-    /* 00: header id
+    /* 00: header id (@SFA=audio, @SFV=video, @SBT=subtitles, possibly others)
      * 04: data size
      * 08: header size (- 0x08)
      * 0a: padding size after data
      * 0c: stream number
      * 0d: empty
-     * 0e: chunk type (0=data, 1=header, 2=comment, 3=seek), possibly a bitflag?
+     * 0e: chunk type (0=data, 1=header, 2=end, 3=metadata), possibly flags?
+     *     0=data is a payload of audio/video/subs, typically except subs
+     *     1=header are @UTF tables: CRIUSF_DIR_STREAM/VIDEO_HDRINFO/AUDIO_HDRINFO (see crid.c)
+     *     2=end is text comment (ex. '#HEADER END   ')
+     *     3=metadata is an @UTF table: VIDEO_SEEKINFO + ofs_byte/ofs_frmid/num_skip/resv, or AUDIO_HEADER + hca_header
      * 10: frame time? (typically 0)
      * 14: frame rate? (typically 30)
     */

--- a/src/meta/ea_schl.c
+++ b/src/meta/ea_schl.c
@@ -203,7 +203,6 @@ fail:
 
 /* EA BNK with variable header - from EA games SFXs; also created by sx.exe */
 static VGMSTREAM* parse_bnk_header(STREAMFILE* sf, off_t offset, int target_stream, int is_embedded) {
-    uint32_t i;
     uint16_t num_sounds;
     off_t header_offset, start_offset, test_offset, table_offset, entry_offset;
     size_t header_size;
@@ -260,7 +259,7 @@ static VGMSTREAM* parse_bnk_header(STREAMFILE* sf, off_t offset, int target_stre
         header_offset = entry_offset + read_u32(entry_offset, sf);
     } else {
         /* some of these are dummies with zero offset, skip them when opening standalone BNK */
-        for (i = 0; i < num_sounds; i++) {
+        for (int i = 0; i < num_sounds; i++) {
             entry_offset = offset + table_offset + 0x04 * i;
             test_offset = read_u32(entry_offset, sf);
 
@@ -280,7 +279,7 @@ static VGMSTREAM* parse_bnk_header(STREAMFILE* sf, off_t offset, int target_stre
 
     /* fix absolute offsets so it works in next funcs */
     if (offset) {
-        for (i = 0; i < ea.channels; i++) {
+        for (int i = 0; i < ea.channels; i++) {
             ea.offsets[i] += offset;
         }
     }
@@ -824,8 +823,10 @@ static int parse_variable_header(STREAMFILE* sf, ea_header* ea, off_t begin_offs
         }
     }
 
-    if (ea->channels > EA_MAX_CHANNELS)
+    if (ea->channels < 0 || ea->channels > EA_MAX_CHANNELS)
         goto fail;
+    if (ea->channels == 0)
+        ea->channels = 1;
 
 
     /* Set defaults per platform, as the header ommits them when possible */
@@ -844,9 +845,6 @@ static int parse_variable_header(STREAMFILE* sf, ea_header* ea, off_t begin_offs
         ea->big_endian = 1;
     }
 
-    if (!ea->channels) {
-        ea->channels = 1;
-    }
 
     /* version mainly affects defaults and minor stuff, can come with all codecs */
     /* V0 is often just null but it's specified in some files (uncommon, with patch size 0x00) */

--- a/src/meta/hca.c
+++ b/src/meta/hca.c
@@ -80,7 +80,7 @@ VGMSTREAM* init_vgmstream_hca_subkey(STREAMFILE* sf, uint16_t subkey) {
 
     /* Assumed mappings; seems correct vs Atom Viewer, that lists L/R/C/LFE/LS/RS and downmixes HCAs like that.
      * USM HCA's seem to be L/R/SL/SR/C/LFE though (probably reordered at USM level, no detection done in Atom Viewer). */
-    if (vgmstream->channels <= 8) { // 8 is max but just in case
+    if (vgmstream->channels <= 8 && !hca_info->ambisonics) {
         static const uint32_t hca_mappings[] = {
                 0,
                 mapping_MONO,

--- a/src/meta/hca.c
+++ b/src/meta/hca.c
@@ -78,8 +78,8 @@ VGMSTREAM* init_vgmstream_hca_subkey(STREAMFILE* sf, uint16_t subkey) {
     vgmstream->layout_type = layout_none;
     vgmstream->codec_data = hca_data;
 
-    /* Assumed mappings; seems correct vs Atom Viewer, that lists L/R/C/LFE/LS/RS and downmixes HCAs like that.
-     * USM HCA's seem to be L/R/SL/SR/C/LFE though (probably reordered at USM level, no detection done in Atom Viewer). */
+    /* Assumed mappings; seems correct vs Atom Viewer, that lists L R FC LFE SL SR and downmixes HCAs like that.
+     * USM HCA's are L R SL SR FC LFE though (reordered at lib/USM level, no detection can be done here). */
     if (vgmstream->channels <= 8 && !hca_info->ambisonics) {
         static const uint32_t hca_mappings[] = {
                 0,

--- a/src/meta/hd3_bd3.c
+++ b/src/meta/hd3_bd3.c
@@ -17,7 +17,7 @@ VGMSTREAM* init_vgmstream_hd3_bd3(STREAMFILE* sf) {
         return NULL;
 
     sb = open_streamfile_by_ext(sf,"bd3");
-    if (!sf) goto fail;
+    if (!sb) goto fail;
 
     /* 0x04: section size (not including first 0x08) */
     /* 0x08: version? 0x00020000 */

--- a/src/meta/ish_isd.c
+++ b/src/meta/ish_isd.c
@@ -33,6 +33,8 @@ VGMSTREAM* init_vgmstream_ish_isd(STREAMFILE* sf) {
     //TODO: loop start may be set mid-frame, which bytes_to_samples doesn't handle
     //h.loop_start = dsp_bytes_to_samples(h.loop_start, h.channels);
     //h.loop_end = dsp_bytes_to_samples(h.loop_end, h.channels);
+    if (h.channels == 0)
+        return NULL;
     h.loop_start = h.loop_start * 14 / 0x08 / h.channels;
     h.loop_end = h.loop_end * 14 / 0x08 / h.channels;
 

--- a/src/meta/ktsr.c
+++ b/src/meta/ktsr.c
@@ -2,6 +2,7 @@
 #include "../coding/coding.h"
 #include "../layout/layout.h"
 #include "../util/companion_files.h"
+#include "../util/chunks.h"
 #include "ktsr_streamfile.h"
 
 typedef enum { NONE, MSADPCM, DSP, GCADPCM, ATRAC9, RIFF_ATRAC9, KMA9, AT9_KM9, KOVS, KTSS, KTAC, KA1A, KA1A_INTERNAL, } ktsr_codec;
@@ -648,40 +649,39 @@ static void build_name(ktsr_header_t* ktsr, STREAMFILE* sf) {
 
 }
 
+/* more configs than sounds is possible so we need target_id first */
 static void parse_longname(ktsr_header_t* ktsr, STREAMFILE* sf) {
-    /* more configs than sounds is possible so we need target_id first */
-    uint32_t offset, end, name_offset;
-    uint32_t stream_id;
+    uint32_t stream_id, name_offset;
+    chunk_t rc = {0};
 
-    offset = 0x40 + ktsr->as_offset;
-    end = ktsr->as_offset + ktsr->as_size;
-    while (offset < end) {
-        uint32_t type = read_u32be(offset + 0x00, sf); /* hash-id? */
-        uint32_t size = read_u32le(offset + 0x04, sf);
-        switch(type) {
+    rc.full_size = true;
+    rc.current = 0x40 + ktsr->as_offset;
+    rc.max = ktsr->as_offset + ktsr->as_size;
+    while (next_chunk(&rc, sf)) {
+
+        switch(rc.type) {  /* hash-id? */
             case 0xBD888C36: /* config */
-                stream_id = read_u32le(offset + 0x08, sf);
+                stream_id = read_u32le(rc.offset + 0x08, sf);
                 if (stream_id != ktsr->sound_id)
                     break;
 
-                ktsr->config_flags = read_u32le(offset + 0x0c, sf);
+                ktsr->config_flags = read_u32le(rc.offset + 0x0c, sf);
 
-                name_offset = read_u32le(offset + 0x28, sf);
+                name_offset = read_u32le(rc.offset + 0x28, sf);
                 if (name_offset > 0)
-                    ktsr->config_name_offset = offset + name_offset;
+                    ktsr->config_name_offset = rc.offset + name_offset;
                 return; /* id found */
 
             default:
                 break;
         }
-
-        offset += size;
     }
 }
 
 static bool parse_ktsr(ktsr_header_t* ktsr, STREAMFILE* sf) {
-    uint32_t offset, end, header_offset, name_offset;
+    uint32_t header_offset, name_offset;
     uint32_t stream_count;
+    chunk_t rc = {0};
 
     /* 00: KTSR
      * 04: type
@@ -707,14 +707,13 @@ static bool parse_ktsr(ktsr_header_t* ktsr, STREAMFILE* sf) {
         return false;
     }
 
-    offset = 0x40 + ktsr->as_offset;
-    end = ktsr->as_offset + ktsr->as_size;
-    while (offset < end) {
-        uint32_t type = read_u32be(offset + 0x00, sf); /* hash-id? */
-        uint32_t size = read_u32le(offset + 0x04, sf);
+    rc.full_size = true;
+    rc.current = 0x40 + ktsr->as_offset;
+    rc.max = ktsr->as_offset + ktsr->as_size;
+    while (next_chunk(&rc, sf)) {
 
         /* parse chunk-like subfiles, usually N configs then N songs */
-        switch(type) {
+        switch(rc.type) {
             case 0x6172DBA8: /* ? (mostly empty) */
             case 0xBD888C36: /* cue? (floats, stream id, etc, may have extended name; can have sub-chunks)-appears N times */
             case 0xC9C48EC1: /* unknown (has some string inside like "boss") */
@@ -741,20 +740,20 @@ static bool parse_ktsr(ktsr_header_t* ktsr, STREAMFILE* sf) {
 
                 if (ktsr->total_subsongs == ktsr->target_subsong) {
 
-                    ktsr->sound_id = read_u32le(offset + 0x08,sf);
-                    ktsr->sound_flags = read_u32le(offset + 0x0c,sf);
-                    stream_count = read_u32le(offset + 0x10,sf);
+                    ktsr->sound_id = read_u32le(rc.offset + 0x08,sf);
+                    ktsr->sound_flags = read_u32le(rc.offset + 0x0c,sf);
+                    stream_count = read_u32le(rc.offset + 0x10,sf);
                     if (stream_count != 1) {
                         VGM_LOG("KTSR: unknown stream count\n");
                         goto fail;
                     }
 
-                    header_offset = read_u32le(offset + 0x14, sf);
-                    name_offset   = read_u32le(offset + 0x18, sf);
+                    header_offset = read_u32le(rc.offset + 0x14, sf);
+                    name_offset   = read_u32le(rc.offset + 0x18, sf);
                     if (name_offset > 0)
-                        ktsr->sound_name_offset = offset + name_offset;
+                        ktsr->sound_name_offset = rc.offset + name_offset;
 
-                    header_offset = read_u32le(offset + header_offset, sf) + offset;
+                    header_offset = read_u32le(rc.offset + header_offset, sf) + rc.offset;
 
                     if (!parse_ktsr_subfile(ktsr, sf, header_offset))
                         goto fail;
@@ -763,11 +762,9 @@ static bool parse_ktsr(ktsr_header_t* ktsr, STREAMFILE* sf) {
 
             default:
                 /* streams also have their own chunks like 0x09D4F415, not needed here */  
-                VGM_LOG("KTSR: unknown chunk 0x%08x at %x\n", type, offset);
+                VGM_LOG("KTSR: unknown chunk 0x%08x at %x\n", rc.type, rc.offset);
                 goto fail;
         }
-
-        offset += size;
     }
 
     if (ktsr->total_subsongs == 0) {

--- a/src/meta/mib_mih.c
+++ b/src/meta/mib_mih.c
@@ -50,11 +50,11 @@ VGMSTREAM* init_vgmstream_mic(STREAMFILE* sf) {
     off_t header_offset, start_offset;
 
     /* check extension */
+    if (read_u32le(0x00, sf) != 0x40) /* header size */
+        return NULL;
     /* .mic: official extension
      * (extensionless): The Urbz (PS2), The Sims 2 series (PS2) */
     if (!check_extensions(sf, "mic,"))
-        return NULL;
-    if (read_u32le(0x00, sf) != 0x40) /* header size */
         return NULL;
 
     header_offset = 0x00;
@@ -87,7 +87,10 @@ static VGMSTREAM* init_vgmstream_multistream(STREAMFILE* sf_head, STREAMFILE* sf
     frame_size  = read_u32le(header_offset + 0x10, sf_head);
     frame_count = read_u32le(header_offset + 0x14, sf_head);
     if (frame_count == 0) { /* rarely [Gladius (PS2)] */
-        frame_count = (get_streamfile_size(sf_body) - start_offset) / (frame_size * channels);
+        uint32_t file_size = get_streamfile_size(sf_body);
+        if (frame_size == 0 || channels < 1 || file_size < start_offset)
+            return NULL;
+        frame_count = (file_size - start_offset) / (frame_size * channels);
     }
 
     data_size = frame_count * frame_size;

--- a/src/meta/mta2.c
+++ b/src/meta/mta2.c
@@ -22,14 +22,16 @@ VGMSTREAM* init_vgmstream_mta2(STREAMFILE* sf) {
 
     /* everything is very similar to MGS3's MTAF but BE */
 
+
+    /* HEAD chunk */
     if (!is_id32be(0x40, sf, "HEAD"))
         return NULL;
     if (read_u32be(0x44, sf) != 0xB0)
         return NULL;
-    // 0x48: null
-    // 0x4c: related to channels? (16 or 2)
-    // 0x50: 127 (volume?)
-    // 0x54: 64 (pan?)
+    // 0x48: version? (0)
+    // 0x4c: channels? (not always accurate?)
+    // 0x50: volume (127)
+    // 0x54: pan (64)
     // 0x56: channels (counting all tracks)
     // 0x58: loop start sample
     // 0x5c: loop end
@@ -37,11 +39,11 @@ VGMSTREAM* init_vgmstream_mta2(STREAMFILE* sf) {
     // 0x64: loop start frame?
     // 0x68: loop end frame?
     // 0x6c: null
-    // 0x70: flags (00/05/07)
-    // 0x7c: null?
+    // 0x70: flags (1=loop, 2=fade-in?, 4=multitrack/enabled?)
+    // 0x74: config?
     // 0x78: null
     // 0x7c: sample rate in 32b float (WHY?) typically 48000.0
-    /* 0x80 .. 0xf8: null */
+    // 0x80 .. 0xf8: null
 
     channels   = read_u16be(0x56, sf);
     loop_start = read_s32be(0x58, sf);
@@ -54,14 +56,15 @@ VGMSTREAM* init_vgmstream_mta2(STREAMFILE* sf) {
 
 
     /* TRKP chunks (x16, per max channels) */
-    // 0x00: -1=unused, 0x00 or others (0x20) if used
-    // 0x04: 127 (volume?)
-    // 0x05: sometimes 127 (volume?)
-    // 0x06: 64 (pan?)
+    // 0x00: mode (-1=unused, 0x00 or others (0x20) if used)
+    // 0x04: volume (127)
+    // 0x05: initial volume? (sometimes 127)
+    // 0x06: pan (64)
     // 0x07: channel layout (ex. 1ch = 0x04, 3ch = 0x07, 4ch = 0x33, 6ch = 0x3f)
-    // 0x2c: always 1
-    // 0x30: x24 16-bit (volumes or ADPCM related?)
-    // 0x60: -1 x4
+    // 0x08 .. 0x2c: reserved
+    // 0x2c: flags (1=loop?, 2=?)
+    // 0x30: s8 x48 (ADPCM related?)
+    // 0x60: s8 x8 (always -1?)
 
 
     /* DATA chunk */

--- a/src/meta/mtaf.c
+++ b/src/meta/mtaf.c
@@ -15,7 +15,7 @@ VGMSTREAM* init_vgmstream_mtaf(STREAMFILE* sf) {
     /* checks */
     if (!is_id32be(0x00, sf, "MTAF"))
         return NULL;
-    /* .mta: actual extension in xor'ed filename
+    /* .mta: actual extension in xor'ed filename/internally
      * .mtaf: header ID */
     if (!check_extensions(sf,"mta,mtaf"))
         return NULL;
@@ -30,10 +30,10 @@ VGMSTREAM* init_vgmstream_mtaf(STREAMFILE* sf) {
         return NULL;
     if (read_u32le(0x44, sf) != 0xB0)
         return NULL;
-    // 0x48: null
-    // 0x4c: related to channels? (16 or 2)
-    // 0x50: 127 (volume?)
-    // 0x54: 64 (pan?)
+    // 0x48: version? (0)
+    // 0x4c: channels? (not always accurate?)
+    // 0x50: volume (127)
+    // 0x54: pan (64)
     // 0x56: null
     // 0x58: loop start sample
     // 0x5c: loop end
@@ -41,11 +41,11 @@ VGMSTREAM* init_vgmstream_mtaf(STREAMFILE* sf) {
     // 0x64: loop start frame (sample / 0x100)
     // 0x68: loop end frame (sample / 0x100)
     // 0x6c: null
-    // 0x70: flags (00/05/07)
-    // 0x74: channel flags?
+    // 0x70: flags (1=loop, 2=fade-in?, 4=multitrack/enabled?)
+    // 0x74: config?
     // 0x78: null
     // 0x7c: null
-    // 0x78 .. 0xf8: null
+    // 0x80 .. 0xf8: null
 
     loop_start = read_s32le(0x58, sf);
     loop_end   = read_s32le(0x5c, sf);
@@ -54,14 +54,15 @@ VGMSTREAM* init_vgmstream_mtaf(STREAMFILE* sf) {
     
 
     /* TRKP chunks (x16, per max channels) */
-    // 0x00: -1=unused, 0x00 or others (0x20) if used
-    // 0x04: 127 (volume?)
-    // 0x05: null
-    // 0x06: 64 (pan?)
+    // 0x00: mode (-1=unused, 0x00 or others (0x20) if used)
+    // 0x04: volume (127)
+    // 0x05: initial volume? (0?)
+    // 0x06: pan (64)
     // 0x07: null
-    // 0x2c: always 1
-    // 0x30: x24 16-bit (volumes or ADPCM related?)
-    // 0x60: -1 x4
+    // 0x08 .. 0x2c: reserved
+    // 0x2c: flags (1=loop?, 2=?)
+    // 0x30: s8 x48 (ADPCM related?)
+    // 0x60: s8 x8 (always -1?)
 
 
     /* DATA chunk */

--- a/src/meta/ogg_vorbis.c
+++ b/src/meta/ogg_vorbis.c
@@ -712,7 +712,7 @@ static VGMSTREAM* _init_vgmstream_ogg_vorbis_config(STREAMFILE* sf, off_t start,
                 loop_end_found = 1;
                 loop_flag = 1;
             }
-            else if (strstr(comment, "omment=") == comment) {               /* Air (Android) */
+            else if (strstr(comment, "omment=LOOPSTART=") == comment) {               /* Air (Android) */
                 sscanf(strstr(comment, "=LOOPSTART=") + 11, "%d,LOOPEND=%d", &loop_start, &loop_end);
                 loop_end_found = 1;
                 loop_flag = 1;

--- a/src/meta/ogl.c
+++ b/src/meta/ogl.c
@@ -63,8 +63,10 @@ VGMSTREAM* init_vgmstream_ogl(STREAMFILE* sf) {
     /* non-looping files do this */
     if (!num_samples) {
         uint32_t avg_bitrate = read_u32le(0x2a,sf); /* inside id packet */
+        if (!avg_bitrate) goto fail;
+
         /* approximate as we don't know the sizes of all packet headers */ //todo this is wrong... but somehow works?
-        vgmstream->num_samples = (partial_file_size - start_offset) * ((sample_rate*10/avg_bitrate)+1);
+        vgmstream->num_samples = (partial_file_size - start_offset) * ((sample_rate * 10 / avg_bitrate) + 1);
     }
 
     /* open the file for reading */

--- a/src/meta/redspark.c
+++ b/src/meta/redspark.c
@@ -243,6 +243,8 @@ static bool parse_header(redspark_header_t* h, STREAMFILE* sf, bool is_new) {
                 5c channel config?
         */
 
+        if (head_pos >= HEADER_MAX - 0x20)
+            return false;
         h->total_subsongs = get_u16(buf + head_pos + 0x0c);
         if (!check_subsongs(&target_subsong, h->total_subsongs))
             return false;

--- a/src/meta/txtp_parser.c
+++ b/src/meta/txtp_parser.c
@@ -1064,14 +1064,13 @@ static int parse_keyval(txtp_header_t* txtp, const char* key, const char* val) {
     }
     else if (0==strcmp(key,"commands")) {
         char val2[TXT_LINE_MAX];
-        strcpy(val2, val); /* copy since val is modified here but probably not important */
+        strcpy_v(val2, sizeof(val2), val); /* copy since val is modified here but probably not important */
         if (!add_entry(txtp, val2, 1)) goto fail;
     }
     else if (0==strcmp(key,"group")) {
         char val2[TXT_LINE_MAX];
-        strcpy(val2, val); /* copy since val is modified here but probably not important */
+        strcpy_v(val2, sizeof(val2), val); /* copy since val is modified here but probably not important */
         if (!add_group(txtp, val2)) goto fail;
-
     }
     else {
         // in rare cases a filename may contain a (blah=blah.blah), but it's hard to distinguish

--- a/src/meta/ubi_hx.c
+++ b/src/meta/ubi_hx.c
@@ -164,9 +164,7 @@ static int parse_name(ubi_hx_header* hx, STREAMFILE* sf) {
 
 
         class_size = read_u32(offset + 0x00, sf); // not including null-terminator
-        if (class_size >= sizeof(class_name) - 1)
-            goto fail;
-        read_string(class_name, class_size + 1, offset + 0x04, sf);
+        read_string_sz(class_name, sizeof(class_name), class_size, offset + 0x04, sf);
         offset += 0x04 + class_size;
 
         cuuid1 = read_u32(offset + 0x00, sf);
@@ -219,19 +217,17 @@ static int parse_name(ubi_hx_header* hx, STREAMFILE* sf) {
             off_t wavres_offset = header_offset;
 
             /* parse WavRes header */
-            resclass_size = read_u32(wavres_offset, sf);
+            resclass_size = read_u32(wavres_offset, sf); // not including null-terminator
             wavres_offset += 0x04 + resclass_size + 0x08 + 0x04; /* skip class + cuiid + flags */
 
-            internal_size = read_u32(wavres_offset + 0x00, sf);
+            internal_size = read_u32(wavres_offset + 0x00, sf); // 
             /* Xbox has some kind of big size and "flags" has a value of 2, instead of 3/4 like other platforms */
             if (strcmp(class_name, "CXBoxWavResData") == 0 && internal_size > 0x100)
                 return true;
-            if (internal_size > sizeof(hx->internal_name)+1)
-                goto fail;
 
             /* usually 0 in consoles */
             if (internal_size != 0) {
-                read_string(hx->internal_name,internal_size+1, wavres_offset + 0x04, sf);
+                read_string_sz(hx->internal_name, sizeof(hx->internal_name), internal_size, wavres_offset + 0x04, sf);
                 return true;
             }
             else {
@@ -274,9 +270,7 @@ static int parse_header(ubi_hx_header* hx, STREAMFILE* sf, uint32_t offset, uint
     hx->header_size     = size;
 
     hx->class_size = read_u32(offset + 0x00, sf);
-    if (hx->class_size >= sizeof(hx->class_name) - 1) // not including null-terminator
-        goto fail;
-    read_string(hx->class_name, hx->class_size + 1, offset + 0x04, sf);
+    read_string_sz(hx->class_name, sizeof(hx->class_name), hx->class_size, offset + 0x04, sf);
     offset += 0x04 + hx->class_size;
 
     hx->cuuid1  = read_u32(offset + 0x00, sf);
@@ -341,8 +335,7 @@ static int parse_header(ubi_hx_header* hx, STREAMFILE* sf, uint32_t offset, uint
             case 0x07: /* static? */
             case 0x0a: /* static? */
                 resource_size = read_u32(offset + 0x00, sf);
-                if (resource_size > sizeof(hx->resource_name)+1) goto fail;
-                read_string(hx->resource_name,resource_size+1, offset + 0x04, sf);
+                read_string_sz(hx->resource_name, sizeof(hx->resource_name), resource_size, offset + 0x04, sf);
 
                 riff_offset = offset + 0x04 + resource_size;
                 riff_size   = read_u32(riff_offset + 0x04, sf) + 0x08;
@@ -509,8 +502,7 @@ static int parse_header(ubi_hx_header* hx, STREAMFILE* sf, uint32_t offset, uint
             case 0x03: /* stream (bigger external file) */
             case 0x07: /* stream? */
                 resource_size = read_u32(offset + 0x00, sf);
-                if (resource_size > sizeof(hx->resource_name)+1) goto fail;
-                read_string(hx->resource_name,resource_size+1, offset + 0x04, sf);
+                read_string_sz(hx->resource_name, sizeof(hx->resource_name), resource_size, offset + 0x04, sf);
 
                 hx->is_external = 1;
                 break;
@@ -568,9 +560,7 @@ static int parse_hx(ubi_hx_header* hx, STREAMFILE* sf, int target_subsong) {
         /* parse index entries: offset to actual header plus some extra info also in the header */
 
         class_size = read_u32(offset + 0x00, sf); // not including null-terminator
-        if (class_size >= sizeof(class_name) - 1)
-            goto fail;
-        read_string(class_name, class_size + 1, offset + 0x04, sf);
+        read_string_sz(class_name, sizeof(class_name), class_size, offset + 0x04, sf);
         offset += 0x04 + class_size;
 
         /* 0x00: id1+2 */

--- a/src/meta/ubi_sb.c
+++ b/src/meta/ubi_sb.c
@@ -646,7 +646,7 @@ static VGMSTREAM* init_vgmstream_ubi_dat_main(ubi_sb_header* sb, STREAMFILE* sf_
         case 0x01: {
             if (!sb->is_external) { /* Dreamcast bank */
                 if (sb->version == 0x00000000) {
-                    uint32_t entry_offset, start_offset, num_samples, codec;
+                    uint32_t entry_offset, start_offset, total_samples, codec;
                     uint8_t buf[4];
 
                     sf_data = open_streamfile_by_ext(sf, "osb");
@@ -657,15 +657,14 @@ static VGMSTREAM* init_vgmstream_ubi_dat_main(ubi_sb_header* sb, STREAMFILE* sf_
 
                     /* FIXME: hacky handling of OSB bank, need to eventually write a full parser once
                      * the format is fully cracked */
-                    entry_offset = read_32bitLE(0x10 + sb->subbank_index * 0x04, sf_data);
+                    entry_offset = read_u32le(0x10 + sb->subbank_index * 0x04, sf_data);
 
                     /* stores values in a weird zig-zag pattern */
                     if (read_streamfile(buf, entry_offset + 0x04, 4, sf_data) != 4) goto fail;
                     start_offset = (buf[0] << 16) | (buf[2]) | (buf[3] << 8);
                     if (read_streamfile(buf, entry_offset + 0x08, 4, sf_data) != 4) goto fail;
-                    num_samples = (buf[0] << 16) | (buf[1] << 24) | (buf[2]) | (buf[3] << 8);
-                    num_samples /= sb->channels;
-                    codec = read_8bit(entry_offset + 0x05, sf_data);
+                    total_samples = (buf[0] << 16) | (buf[1] << 24) | (buf[2]) | (buf[3] << 8);
+                    codec = read_u8(entry_offset + 0x05, sf_data);
 
                     /* build the VGMSTREAM */
                     vgmstream = allocate_vgmstream(sb->channels, sb->loop_flag);
@@ -675,21 +674,23 @@ static VGMSTREAM* init_vgmstream_ubi_dat_main(ubi_sb_header* sb, STREAMFILE* sf_
                         vgmstream->coding_type = coding_PCM16LE;
                         vgmstream->layout_type = layout_interleave;
                         vgmstream->interleave_block_size = 0x02;
-                        vgmstream->stream_size = num_samples * sb->channels * 2;
-                    } else {
+                        vgmstream->stream_size = total_samples * 2;
+                    }
+                    else {
                         vgmstream->coding_type = coding_AICA_int;
                         vgmstream->layout_type = layout_interleave;
                         vgmstream->interleave_block_size = 0x01;
-                        vgmstream->stream_size = num_samples * sb->channels / 2;
+                        vgmstream->stream_size = total_samples / 2;
                     }
 
-                    vgmstream->num_samples = num_samples;
+                    vgmstream->num_samples = total_samples / sb->channels;
                     vgmstream->loop_start_sample = sb->loop_start;
                     vgmstream->loop_end_sample = vgmstream->num_samples;
 
                     if (!vgmstream_open_stream(vgmstream, sf_data, start_offset))
                         goto fail;
-                } else if (sb->version == 0x00000200) {
+                }
+                else if (sb->version == 0x00000200) {
                     sf_data = open_streamfile_by_ext(sf, "kat");
                     if (!sf_data) {
                         VGM_LOG("UBI DAT: no matching KAT found\n");
@@ -700,7 +701,8 @@ static VGMSTREAM* init_vgmstream_ubi_dat_main(ubi_sb_header* sb, STREAMFILE* sf_
                     sf_data->stream_index = sb->subbank_index + 1;
                     vgmstream = init_vgmstream_kat(sf_data);
                     if (!vgmstream) goto fail;
-                } else {
+                }
+                else {
                     goto fail;
                 }
             } else { /* raw PCM */

--- a/src/meta/vag.c
+++ b/src/meta/vag.c
@@ -30,8 +30,9 @@ VGMSTREAM* init_vgmstream_vag(STREAMFILE* sf) {
      * (extensionless): The Urbz (PS2), The Sims series (PS2)
      * .wav: Sniper Elite (PS2), The Simpsons Game (PS2/PSP) 
      * .msv: Casper and the Ghostly Trio (PS2), Earache Extreme Metal Racing (PS2)
-     * .eng,fre,ger,int,ita,jap,spa: Jak and Daxter (PS2) (Preview build) */
-    if (!check_extensions(sf,"vag,swag,str,vig,l,r,vas,xa2,snd,svg,,wav,lwav,msv,eng,fre,ger,int,ita,jap,spa"))
+     * .eng,fre,ger,int,ita,jap,spa: Jak and Daxter (PS2) (Preview build)
+     * .stv: Metal Gear Solid 3 (PS2) internal names (STreamed Vag?) */
+    if (!check_extensions(sf,"vag,swag,str,vig,l,r,vas,xa2,snd,svg,,wav,lwav,msv,eng,fre,ger,int,ita,jap,spa,stv"))
         return NULL;
 
     file_size = get_streamfile_size(sf);
@@ -64,7 +65,7 @@ VGMSTREAM* init_vgmstream_vag(STREAMFILE* sf) {
     switch(vag_id) {
 
         case 0x56414731: /* "VAG1" [Metal Gear Solid 3 (PS2), Cabela's African Safari (PSP), Shamu's Deep Sea Adventures (PS2)] */
-            meta_type = meta_VAG_custom; //TODO not always Konami (Sand Grain Studios)
+            meta_type = meta_VAG_custom;
             start_offset = 0x40; /* 0x30 is extra data in VAG1 */
             interleave = 0x10;
             loop_flag = 0;
@@ -86,7 +87,7 @@ VGMSTREAM* init_vgmstream_vag(STREAMFILE* sf) {
         case 0x56414732: /* "VAG2" (2 channels) [Metal Gear Solid 3 (PS2)] */
             meta_type = meta_VAG_custom;
             start_offset = 0x40; /* 0x30 is extra data in VAG2 */
-            channels = 2;
+            channels = 2; // (seems to be mapped to "VAG1" = 1, other = 2)
             interleave = 0x800;
             loop_flag = 0;
             break;

--- a/src/meta/xwc.c
+++ b/src/meta/xwc.c
@@ -4,44 +4,44 @@
 /* .XWC - Starbreeze games [Chronicles of Riddick: Assault on Dark Athena, Syndicate] */
 VGMSTREAM* init_vgmstream_xwc(STREAMFILE* sf) {
     VGMSTREAM* vgmstream = NULL;
-    off_t start_offset, extra_offset;
-    size_t data_size;
-    int loop_flag, channels, codec, num_samples;
+    uint32_t start_offset, data_size, extra_offset;
+    uint32_t codec;
+    int loop_flag, channels,num_samples;
 
 
     /* checks */
     /* .xwc: extension of the bigfile, individual files don't have one */
     if (!check_extensions(sf,"xwc"))
-        goto fail;
+        return NULL;
 
 
     /* version */
-    if (read_32bitBE(0x00,sf) == 0x00030000 &&
-        read_32bitBE(0x04,sf) == 0x00900000) { /* The Darkness */
-        data_size = read_32bitLE(0x08, sf) + 0x1c; /* not including subheader */
-        channels = read_32bitLE(0x0c, sf);
-        /* 0x10: num_samples */
-        /* 0x14: 0x8000? */
-        /* 0x18: null */
-        codec = read_32bitBE(0x1c, sf);
-        num_samples = read_32bitLE(0x20, sf);
-        /* 0x24: config data >> 2? (0x00(1): channels; 0x01(2): ?, 0x03(2): sample_rate) */
+    if (read_u32be(0x00,sf) == 0x00030000 && read_u32be(0x04,sf) == 0x00900000) {
+        /* The Darkness */
+        data_size   = read_u32le(0x08, sf) + 0x1c; // not including subheader
+        channels    = read_s32le(0x0c, sf);
+        // 0x10: num_samples?
+        // 0x14: 0x8000?
+        // 0x18: null
+        codec       = read_u32be(0x1c, sf);
+        num_samples = read_s32le(0x20, sf);
+        // 0x24: config data >> 2? (0x00(1): channels; 0x01(2): ?, 0x03(2): sample_rate)
         extra_offset = 0x28;
     }
-    else if (read_32bitBE(0x00,sf) == 0x00040000 &&
-             read_32bitBE(0x04,sf) == 0x00900000) { /* Riddick, Syndicate */
-        data_size = read_32bitLE(0x08, sf) + 0x24; /* not including subheader */
-        channels = read_32bitLE(0x0c, sf);
-        /* 0x10: num_samples */
-        /* 0x14: 0x8000? */
-        codec = read_32bitBE(0x24, sf);
-        num_samples = read_32bitLE(0x28, sf);
-        /* 0x2c: config data >> 2? (0x00(1): channels; 0x01(2): ?, 0x03(2): sample_rate) */
-        /* 0x30+: codec dependant */
+    else if (read_u32be(0x00,sf) == 0x00040000 && read_u32be(0x04,sf) == 0x00900000) {
+        /* Riddick, Syndicate */
+        data_size   = read_u32le(0x08, sf) + 0x24; /* not including subheader */
+        channels    = read_u32le(0x0c, sf);
+        // 0x10: num_samples?
+        // 0x14: 0x8000?
+        codec       = read_u32be(0x24, sf);
+        num_samples = read_s32le(0x28, sf);
+        // 0x2c: config data >> 2? (0x00(1): channels; 0x01(2): ?, 0x03(2): sample_rate)
+        // 0x30+: codec dependant
         extra_offset = 0x30;
     }
     else {
-        goto fail;
+        return NULL;
     }
 
     loop_flag = 0;
@@ -60,8 +60,8 @@ VGMSTREAM* init_vgmstream_xwc(STREAMFILE* sf) {
             mpeg_custom_config cfg = {0};
 
             start_offset = 0x800;
-            vgmstream->num_samples = read_32bitLE(extra_offset+0x00, sf); /* with encoder delay */ //todo improve
-            cfg.data_size = read_32bitLE(extra_offset+0x04, sf); /* without padding */
+            vgmstream->num_samples = read_s32le(extra_offset+0x00, sf); // with encoder delay //TODO: improve
+            cfg.data_size = read_u32le(extra_offset+0x04, sf); // without padding
 
             vgmstream->codec_data = init_mpeg_custom(sf, start_offset, &vgmstream->coding_type, vgmstream->channels, MPEG_STANDARD, &cfg);
             if (!vgmstream->codec_data) goto fail;
@@ -73,28 +73,30 @@ VGMSTREAM* init_vgmstream_xwc(STREAMFILE* sf) {
 #endif
 #ifdef VGM_USE_FFMPEG
         case 0x584D4100: { /* "XMA\0" (X360) */
-            uint32_t seek_size, chunk_size, chunk_offset;
-            int block_size, block_count, sample_rate;
+            uint32_t seek_size, chunk_size, chunk_offset, block_size;
+            int block_count, sample_rate;
 
-            seek_size  = read_32bitLE(extra_offset + 0x00, sf);
-            chunk_size = read_32bitLE(extra_offset + 0x04 + seek_size, sf);
+            seek_size  = read_u32le(extra_offset + 0x00, sf);
+            chunk_size = read_u32le(extra_offset + 0x04 + seek_size, sf);
             chunk_offset = extra_offset + 0x04 + seek_size + 0x04;
 
-            data_size = read_32bitLE(chunk_offset + chunk_size + 0x00, sf);
+            data_size = read_u32le(chunk_offset + chunk_size + 0x00, sf);
             start_offset = chunk_offset + chunk_size + 0x04;
-            start_offset += (start_offset % 0x800) ? 0x800 - (start_offset % 0x800) : 0; /* padded */
+            start_offset += (start_offset % 0x800) ? 0x800 - (start_offset % 0x800) : 0; // padded
 
             if (chunk_size == 0x34) { /* new XMA2 */
-                sample_rate = read_32bitLE(extra_offset+0x04+seek_size+0x08, sf);
-                block_size  = read_32bitLE(extra_offset+0x04+seek_size+0x20, sf);
+                sample_rate = read_s32le(extra_offset+0x04+seek_size+0x08, sf);
+                block_size  = read_u32le(extra_offset+0x04+seek_size+0x20, sf);
+                if (block_size == 0)
+                    goto fail;
                 block_count = data_size / block_size;
-                /* others: standard RIFF XMA2 fmt? */
+                // others: standard RIFF XMA2 fmt?
             }
             else if (chunk_size == 0x2c) { /* old XMA2 (not fully valid?) */
-                sample_rate = read_32bitBE(extra_offset+0x04+seek_size+0x10, sf);
-                block_size  = read_32bitBE(extra_offset+0x04+seek_size+0x1c, sf);
-                block_count = read_32bitBE(extra_offset+0x04+seek_size+0x28, sf);
-                /* others: scrambled RIFF fmt BE values */
+                sample_rate = read_s32be(extra_offset+0x04+seek_size+0x10, sf);
+                block_size  = read_u32be(extra_offset+0x04+seek_size+0x1c, sf);
+                block_count = read_s32be(extra_offset+0x04+seek_size+0x28, sf);
+                // others: scrambled RIFF fmt BE values
             }
             else {
                 goto fail;
@@ -116,7 +118,7 @@ VGMSTREAM* init_vgmstream_xwc(STREAMFILE* sf) {
             start_offset = 0x30;
             data_size = data_size - start_offset;
 
-            vgmstream->sample_rate = read_32bitLE(start_offset + 0x28, sf);
+            vgmstream->sample_rate = read_s32le(start_offset + 0x28, sf);
 
             vgmstream->codec_data = init_ogg_vorbis(sf, start_offset, data_size, NULL);
             if ( !vgmstream->codec_data ) goto fail;

--- a/src/util/bitstream_lsb.h
+++ b/src/util/bitstream_lsb.h
@@ -6,15 +6,17 @@
 /* Simple bitreader for Vorbis' bit style, in 'least significant byte' (LSB) format.
  * Example: with 0x1234 = 00010010 00110100, reading 5b + 6b = 10010 100000
  *  (first lower 5b, then next upper 3b and next lower 3b = 6b)
- * It's designed like this to read 32-bit LE ints (faster), though this implementation is endian-agnostic.
- * Kept in .h since it's slightly faster (compiler can optimize statics better using default compile flags). */
-
+ * It was designed like this to read 32-bit LE ints (faster), though this implementation is endian-agnostic.
+ * Kept in .h since it's faster (compiler can optimize statics better using default compile flags).
+ * Assumes bufs aren't that big (probable max ~0x20000000)
+ */
 
 typedef struct {
     uint8_t* buf;           // buffer to read/write
     uint32_t bufsize;       // max size
-    uint32_t _b_max;         // max size in bits
-    uint32_t _b_off;         // current offset in bits inside the buffer
+    uint32_t _b_max;        // max size in bits
+    uint32_t _b_off;        // current offset in bits inside the buffer
+
     bool error;             // attempted to read/write past max data
 } bitstream_t;
 
@@ -27,15 +29,26 @@ static inline void bl_setup(bitstream_t* bs, uint8_t* buf, uint32_t bufsize) {
     bs->error = false;
 }
 
-/* same as (1 << bits) - 1, but that seems to trigger some nasty UB when bits = 32
- * (though in theory (1 << 32) = 0, 0 - 1 = UINT_MAX, but gives 0 compiling in some cases, but not always) */
-static const uint32_t MASK_TABLE_LSB[33] = {
-        0x00000000, 0x00000001, 0x00000003, 0x00000007, 0x0000000f, 0x0000001f, 0x0000003f, 0x0000007f, 0x000000ff,
-        0x000001ff, 0x000003ff, 0x000007ff, 0x00000fff, 0x00001fff, 0x00003fff, 0x00007fff, 0x0000ffff, 0x0001ffff,
-        0x0003ffff, 0x0007ffff, 0x000fffff, 0x001fffff, 0x003fffff, 0x007fffff, 0x00ffffff, 0x01ffffff, 0x03ffffff,
-        0x07ffffff, 0x0fffffff, 0x1fffffff, 0x3fffffff, 0x7fffffff, 0xffffffff
-};
+#if 0
+static inline int bl_fill(bitstream_t* bs, uint32_t bytes) {
+    if (bs->_b_off > bs->_b_max)
+        return 0;
 
+    bs->bufsize += bytes;
+    bs->_b_max += bytes * 8;
+
+    return 1;
+}
+
+static inline int bl_set(bitstream_t* bs, uint32_t b_off) {
+    if (bs->_b_off > bs->_b_max)
+        return 0;
+
+    bs->_b_off = b_off;
+
+    return 1;
+}
+#endif
 
 static inline int bl_skip(bitstream_t* bs, uint32_t bits) {
     if (bs->_b_off + bits > bs->_b_max) {
@@ -48,6 +61,7 @@ static inline int bl_skip(bitstream_t* bs, uint32_t bits) {
     return 1;
 }
 
+
 static inline void bl_align(bitstream_t* bs, uint32_t bits) {
     if (bits == 0)
         return;
@@ -59,15 +73,24 @@ static inline void bl_align(bitstream_t* bs, uint32_t bits) {
     bl_skip(bs, bits - left);
 }
 
+
 static inline int bl_pos(bitstream_t* bs) {
     return bs->_b_off;
 }
 
+
+static const uint32_t MASK_TABLE_LSB[33] = {
+        0x00000000, 0x00000001, 0x00000003, 0x00000007, 0x0000000f, 0x0000001f, 0x0000003f, 0x0000007f, 0x000000ff,
+        0x000001ff, 0x000003ff, 0x000007ff, 0x00000fff, 0x00001fff, 0x00003fff, 0x00007fff, 0x0000ffff, 0x0001ffff,
+        0x0003ffff, 0x0007ffff, 0x000fffff, 0x001fffff, 0x003fffff, 0x007fffff, 0x00ffffff, 0x01ffffff, 0x03ffffff,
+        0x07ffffff, 0x0fffffff, 0x1fffffff, 0x3fffffff, 0x7fffffff, 0xffffffff
+};
+
 /* Read bits (max 32) from buf and update the bit offset. Vorbis packs values in LSB order and byte by byte.
  * (ex. from 2 bytes 00100111 00000001 we can could read 4b=0111 and 6b=010010, 6b=remainder (second value is split into the 2nd byte) */
 static inline int bl_get(bitstream_t* ib, uint32_t bits, uint32_t* value) {
-    uint32_t shift, mask, pos, val;
 
+    // removing this check (manually validating enough buf) doesn't seem to affect performance much
     if (bits > 32 || bits > ib->_b_max - ib->_b_off) {
         *value = 0;
         ib->error = true;
@@ -79,11 +102,15 @@ static inline int bl_get(bitstream_t* ib, uint32_t bits, uint32_t* value) {
         return 1;
     }
 
-    pos = ib->_b_off / 8;            // byte offset
-    shift = ib->_b_off % 8;          // bit sub-offset
-    mask = MASK_TABLE_LSB[bits];    // to remove upper in highest byte
+    // Simple approach, considering typical case is bits <8
+    // Other approaches (u64 local or global cache w/ shift-mask, switch+fallthrough) and micro
+    // optimizations (no table) don't seem to improve performance (optimized out or branch prediction?)
 
-    val = ib->buf[pos+0] >> shift;
+    uint32_t pos = ib->_b_off / 8;          // byte offset (equivalent: ib->_b_off >> 3)
+    uint32_t shift = ib->_b_off % 8;        // bit sub-offset (equivalent: ib->_b_off & 7)
+    uint32_t mask = MASK_TABLE_LSB[bits];   // to remove upper in highest byte (equivalent: 0xFFFFFFFF >> (32 - bits))
+
+    uint32_t val = ib->buf[pos+0] >> shift;
     if (bits + shift > 8) {
         val |= ib->buf[pos+1] << (8u - shift);
         if (bits + shift > 16) {
@@ -91,7 +118,8 @@ static inline int bl_get(bitstream_t* ib, uint32_t bits, uint32_t* value) {
             if (bits + shift > 24) {
                 val |= ib->buf[pos+3] << (24u - shift);
                 if (bits + shift > 32) {
-                    val |= ib->buf[pos+4] << (32u - shift); // upper bits are lost (shifting over 32)
+                    // upper bits are lost (shifting over 32)
+                    val |= ib->buf[pos+4] << (32u - shift);
                 }
             }
         }
@@ -100,22 +128,20 @@ static inline int bl_get(bitstream_t* ib, uint32_t bits, uint32_t* value) {
     *value = (val & mask);
 
     ib->_b_off += bits;
-
     return 1;
 }
 
 static inline uint32_t bl_read(bitstream_t* ib, uint32_t bits) {
     uint32_t value;
-    int res = bl_get(ib, bits, &value);
-    if (!res)
-        return 0;
+    /*int res =*/ bl_get(ib, bits, &value);
+    //if (!res)
+    //    return 0;
     return value;
 }
 
 /* Write bits (max 32) to buf and update the bit offset. Vorbis packs values in LSB order and byte by byte.
  * (ex. writing 1101011010 from b_off 2 we get 01101011 00001101 (value split, and 11 in the first byte skipped)*/
 static inline int bl_put(bitstream_t* ob, uint32_t bits, uint32_t value) {
-    uint32_t shift, mask, pos;
 
     if (bits > 32 || bits > ob->_b_max - ob->_b_off) {
         ob->error = true;
@@ -126,9 +152,11 @@ static inline int bl_put(bitstream_t* ob, uint32_t bits, uint32_t value) {
         return 1;
     }
 
-    pos = ob->_b_off / 8;        // byte offset
-    shift = ob->_b_off % 8;      // bit sub-offset
-    mask = (1 << shift) - 1;    // to keep lower bits in lowest byte
+    // see bl_get
+
+    uint32_t pos = ob->_b_off / 8;      // byte offset
+    uint32_t shift = ob->_b_off % 8;    // bit sub-offset
+    uint32_t mask = (1 << shift) - 1;   // to keep lower bits in lowest byte
 
     ob->buf[pos+0] =  (value << shift) | (ob->buf[pos+0] & mask);
     if (bits + shift > 8) {

--- a/src/util/bitstream_lsb.h
+++ b/src/util/bitstream_lsb.h
@@ -13,8 +13,8 @@
 typedef struct {
     uint8_t* buf;           // buffer to read/write
     uint32_t bufsize;       // max size
-    uint32_t b_max;         // max size in bits
-    uint32_t b_off;         // current offset in bits inside the buffer
+    uint32_t _b_max;         // max size in bits
+    uint32_t _b_off;         // current offset in bits inside the buffer
     bool error;             // attempted to read/write past max data
 } bitstream_t;
 
@@ -22,8 +22,8 @@ typedef struct {
 static inline void bl_setup(bitstream_t* bs, uint8_t* buf, uint32_t bufsize) {
     bs->buf = buf;
     bs->bufsize = bufsize;
-    bs->b_max = bufsize * 8;
-    bs->b_off = 0;
+    bs->_b_max = bufsize * 8;
+    bs->_b_off = 0;
     bs->error = false;
 }
 
@@ -38,12 +38,12 @@ static const uint32_t MASK_TABLE_LSB[33] = {
 
 
 static inline int bl_skip(bitstream_t* bs, uint32_t bits) {
-    if (bs->b_off + bits > bs->b_max) {
+    if (bs->_b_off + bits > bs->_b_max) {
         bs->error = true;
         return 0;
     }
 
-    bs->b_off += bits;
+    bs->_b_off += bits;
 
     return 1;
 }
@@ -52,7 +52,7 @@ static inline void bl_align(bitstream_t* bs, uint32_t bits) {
     if (bits == 0)
         return;
 
-    int left = bs->b_off % bits;
+    int left = bs->_b_off % bits;
     if (left == 0)
         return;
 
@@ -60,7 +60,7 @@ static inline void bl_align(bitstream_t* bs, uint32_t bits) {
 }
 
 static inline int bl_pos(bitstream_t* bs) {
-    return bs->b_off;
+    return bs->_b_off;
 }
 
 /* Read bits (max 32) from buf and update the bit offset. Vorbis packs values in LSB order and byte by byte.
@@ -68,7 +68,7 @@ static inline int bl_pos(bitstream_t* bs) {
 static inline int bl_get(bitstream_t* ib, uint32_t bits, uint32_t* value) {
     uint32_t shift, mask, pos, val;
 
-    if (bits > 32 || bits > ib->b_max - ib->b_off) {
+    if (bits > 32 || bits > ib->_b_max - ib->_b_off) {
         *value = 0;
         ib->error = true;
         return 0;
@@ -79,8 +79,8 @@ static inline int bl_get(bitstream_t* ib, uint32_t bits, uint32_t* value) {
         return 1;
     }
 
-    pos = ib->b_off / 8;            // byte offset
-    shift = ib->b_off % 8;          // bit sub-offset
+    pos = ib->_b_off / 8;            // byte offset
+    shift = ib->_b_off % 8;          // bit sub-offset
     mask = MASK_TABLE_LSB[bits];    // to remove upper in highest byte
 
     val = ib->buf[pos+0] >> shift;
@@ -99,7 +99,7 @@ static inline int bl_get(bitstream_t* ib, uint32_t bits, uint32_t* value) {
 
     *value = (val & mask);
 
-    ib->b_off += bits;
+    ib->_b_off += bits;
 
     return 1;
 }
@@ -117,7 +117,7 @@ static inline uint32_t bl_read(bitstream_t* ib, uint32_t bits) {
 static inline int bl_put(bitstream_t* ob, uint32_t bits, uint32_t value) {
     uint32_t shift, mask, pos;
 
-    if (bits > 32 || bits > ob->b_max - ob->b_off) {
+    if (bits > 32 || bits > ob->_b_max - ob->_b_off) {
         ob->error = true;
         return 0;
     }
@@ -126,8 +126,8 @@ static inline int bl_put(bitstream_t* ob, uint32_t bits, uint32_t value) {
         return 1;
     }
 
-    pos = ob->b_off / 8;        // byte offset
-    shift = ob->b_off % 8;      // bit sub-offset
+    pos = ob->_b_off / 8;        // byte offset
+    shift = ob->_b_off % 8;      // bit sub-offset
     mask = (1 << shift) - 1;    // to keep lower bits in lowest byte
 
     ob->buf[pos+0] =  (value << shift) | (ob->buf[pos+0] & mask);
@@ -145,8 +145,20 @@ static inline int bl_put(bitstream_t* ob, uint32_t bits, uint32_t value) {
         }
     }
 
-    ob->b_off += bits;
+    ob->_b_off += bits;
     return 1;
+}
+
+static inline void bl_pad(bitstream_t* bs, uint32_t bits) {
+    if (bits == 0)
+        return;
+
+    int left = bs->_b_off % bits;
+    if (left == 0)
+        return;
+
+    int padding = bits - left;
+    bl_put(bs, padding, 0);
 }
 
 #endif

--- a/src/util/bitstream_msb.h
+++ b/src/util/bitstream_msb.h
@@ -6,6 +6,7 @@
 /* Simple bitreader for MPEG/standard bit style, in 'most significant byte' (MSB) format.
  * Example: with 0x1234 = 00010010 00110100, reading 5b + 6b = 00010 010001
  *  (first upper 5b, then next lower 3b and next upper 3b = 6b)
+ *
  * Kept in .h since it's slightly faster (compiler can optimize statics better using default compile flags).
  * Assumes bufs aren't that big (probable max ~0x20000000)
  */
@@ -13,8 +14,9 @@
 typedef struct {
     uint8_t* buf;           // buffer to read/write
     uint32_t bufsize;       // max size
-    uint32_t _b_max;         // max size in bits
-    uint32_t _b_off;         // current offset in bits inside buffer
+    uint32_t _b_max;        // max size in bits
+    uint32_t _b_off;        // current offset in bits inside the buffer
+
     bool error;             // attempted to read/write past max data
 } bitstream_t;
 
@@ -27,14 +29,6 @@ static inline void bm_setup(bitstream_t* bs, uint8_t* buf, uint32_t bufsize) {
     bs->error = false;
 }
 
-static inline int bm_set(bitstream_t* bs, uint32_t b_off) {
-    if (bs->_b_off > bs->_b_max)
-        return 0;
-
-    bs->_b_off = b_off;
-
-    return 1;
-}
 
 static inline int bm_fill(bitstream_t* bs, uint32_t bytes) {
     if (bs->_b_off > bs->_b_max)
@@ -45,6 +39,16 @@ static inline int bm_fill(bitstream_t* bs, uint32_t bytes) {
 
     return 1;
 }
+
+static inline int bm_set(bitstream_t* bs, uint32_t b_off) {
+    if (bs->_b_off > bs->_b_max)
+        return 0;
+
+    bs->_b_off = b_off;
+
+    return 1;
+}
+
 
 static inline int bm_skip(bitstream_t* bs, uint32_t bits) {
     if (bs->_b_off + bits > bs->_b_max) {
@@ -57,12 +61,24 @@ static inline int bm_skip(bitstream_t* bs, uint32_t bits) {
     return 1;
 }
 
+#if 0
+static inline void bm_align(bitstream_t* bs, uint32_t bits) {
+    if (bits == 0)
+        return;
+
+    int left = bs->_b_off % bits;
+    if (left == 0)
+        return;
+
+    bm_skip(bs, bits - left);
+}
+#endif
+
 static inline int bm_pos(bitstream_t* bs) {
     return bs->_b_off;
 }
 
-/* same as (1 << bits) - 1, but that seems to trigger some nasty UB when bits = 32
- * (though in theory (1 << 32) = 0, 0 - 1 = UINT_MAX, but gives 0 compiling in some cases, but not always) */
+
 static const uint32_t MASK_TABLE_MSB[33] = {
         0x00000000, 0x00000001, 0x00000003, 0x00000007, 0x0000000f, 0x0000001f, 0x0000003f, 0x0000007f, 0x000000ff,
         0x000001ff, 0x000003ff, 0x000007ff, 0x00000fff, 0x00001fff, 0x00003fff, 0x00007fff, 0x0000ffff, 0x0001ffff,
@@ -70,12 +86,11 @@ static const uint32_t MASK_TABLE_MSB[33] = {
         0x07ffffff, 0x0fffffff, 0x1fffffff, 0x3fffffff, 0x7fffffff, 0xffffffff
 };
 
-/* Read bits (max 32) from buf and update the bit offset. Order is BE (MSB). */
+/* Read bits (max 32) from buf and update the bit offset.
+ * Order is BE (MSB). */
 static inline int bm_get(bitstream_t* ib, uint32_t bits, uint32_t* value) {
-    uint32_t shift, pos, mask;
-    uint64_t val; //TODO: could use u32 with some shift fiddling
-    int left;
 
+    // removing this check (manually validating enough buf) doesn't seem to affect performance much
     if (bits > 32 || bits > ib->_b_max - ib->_b_off) {
         *value = 0;
         ib->error = true;
@@ -87,31 +102,16 @@ static inline int bm_get(bitstream_t* ib, uint32_t bits, uint32_t* value) {
         return 1;
     }
 
-    pos = ib->_b_off / 8;                        // byte offset
-    shift = ib->_b_off % 8;                      // bit sub-offset
+    // Simple approach, considering typical case is bits <8
+    // Other approaches (u64 local or global cache w/ shift-mask, switch+fallthrough) and micro
+    // optimizations (no table) don't seem to improve performance (optimized out or branch prediction?)
 
-#if 0 //naive approach
-    int bit_val, bit_buf;
+    uint32_t pos = ib->_b_off / 8;          // byte offset
+    uint32_t shift = ib->_b_off % 8;        // bit sub-offset
+    uint32_t mask = MASK_TABLE_MSB[bits];   // to remove upper in highest byte
 
-    val = 0;
-    for (int i = 0; i < bits; i++) {
-        bit_buf = (1U << (8-1-shift)) & 0xFF;   // bit check for buf
-        bit_val = (1U << (bits-1-i));           // bit to set in value
-
-        if (ib->_buf[pos] & bit_buf)             // is bit in buf set?
-            val |= bit_val;                     // set bit
-
-        shift++;
-        if (shift % 8 == 0) {                   // new byte starts
-            shift = 0;
-            pos++;
-        }
-    }
-#else
-    mask = MASK_TABLE_MSB[bits];    // to remove upper in highest byte
-
-    val = ib->buf[pos+0];
-    left = 8 - (bits + shift);
+    uint64_t val = ib->buf[pos+0]; //TODO: could use u32 with some shift fiddling
+    int left = 8 - (bits + shift);
     if (bits + shift > 8) {
         val = (val << 8u) | ib->buf[pos+1];
         left = 16 - (bits + shift);
@@ -129,7 +129,6 @@ static inline int bm_get(bitstream_t* ib, uint32_t bits, uint32_t* value) {
         }
     }
     val = ((val >> left) & mask);
-#endif
 
     *value = val;
     ib->_b_off += bits;
@@ -138,16 +137,15 @@ static inline int bm_get(bitstream_t* ib, uint32_t bits, uint32_t* value) {
 
 static inline uint32_t bm_read(bitstream_t* ib, uint32_t bits) {
     uint32_t value;
-    int res = bm_get(ib, bits, &value);
-    if (!res)
-        return 0;
+    /*int res =*/ bm_get(ib, bits, &value);
+    //if (!res)
+    //    return 0;
     return value;
 }
 
-/* Write bits (max 32) to buf and update the bit offset. Order is BE (MSB). */
+/* Write bits (max 32) to buf and update the bit offset.
+ * Order is BE (MSB). */
 static inline int bm_put(bitstream_t* ob, uint32_t bits, uint32_t value) {
-    uint32_t shift, pos;
-    int i, bit_val, bit_buf;
 
     if (bits > 32 || bits > ob->_b_max - ob->_b_off) {
         ob->error = true;
@@ -158,20 +156,22 @@ static inline int bm_put(bitstream_t* ob, uint32_t bits, uint32_t value) {
         return 1;
     }
 
-    pos = ob->_b_off / 8;                       // byte offset
-    shift = ob->_b_off % 8;                     // bit sub-offset
+    // see bl_get
 
-    for (i = 0; i < bits; i++) {
-        bit_val = (1U << (bits-1-i));           // bit check for value
-        bit_buf = (1U << (8-1-shift)) & 0xFF;   // bit to set in buf
+    uint32_t pos = ob->_b_off / 8;                  // byte offset
+    uint32_t shift = ob->_b_off % 8;                // bit sub-offset
 
-        if (value & bit_val)                    // is bit in val set?
-            ob->buf[pos] |= bit_buf;            // set bit
+    for (int i = 0; i < bits; i++) {
+        int bit_val = (1U << (bits-1-i));           // bit check for value
+        int bit_buf = (1U << (8-1-shift)) & 0xFF;   // bit to set in buf
+
+        if (value & bit_val)                        // is bit in val set?
+            ob->buf[pos] |= bit_buf;                // set bit
         else
-            ob->buf[pos] &= ~bit_buf;           // unset bit
+            ob->buf[pos] &= ~bit_buf;               // unset bit
 
         shift++;
-        if (shift % 8 == 0) {                   // new byte starts
+        if (shift % 8 == 0) {                       // new byte starts
             shift = 0;
             pos++;
         }

--- a/src/util/bitstream_msb.h
+++ b/src/util/bitstream_msb.h
@@ -13,8 +13,8 @@
 typedef struct {
     uint8_t* buf;           // buffer to read/write
     uint32_t bufsize;       // max size
-    uint32_t b_max;         // max size in bits
-    uint32_t b_off;         // current offset in bits inside buffer
+    uint32_t _b_max;         // max size in bits
+    uint32_t _b_off;         // current offset in bits inside buffer
     bool error;             // attempted to read/write past max data
 } bitstream_t;
 
@@ -22,43 +22,43 @@ typedef struct {
 static inline void bm_setup(bitstream_t* bs, uint8_t* buf, uint32_t bufsize) {
     bs->buf = buf;
     bs->bufsize = bufsize;
-    bs->b_max = bufsize * 8;
-    bs->b_off = 0;
+    bs->_b_max = bufsize * 8;
+    bs->_b_off = 0;
     bs->error = false;
 }
 
 static inline int bm_set(bitstream_t* bs, uint32_t b_off) {
-    if (bs->b_off > bs->b_max)
+    if (bs->_b_off > bs->_b_max)
         return 0;
 
-    bs->b_off = b_off;
+    bs->_b_off = b_off;
 
     return 1;
 }
 
 static inline int bm_fill(bitstream_t* bs, uint32_t bytes) {
-    if (bs->b_off > bs->b_max)
+    if (bs->_b_off > bs->_b_max)
         return 0;
 
     bs->bufsize += bytes;
-    bs->b_max += bytes * 8;
+    bs->_b_max += bytes * 8;
 
     return 1;
 }
 
 static inline int bm_skip(bitstream_t* bs, uint32_t bits) {
-    if (bs->b_off + bits > bs->b_max) {
+    if (bs->_b_off + bits > bs->_b_max) {
         bs->error = true;
         return 0;
     }
 
-    bs->b_off += bits;
+    bs->_b_off += bits;
 
     return 1;
 }
 
 static inline int bm_pos(bitstream_t* bs) {
-    return bs->b_off;
+    return bs->_b_off;
 }
 
 /* same as (1 << bits) - 1, but that seems to trigger some nasty UB when bits = 32
@@ -76,7 +76,7 @@ static inline int bm_get(bitstream_t* ib, uint32_t bits, uint32_t* value) {
     uint64_t val; //TODO: could use u32 with some shift fiddling
     int left;
 
-    if (bits > 32 || bits > ib->b_max - ib->b_off) {
+    if (bits > 32 || bits > ib->_b_max - ib->_b_off) {
         *value = 0;
         ib->error = true;
         return 0;
@@ -87,8 +87,8 @@ static inline int bm_get(bitstream_t* ib, uint32_t bits, uint32_t* value) {
         return 1;
     }
 
-    pos = ib->b_off / 8;                        // byte offset
-    shift = ib->b_off % 8;                      // bit sub-offset
+    pos = ib->_b_off / 8;                        // byte offset
+    shift = ib->_b_off % 8;                      // bit sub-offset
 
 #if 0 //naive approach
     int bit_val, bit_buf;
@@ -98,7 +98,7 @@ static inline int bm_get(bitstream_t* ib, uint32_t bits, uint32_t* value) {
         bit_buf = (1U << (8-1-shift)) & 0xFF;   // bit check for buf
         bit_val = (1U << (bits-1-i));           // bit to set in value
 
-        if (ib->buf[pos] & bit_buf)             // is bit in buf set?
+        if (ib->_buf[pos] & bit_buf)             // is bit in buf set?
             val |= bit_val;                     // set bit
 
         shift++;
@@ -132,7 +132,7 @@ static inline int bm_get(bitstream_t* ib, uint32_t bits, uint32_t* value) {
 #endif
 
     *value = val;
-    ib->b_off += bits;
+    ib->_b_off += bits;
     return 1;
 }
 
@@ -149,7 +149,7 @@ static inline int bm_put(bitstream_t* ob, uint32_t bits, uint32_t value) {
     uint32_t shift, pos;
     int i, bit_val, bit_buf;
 
-    if (bits > 32 || bits > ob->b_max - ob->b_off) {
+    if (bits > 32 || bits > ob->_b_max - ob->_b_off) {
         ob->error = true;
         return 0;
     }
@@ -158,8 +158,8 @@ static inline int bm_put(bitstream_t* ob, uint32_t bits, uint32_t value) {
         return 1;
     }
 
-    pos = ob->b_off / 8;                        // byte offset
-    shift = ob->b_off % 8;                      // bit sub-offset
+    pos = ob->_b_off / 8;                       // byte offset
+    shift = ob->_b_off % 8;                     // bit sub-offset
 
     for (i = 0; i < bits; i++) {
         bit_val = (1U << (bits-1-i));           // bit check for value
@@ -177,8 +177,20 @@ static inline int bm_put(bitstream_t* ob, uint32_t bits, uint32_t value) {
         }
     }
 
-    ob->b_off += bits;
+    ob->_b_off += bits;
     return 1;
+}
+
+static inline void bm_pad(bitstream_t* bs, uint32_t bits) {
+    if (bits == 0)
+        return;
+
+    int left = bs->_b_off % bits;
+    if (left == 0)
+        return;
+
+    int padding = bits - left;
+    bm_put(bs, padding, 0);
 }
 
 #endif

--- a/src/util/channel_mappings.h
+++ b/src/util/channel_mappings.h
@@ -25,9 +25,14 @@ typedef enum {
 
 } speaker_t;
 
-/* typical mappings that metas may use to set channel_layout (but plugin must actually use it)
+/* Typical mappings that metas may use to set channel_layout (but plugin must actually use it)
  * (in order, so 3ch file could be mapped to FL FR FC or FL FR LFE but not LFE FL FR)
- * not too sure about names but no clear standards */
+ * not too sure about names but no clear standards. Ex. most common for 5.1:
+ * - SMPTE: L R FC LFE Ls SR (.wav)
+ * - Film: L FC R SL SR LFE (.ogg vorbis, opus in some cases, ac3?)
+ * - DTS: L R SL SR FC LFE (.usm)
+ * - AAC: C L R SL SR LFE (.aac)
+ *  */
 typedef enum {
     mapping_MONO             = speaker_FC,
     mapping_STEREO           = speaker_FL | speaker_FR,

--- a/src/util/chunks.c
+++ b/src/util/chunks.c
@@ -27,13 +27,20 @@ bool next_chunk(chunk_t* chunk, STREAMFILE* sf) {
     // read past data
     if (chunk->type == 0xFFFFFFFF || chunk->size == 0xFFFFFFFF)
         return false;
+    if (chunk->full_size && chunk->size < 0x08)
+        return false;
 
     // allow broken files (such as prefetch)
     //if (chunk->size > remaining - 0x08)
     //    return false;
 
-    chunk->offset = chunk->current + 0x08;
-    chunk->current += chunk->full_size ? chunk->size : 0x08 + chunk->size;
+    chunk->offset = chunk->current;
+    chunk->current += chunk->size;
+    if (!chunk->full_size) {
+        chunk->offset += 0x08;
+        chunk->current += 0x08;
+    }
+
     //;VGM_LOG("CHUNK: %x, %x, %x\n", dc.offset, chunk->type, chunk->size);
 
     // enforce 16-bit chunk alignment as per spec, where chunk_size may be odd (0x11) but must be

--- a/src/util/chunks.h
+++ b/src/util/chunks.h
@@ -12,7 +12,7 @@ typedef struct {
 
     bool le_type;       /* read type as LE instead of more common BE */
     bool be_size;       /* read type as BE instead of more common LE */
-    bool full_size;     /* chunk size includes type+size */
+    bool full_size;     /* chunk size includes type+size, at offset is set at fourcc */
     bool alignment;     /* chunks with odd size need to be aligned to even, per RIFF spec */
 } chunk_t;
 

--- a/src/util/companion_files.c
+++ b/src/util/companion_files.c
@@ -4,6 +4,7 @@
 #include "reader_text.h"
 #include "sf_utils.h"
 #include "string_utils.h"
+#include "hashes.h"
 
 #define TXT_LINE_MAX 1024
 
@@ -56,15 +57,18 @@ fail:
     return 0;
 }
 
-STREAMFILE* read_filemap_file(STREAMFILE* sf, int file_num) {
-    return read_filemap_file_pos(sf, file_num, NULL);
+STREAMFILE* read_filemap_file(STREAMFILE* sf, int val_num) {
+    return read_filemap_file_pos(sf, val_num, NULL);
 }
 
-STREAMFILE* read_filemap_file_pos(STREAMFILE* sf, int file_num, int* p_pos) {
+STREAMFILE* read_filemap_file_pos(STREAMFILE* sf, int val_num, int* p_key_pos) {
     char filename[PATH_LIMIT];
     off_t txt_offset, file_size;
     STREAMFILE* sf_map = NULL;
-    int file_pos = 0;
+
+    uint32_t prev_hash, curr_hash;
+    int key_pos = 0;
+
 
     sf_map = open_streamfile_by_filename(sf, ".txtm");
     if (!sf_map) goto fail;
@@ -73,6 +77,8 @@ STREAMFILE* read_filemap_file_pos(STREAMFILE* sf, int file_num, int* p_pos) {
 
     txt_offset = read_bom(sf_map);
     file_size = get_streamfile_size(sf_map);
+
+    prev_hash = 0;
 
     /* read lines and find target filename, format is (filename): value1, ... valueN */
     while (txt_offset < file_size) {
@@ -88,12 +94,16 @@ STREAMFILE* read_filemap_file_pos(STREAMFILE* sf, int file_num, int* p_pos) {
 
         /* get key/val (ignores lead/trailing spaces, stops at comment/separator) */
         ok = sscanf(line, " %[^\t#:] : %[^\t#\r\n] ", key, val);
-        if (ok != 2) { /* ignore line if no key=val (comment or garbage) */
-            /* better way? */
-            if (strcmp(line, "#@reset-pos") == 0) {
-                file_pos = 0;
-            }
+        if (ok != 2) {
             continue;
+        }
+
+        // Multiple .awb can be mapped to a single .acb, so we need to detect .awb's position
+        // in the .txtm (0, 1, 2...). If the .acb changes this position also resets.
+        curr_hash = hash_str_lc(val);
+        if (prev_hash != curr_hash) {
+            prev_hash = curr_hash;
+            key_pos = 0;
         }
 
         if (strcmp(key, filename) == 0) {
@@ -101,7 +111,8 @@ STREAMFILE* read_filemap_file_pos(STREAMFILE* sf, int file_num, int* p_pos) {
             char subval[TXT_LINE_MAX];
             const char* current = val;
 
-            for (int i = 0; i <= file_num; i++) {
+            // find subfile N (valueN) for "filename: value0, value1, value2"
+            for (int i = 0; i <= val_num; i++) {
                 if (current[0] == '\0')
                     goto fail;
 
@@ -109,8 +120,8 @@ STREAMFILE* read_filemap_file_pos(STREAMFILE* sf, int file_num, int* p_pos) {
                 if (ok != 1)
                     goto fail;
 
-                if (i == file_num) {
-                    if (p_pos) *p_pos = file_pos;
+                if (i == val_num) {
+                    if (p_key_pos) *p_key_pos = key_pos;
 
                     close_streamfile(sf_map);
                     return open_streamfile_by_filename(sf, subval);
@@ -121,7 +132,8 @@ STREAMFILE* read_filemap_file_pos(STREAMFILE* sf, int file_num, int* p_pos) {
                     current++;
             }
         }
-        file_pos++;
+
+        key_pos++;
     }
 
 fail:

--- a/src/util/hashes.c
+++ b/src/util/hashes.c
@@ -1,0 +1,26 @@
+#include <ctype.h>
+#include "hashes.h"
+#include "sf_utils.h"
+#include "vgmstream_limits.h"
+
+/* our favorite garbo hash a.k.a FNV-1 32b */
+uint32_t hash_str_lc(const char* str) {
+
+    uint32_t hash = 2166136261;
+    int i = 0;
+    while (str[i] != '\0') {
+        char c = tolower(str[i]);
+        hash = (hash * 16777619) ^ (uint8_t)c;
+        i++;
+    }
+
+    return hash;
+}
+
+uint32_t hash_sf(STREAMFILE* sf) {
+    char path[PATH_LIMIT];
+
+    get_streamfile_name(sf, path, sizeof(path));
+
+    return hash_str_lc(path);
+}

--- a/src/util/hashes.h
+++ b/src/util/hashes.h
@@ -1,0 +1,10 @@
+#ifndef _HASHES_H_
+#define _HASHES_H_
+
+#include "../streamfile.h"
+#include <stdint.h>
+
+uint32_t hash_str_lc(const char* str);
+uint32_t hash_sf(STREAMFILE* sf);
+
+#endif

--- a/winamp/in_vgmstream.c
+++ b/winamp/in_vgmstream.c
@@ -92,19 +92,14 @@ bool info_was_protocol;
 #endif
 #endif
 
-/* parses a modified filename ('fakename') extracting tags parameters (NULL tag for first = filename) */
-static bool parse_fn_string(const in_char* fn, const in_char* tag, in_char* dst, size_t dst_size) {
-    const in_char* end = wa_strchr(fn,'|');
+/* copies a filename removing extra params ('C:\blah\file.fsb|1' to 'C:\blah\file.fsb') */
+static void parse_fn_base(const in_char* fn, in_char* dst, size_t dst_size) {
+    wa_istrcpy(dst, dst_size, fn);
 
-    if (tag == NULL) {
-        wa_istrcpy(dst, dst_size, fn);
-        if (end)
-            dst[end - fn] = '\0';
-        return true;
-    }
-
-    dst[0] = '\0';
-    return false;
+    in_char* end = wa_strchr(dst, '|');
+    if (!end)
+        return;
+    end[0] = 0; //'\0';
 }
 
 static int parse_fn_int(const in_char* fn, const in_char* tag, int* num) {
@@ -160,7 +155,7 @@ static libvgmstream_t* init_vgmstream_winamp_fileinfo(const in_char* fn) {
     int stream_index = 0;
 
     /* check for info encoded in the filename */
-    parse_fn_string(fn, NULL, filename, WINAMP_PATH_LIMIT);
+    parse_fn_base(fn, filename, WINAMP_PATH_LIMIT);
     parse_fn_int(fn, wa_L("$s"), &stream_index);
 
     return init_vgmstream_winamp(filename, stream_index);
@@ -185,7 +180,7 @@ static void get_title(in_char* dst, int dst_size, const in_char* fn, libvgmstrea
     char buffer[WINAMP_PATH_LIMIT];
     char filename_utf8[WINAMP_PATH_LIMIT];
 
-    parse_fn_string(fn, NULL, filename,WINAMP_PATH_LIMIT);
+    parse_fn_base(fn, filename, WINAMP_PATH_LIMIT);
     //parse_fn_int(fn, wa_L("$s"), &stream_index);
 
     wa_ichar_to_char(filename_utf8, WINAMP_PATH_LIMIT, filename);
@@ -419,7 +414,7 @@ static int winamp_Play(const in_char *fn) {
         return 1;
 
     /* check for info encoded in the filename */
-    parse_fn_string(fn, NULL, filename,WINAMP_PATH_LIMIT);
+    parse_fn_base(fn, filename, WINAMP_PATH_LIMIT);
     parse_fn_int(fn, wa_L("$s"), &stream_index);
 
     /* open the stream */
@@ -859,7 +854,7 @@ static void load_tagfile_info(in_char* filename) {
     }
 
     /* clean extra part for subsong tags */
-    parse_fn_string(filename, NULL, filename_clean, WINAMP_PATH_LIMIT);
+    parse_fn_base(filename, filename_clean, WINAMP_PATH_LIMIT);
 
     if (wa_strcmp(last_tags.filename, filename_clean) == 0) {
         return; /* not changed, tags still apply */

--- a/xmplay/xmp_vgmstream.c
+++ b/xmplay/xmp_vgmstream.c
@@ -250,23 +250,24 @@ void WINAPI xmplay_GetGeneralInfo(char* buf) {
     libvgmstream_format_describe(vgmstream, description, sizeof(description));
 
     /* tags are divided with a tab and lines with carriage return so we'll do some guetto fixin' */
-	int tag_done = 0;
+	bool tag_done = false;
 	description[0] -= 32; //Replace small letter with capital for consistency with XMPlay's output
     for (int i = 0; i < 1024; i++) {
         if (description[i] == '\0')
             break;
 
-        if (description[i] == ':' && !tag_done) { /* to ignore multiple ':' in a line*/
+        if (description[i] == ':' && !tag_done) { // to ignore multiple ':' in a line
             description[i] = ' ';
-            description[i+1] = '\t';
-            tag_done = 1;
+            if (description[i+1] != '\0')
+                description[i+1] = '\t';
+            tag_done = true;
         }
 
         if (description[i] == '\n') {
             description[i] = '\r';
-			if (description[i+1])
-				description[i+1] -= 32; //Replace small letter with capital for consistency with XMPlay's output
-            tag_done = 0;
+			if (description[i+1] != '\0')
+				description[i+1] -= 32; // replace small letter with capital for consistency with XMPlay's output
+            tag_done = false;
         }
     }
 


### PR DESCRIPTION
- Improve ambisonic HCA files 
- Fix .txtm order in some cases 
- Fix .awb/acb with .bcwav in some cases 
- Add missing .nst/ste extensions 
- misc: fix minor ub/buffer/int overflow issues 
- cli: optimize output filename wildcards 
