### PR TITLE
cf_df: Add support for older titles

### DIFF
--- a/src/coding/df_decoder.c
+++ b/src/coding/df_decoder.c
@@ -34,75 +34,100 @@
 /* DC offset fix. v4.x callers pass shift=8 (canonical u8->s16); v5 uses 9. */
 #define DF_V40_SAMPLE_TO_16BIT(sample, shift) ((int16_t)(((int8_t)(sample) - 0x40) << (shift)))
 
-/* DreamFactory v4.0 ADPCM Decoder (8-bit to 8-bit) */
-
-static bool decode_cf_df_v40(VGMSTREAM* v, sbuf_t* sdst) {
+/* DreamFactory v4.0 / DreamFactory 5 v4.0 shared decoder.
+ * Both use the same control stream and need the same mid-run state across decode_buf calls.
+ * v4.0 emits the initial stream byte as a sample and scales at <<8; D5 gets the seed from
+ * the block layout (not emitted) and scales at <<9. */
+static bool decode_cf_df_v40_common(VGMSTREAM* v, sbuf_t* sdst, int shift, bool emit_stream_seed) {
     VGMSTREAMCHANNEL* stream = &v->ch[0];
     decode_state_t* ds = v->decode_state;
     int samples_to_do = ds->samples_left;
     sample_t* outbuf = sbuf_get_filled_buf(sdst);
     int i = 0;
-    int8_t prev_sample = (int8_t)stream->adpcm_history1_16;
 
-    /* Handle the very first sample if starting from the beginning */
-    if (stream->offset == stream->channel_start_offset) {
-        prev_sample = read_u8(stream->offset, stream->streamfile);
-        stream->offset++;
-        if (samples_to_do > 0) {
-            outbuf[0] = DF_V40_SAMPLE_TO_16BIT(prev_sample, 8);
-            samples_to_do--;
-            outbuf++;
-        }
+    int8_t prev = (int8_t)stream->adpcm_history1_16;
+    int run_mode = stream->adpcm_step_index;
+    int run_count = stream->adpcm_history2_32;
+    int pending_valid = stream->adpcm_history4_32;
+    int16_t pending = (int16_t)stream->adpcm_history3_32;
+
+    /* v4.0 stores its initial absolute sample in the stream and emits it.
+     * D5 has already loaded the seed and points offset at the first control byte. */
+    if (emit_stream_seed && stream->offset == stream->channel_start_offset) {
+        prev = (int8_t)read_u8(stream->offset++, stream->streamfile);
+        if (i < samples_to_do)
+            outbuf[i++] = DF_V40_SAMPLE_TO_16BIT(prev, shift);
     }
 
     while (i < samples_to_do) {
-        uint8_t control_byte = read_u8(stream->offset, stream->streamfile);
-        stream->offset++;
-
-        /* Mode I: Absolute Value */
-        if ((control_byte & 0x80) == 0) {
-            prev_sample = (int8_t)control_byte;
-            outbuf[i++] = DF_V40_SAMPLE_TO_16BIT(prev_sample, 8);
+        /* flush a buffered Mode-II second sample from a previous call */
+        if (pending_valid) {
+            outbuf[i++] = pending;
+            pending_valid = 0;
+            continue;
         }
+
+        /* Mode III: Repeat (RLE) */
+        if (run_mode == 3) {
+            while (run_count > 0 && i < samples_to_do) {
+                outbuf[i++] = DF_V40_SAMPLE_TO_16BIT(prev, shift);
+                run_count--;
+            }
+            if (run_count == 0)
+                run_mode = 0;
+            continue;
+        }
+
         /* Mode II: DPCM Nibble Sequences */
-        else if ((control_byte & 0x40) == 0) {
-            int count = (control_byte & 0x3f) + 1;
-            for (int j = 0; j < count && i < samples_to_do; j++) {
-                uint8_t table_val = read_u8(stream->offset, stream->streamfile);
-                stream->offset++;
-
-                /* High Nibble Sign-Extension */
+        if (run_mode == 2) {
+            while (run_count > 0 && i < samples_to_do) {
+                uint8_t table_val = read_u8(stream->offset++, stream->streamfile);
                 int8_t step_delta = (int8_t)table_val >> 4;
-
-                /* Low Nibble Sign-Extension */
                 int8_t index_delta = (int8_t)(table_val << 4) >> 4;
+                int8_t s1 = prev + step_delta;
+                int8_t s2 = s1 + index_delta;
+                prev = s2;
+                run_count--;
 
-                /* Apply High Nibble Delta */
-                int8_t step_sample = prev_sample + step_delta;
-                outbuf[i++] = DF_V40_SAMPLE_TO_16BIT(step_sample, 8);
-
-                if (i >= samples_to_do) {
-                    prev_sample = step_sample;
+                outbuf[i++] = DF_V40_SAMPLE_TO_16BIT(s1, shift);
+                if (i < samples_to_do) {
+                    outbuf[i++] = DF_V40_SAMPLE_TO_16BIT(s2, shift);
+                } else {
+                    pending = DF_V40_SAMPLE_TO_16BIT(s2, shift);
+                    pending_valid = 1;
                     break;
                 }
-
-                /* Apply Low Nibble Delta */
-                int8_t index_sample = step_sample + index_delta;
-                outbuf[i++] = DF_V40_SAMPLE_TO_16BIT(index_sample, 8);
-                prev_sample = index_sample;
             }
+            if (run_count == 0)
+                run_mode = 0;
+            continue;
         }
-        /* Mode III: Repeat (RLE) */
-        else {
-            int count = (control_byte & 0x3f) + 1;
-            for (int j = 0; j < count && i < samples_to_do; j++) {
-                outbuf[i++] = DF_V40_SAMPLE_TO_16BIT(prev_sample, 8);
-            }
+
+        /* idle: read a control byte */
+        uint8_t control_byte = read_u8(stream->offset++, stream->streamfile);
+        if ((control_byte & 0x80) == 0) {        /* Mode I: absolute */
+            prev = (int8_t)control_byte;
+            outbuf[i++] = DF_V40_SAMPLE_TO_16BIT(prev, shift);
+        } else if ((control_byte & 0x40) == 0) { /* Mode II */
+            run_mode = 2;
+            run_count = (control_byte & 0x3f) + 1;
+        } else {                                 /* Mode III */
+            run_mode = 3;
+            run_count = (control_byte & 0x3f) + 1;
         }
     }
 
-    stream->adpcm_history1_16 = prev_sample;
+    stream->adpcm_history1_16 = prev;
+    stream->adpcm_step_index  = run_mode;
+    stream->adpcm_history2_32 = run_count;
+    stream->adpcm_history4_32 = pending_valid;
+    stream->adpcm_history3_32 = pending;
     return true;
+}
+
+/* DreamFactory v4.0 ADPCM Decoder (8-bit to 8-bit) */
+static bool decode_cf_df_v40(VGMSTREAM* v, sbuf_t* sdst) {
+    return decode_cf_df_v40_common(v, sdst, 8, true);
 }
 
 /* DreamFactory v4.1 DPCM Decoder (16-bit) */
@@ -172,77 +197,7 @@ int32_t cf_df_v5_get_samples(STREAMFILE* sf, off_t block_data, int block_size) {
 }
 
 static bool decode_cf_df_v5_v40(VGMSTREAM* v, sbuf_t* sdst) {
-    VGMSTREAMCHANNEL* stream = &v->ch[0];
-    decode_state_t* ds = v->decode_state;
-    int samples_to_do = ds->samples_left;
-    sample_t* outbuf = sbuf_get_filled_buf(sdst);
-    int i = 0;
-
-    int8_t prev = (int8_t)stream->adpcm_history1_16;
-    int run_mode = stream->adpcm_step_index;
-    int run_count = stream->adpcm_history2_32;
-    int pending_valid = stream->adpcm_history4_32;
-    int16_t pending = (int16_t)stream->adpcm_history3_32;
-
-    while (i < samples_to_do) {
-        /* flush a buffered Mode-II second sample from a previous call */
-        if (pending_valid) {
-            outbuf[i++] = pending;
-            pending_valid = 0;
-            continue;
-        }
-        /* Mode III: Repeat (RLE) */
-        if (run_mode == 3) {
-            while (run_count > 0 && i < samples_to_do) {
-                outbuf[i++] = DF_V40_SAMPLE_TO_16BIT(prev, 9);
-                run_count--;
-            }
-            if (run_count == 0) run_mode = 0;
-            continue;
-        }
-        /* Mode II: DPCM Nibble Sequences */
-        if (run_mode == 2) {
-            while (run_count > 0 && i < samples_to_do) {
-                uint8_t table_val = read_u8(stream->offset++, stream->streamfile);
-                int8_t step_delta = (int8_t)table_val >> 4;
-                int8_t index_delta = (int8_t)(table_val << 4) >> 4;
-                int8_t s1 = prev + step_delta;
-                int8_t s2 = s1 + index_delta;
-                prev = s2;
-                run_count--;
-
-                outbuf[i++] = DF_V40_SAMPLE_TO_16BIT(s1, 9);
-                if (i < samples_to_do) {
-                    outbuf[i++] = DF_V40_SAMPLE_TO_16BIT(s2, 9);
-                } else {
-                    pending = DF_V40_SAMPLE_TO_16BIT(s2, 9);
-                    pending_valid = 1;
-                    break;
-                }
-            }
-            if (run_count == 0) run_mode = 0;
-            continue;
-        }
-        /* idle: read a control byte */
-        uint8_t control_byte = read_u8(stream->offset++, stream->streamfile);
-        if ((control_byte & 0x80) == 0) {        /* Mode I: absolute */
-            prev = (int8_t)control_byte;
-            outbuf[i++] = DF_V40_SAMPLE_TO_16BIT(prev, 9);
-        } else if ((control_byte & 0x40) == 0) { /* Mode II */
-            run_mode = 2;
-            run_count = (control_byte & 0x3f) + 1;
-        } else {                                 /* Mode III */
-            run_mode = 3;
-            run_count = (control_byte & 0x3f) + 1;
-        }
-    }
-
-    stream->adpcm_history1_16 = prev;
-    stream->adpcm_step_index = run_mode;
-    stream->adpcm_history2_32 = run_count;
-    stream->adpcm_history4_32 = pending_valid;
-    stream->adpcm_history3_32 = pending;
-    return true;
+    return decode_cf_df_v40_common(v, sdst, 9, false);
 }
 
 const codec_info_t cf_df_v40_decoder = {

--- a/src/formats.c
+++ b/src/formats.c
@@ -25,6 +25,7 @@
 static const char* extension_list[] = {
     //"", /* vgmstream can play extensionless files too, but plugins must accept them manually */
 
+    "11k",
     "208",
     "2dx",
     "2dx9",

--- a/src/meta/cf_df.c
+++ b/src/meta/cf_df.c
@@ -49,7 +49,7 @@
 #define DF_PROTO_MACINTOSH_RATE      22255  /* nearest integer to 0x56EE8BA3 (16.16) */
 #define DF_PROTO_PLAYLIST_MAX        64
 
-/* Revision-4 .snd control payload. Unlike the shared .mov/.sfx/.trk layout,
+/* Revision-4 .snd control payload. Unlike the shared .mov/.sfx/.trk/.11k layout,
  * the loop block is referenced by container id instead of fixed at id 1. */
 #define DF_SND_REVISION              0x02
 #define DF_SND_REVISION_4            0x0004
@@ -723,7 +723,7 @@ fail:
 }
 
 /* Assembled track via segmented layout: play the given sequence of loop chunks once.
- * loop=1 marks the whole assembled track as an end-to-end loop (.snd/.sfx/.trk only; .mov excluded). */
+ * loop=1 marks the whole assembled track as an end-to-end loop (.snd/.sfx/.trk/.11k only; .mov excluded). */
 static VGMSTREAM* build_segmented(STREAMFILE* sf, df_chunk_t* chunks, const int* seq, int count, int loop, int loop_start) {
     VGMSTREAM* v = NULL;
     segmented_layout_data* data = init_layout_segmented(count);
@@ -897,7 +897,7 @@ static VGMSTREAM* build_cf_df_v4(STREAMFILE* sf, int containers, bool is_mov) {
     int16_t* order = NULL;
     uint8_t* in_loop = NULL;
 
-    int loop_track = check_extensions(sf, "sfx,snd,trk");
+    int loop_track = check_extensions(sf, "sfx,snd,trk,11k");
     int target = sf->stream_index;
     if (target == 0)
         target = 1;
@@ -1077,7 +1077,7 @@ VGMSTREAM* init_vgmstream_cf_df(STREAMFILE* sf) {
     bool v1_big_endian = false;
     bool is_extensionless;
 
-    if (!check_extensions(sf, "snd,sfx,trk,mov,move,"))
+    if (!check_extensions(sf, "snd,sfx,trk,11k,mov,move,"))
         return NULL;
 
     is_mov = check_extensions(sf, "mov,move");

--- a/src/meta/cf_df.c
+++ b/src/meta/cf_df.c
@@ -22,9 +22,12 @@
  */
 
 #define DF_HEADER_SIZE  0x400
-#define DF_ORDER_REGION 260     /* fixed-size chunkOrder area in the loop block */
-#define DF_LOOP_ENTRY   26      /* loop-block entry stride */
-#define DF_NAME_MAX     (32-1)  /* MOV identifiers; others use 15 */
+#define DF_ORDER_REGION 0x104   /* fixed-size chunkOrder area in the loop block */
+#define DF_NAME_OFFSET  0x0A    /* Pascal length byte within named entries */
+#define DF_LOOP_ENTRY   0x1A    /* loop/non-MOV entry stride: 16-byte Pascal field */
+#define DF_MOV_ENTRY    0x2A    /* MOV one-shot entry stride: 32-byte Pascal field */
+#define DF_SHORT_NAME_MAX (DF_LOOP_ENTRY - DF_NAME_OFFSET - 1)
+#define DF_MOV_NAME_MAX   (DF_MOV_ENTRY - DF_NAME_OFFSET - 1)
 #define DF_MAX_CHUNKS   0x4000  /* sanity cap for table sizes */
 
 /* .snd "container-0" variant (HELP.SND/KID.SND): unlike the trk/sfx/mov container-1 loop block, the
@@ -45,11 +48,11 @@ typedef struct {
     int32_t sample_rate;
     int32_t uncompressed_size;
     int valid;
-    char name[DF_NAME_MAX + 1];
+    char name[DF_MOV_NAME_MAX + 1];
 } df_chunk_t;
 
 typedef struct {
-    char name[DF_NAME_MAX + 1];
+    char name[DF_MOV_NAME_MAX + 1];
 } df_name_t;
 
 /* Read the audio fields of a container; returns 1 if it looks like a valid audio chunk. */
@@ -132,11 +135,13 @@ static bool is_silent_chunk(STREAMFILE* sf, const df_chunk_t* c) {
 
 /* Pascal String (nameLen @ entry+0x0A, chars @ entry+0x0B). */
 static void read_name(STREAMFILE* sf, off_t entry, int name_max, df_name_t* dst) {
-    int len = read_u8(entry + 0x0A, sf);
-    if (len > name_max)
-        len = name_max;
+    int len = read_u8(entry + DF_NAME_OFFSET, sf);
+    if (len > name_max) {
+        dst->name[0] = '\0';
+        return;
+    }
     for (int k = 0; k < len; k++)
-        dst->name[k] = read_u8(entry + 0x0B + k, sf);
+        dst->name[k] = read_u8(entry + DF_NAME_OFFSET + 1 + k, sf);
     dst->name[len] = '\0';
 }
 
@@ -267,7 +272,7 @@ static VGMSTREAM* build_snd_c0(STREAMFILE* sf, int containers, int* handled) {
         if (e + 1 > fsize)
             break;
         int ln = read_u8(e, sf);
-        if (ln <= 0 || ln > 15 || e + 1 + ln > fsize)
+        if (ln <= 0 || ln > DF_SHORT_NAME_MAX || e + 1 + ln > fsize)
             continue;
         for (int k = 0; k < ln; k++)
             names[id].name[k] = read_u8(e + 1 + k, sf);
@@ -277,7 +282,7 @@ static VGMSTREAM* build_snd_c0(STREAMFILE* sf, int containers, int* handled) {
     /* track name */
     {
         int tl = read_u8(c0 + DF_SND_TRACK_NAME, sf);
-        if (tl > 0 && tl <= DF_NAME_MAX && c0 + DF_SND_TRACK_NAME + 1 + tl <= fsize) {
+        if (tl > 0 && tl <= DF_MOV_NAME_MAX && c0 + DF_SND_TRACK_NAME + 1 + tl <= fsize) {
             for (int k = 0; k < tl; k++)
                 track_name[k] = read_u8(c0 + DF_SND_TRACK_NAME + 1 + k, sf);
             track_name[tl] = '\0';
@@ -427,7 +432,7 @@ VGMSTREAM* init_vgmstream_cf_df(STREAMFILE* sf) {
             for (int i = 0; i < lc; i++) {
                 int id = read_u16le(e + 0x04, sf);
                 if (id >= 0 && id < containers)
-                    read_name(sf, e, 15, &names[id]);
+                    read_name(sf, e, DF_SHORT_NAME_MAX, &names[id]);
                 if (!is_valid_chunk(sf, containers, id, &loop[i]))
                     all_valid = 0;
                 e += DF_LOOP_ENTRY;
@@ -456,7 +461,7 @@ VGMSTREAM* init_vgmstream_cf_df(STREAMFILE* sf) {
 
         if (!is_mov) {
             int tl = read_u8(p0 + 0x24, sf);
-            if (tl > 0 && tl <= DF_NAME_MAX) {
+            if (tl > 0 && tl <= DF_MOV_NAME_MAX) {
                 for (int k = 0; k < tl; k++)
                     track_name[k] = read_u8(p0 + 0x25 + k, sf);
                 track_name[tl] = '\0';
@@ -469,8 +474,8 @@ VGMSTREAM* init_vgmstream_cf_df(STREAMFILE* sf) {
             if (sp > 0) {
                 off_t spp = sp + 0x08;
                 int count = read_u16le(spp + 0x04, sf);
-                int name_max = is_mov ? DF_NAME_MAX : 15;
-                int stride = is_mov ? 42 : 26;
+                int name_max = is_mov ? DF_MOV_NAME_MAX : DF_SHORT_NAME_MAX;
+                int stride = is_mov ? DF_MOV_ENTRY : DF_LOOP_ENTRY;
                 if (count > 0 && count <= containers) {
                     off_t e = spp + 0x08;
                     for (int i = 0; i < count; i++) {

--- a/src/meta/cf_df.c
+++ b/src/meta/cf_df.c
@@ -55,6 +55,12 @@
 #define DF_PROTO_PLAYLIST_ORDER      0x822
 #define DF_PROTO_PLAYLIST_MAX        64
 
+/* Revision-4 .snd control payload. Unlike the shared .mov/.sfx/.trk layout,
+ * the loop block is referenced by container id instead of fixed at id 1. */
+#define DF_SND_REVISION              0x02
+#define DF_SND_REVISION_4            0x0004
+#define DF_SND_LOOP_BLOCK_PTR        0x1C
+
 /* .snd "container-0" variant (HELP.SND/KID.SND): unlike the trk/sfx/mov container-1 loop block, the
  * order list, track name and per-chunk names live in container 0. Offsets are relative to container 0.
  * The order list holds 1-based container ids; the chunk-name table has one Pascal entry per chunk
@@ -255,6 +261,42 @@ static int get_mov_control_revision(STREAMFILE* sf) {
     if (pos <= 0 || pos + 0x08 + DF_MOV_CONTROL_REVISION + 0x02 > file_size)
         return 0;
     return read_u16le(pos + 0x08 + DF_MOV_CONTROL_REVISION, sf);
+}
+
+/* Revision-4 .snd stores the normal loop block's container id in control 0.
+ * Other generations use different data at this offset, so the revision gate is
+ * required before interpreting it as a pointer. */
+static int get_snd_loop_block_id(STREAMFILE* sf, int containers) {
+    off_t file_size = get_streamfile_size(sf);
+    off_t pos = read_u32le(DF_HEADER_SIZE, sf);
+
+    if (pos <= 0 || pos + 0x08 > file_size)
+        return 1;
+    if (read_u32le(pos, sf) != 0)
+        return 1;
+
+    uint32_t payload_size = read_u32le(pos + 0x04, sf);
+    off_t p = pos + 0x08;
+    if (payload_size < DF_SND_LOOP_BLOCK_PTR + 0x04 || payload_size > file_size - p)
+        return 1;
+    if (read_u16le(p + DF_SND_REVISION, sf) != DF_SND_REVISION_4)
+        return 1;
+
+    uint32_t id = read_u32le(p + DF_SND_LOOP_BLOCK_PTR, sf);
+    if (id == 0 || id >= (uint32_t)containers)
+        return 0;
+
+    off_t block = read_u32le(DF_HEADER_SIZE + (off_t)id * 0x04, sf);
+    if (block <= 0 || block + 0x08 > file_size)
+        return 0;
+    if (read_u32le(block, sf) != id)
+        return 0;
+
+    uint32_t block_size = read_u32le(block + 0x04, sf);
+    if (block_size < 0x06 + DF_ORDER_REGION + 0x04 || block_size > file_size - (block + 0x08))
+        return 0;
+
+    return id;
 }
 
 static void trim_early_playlist(STREAMFILE* sf, df_chunk_t* chunks,
@@ -676,7 +718,7 @@ static VGMSTREAM* build_blocked(STREAMFILE* sf, df_chunk_t* loop, int loop_count
     return v;
 }
 
-/* DreamFactory v4 .snd "container-0" variant: the assembled theme's order list, track name and
+/* DreamFactory revision-1 .snd "container-0" variant: the assembled theme's order list, track name and
  * per-chunk names live in container 0, unlike the container 1 found in trk/sfx/mov.
  * Builds the theme (subsong 1: order assembled in order, leading/trailing silence trimmed,
  * end-to-end loop) plus every chunk as a named subsong. *handled is set once a valid container-0
@@ -859,7 +901,7 @@ VGMSTREAM* init_vgmstream_cf_df(STREAMFILE* sf) {
     track_name[0] = '\0';
 
     // definitions before 'goto fail'
-    int loop_count, order_count;
+    int loop_count, order_count, loop_block_id;
     off_t first_entry, c1, c0;
     int audio_count, disk_stream;
     int has_loop, subsongs;
@@ -873,7 +915,8 @@ VGMSTREAM* init_vgmstream_cf_df(STREAMFILE* sf) {
     loop_count = 0;
     order_count = 0;
     first_entry = 0;
-    c1 = read_u32le(DF_HEADER_SIZE + 0x01 * 0x04, sf);
+    loop_block_id = check_extensions(sf, "snd") ? get_snd_loop_block_id(sf, containers) : 1;
+    c1 = loop_block_id > 0 ? read_u32le(DF_HEADER_SIZE + (off_t)loop_block_id * 0x04, sf) : 0;
     if (c1 > 0) {
         off_t lp = c1 + 0x08;
 

--- a/src/meta/cf_df.c
+++ b/src/meta/cf_df.c
@@ -15,10 +15,9 @@
  *   u32 uncompressed size @0x24, u32 data offset @0x2C.
  * - Proto audio resources hold a native-endian u16 duration followed by v4.0 ADPCM.
  *
- * Container 1 holds a "loop block" describing a playback track: a chunkOrder sequence plus a
- * list of audio chunks. A second "single block" (pointed at from container 0) lists named
- * one-shot chunks. subsong 1 = the assembled track, subsongs 2..N = every audio
- * chunk individually.
+ * Format-specific control data describes a playback track plus stored one-shot
+ * and reusable background chunks. subsong 1 = the assembled background track,
+ * subsongs 2..N = every stored audio chunk individually.
  *
  * Titles: Lunicus, Jump Raven, Dust 1996 3.1/95, Titanic: Adventure Out of Time
  * Disney's Math/Reading Quest with Aladdin
@@ -55,6 +54,14 @@
 #define DF_PROTO_PLAYLIST_ORDER      0x822
 #define DF_PROTO_PLAYLIST_MAX        64
 
+/* Compact Proto music-bank control payload. Group-B background sources are a
+ * contiguous range selected by a fixed 64-entry order table. */
+#define DF_PROTO_BANK_GROUP_A_BOUNDARY  0x00
+#define DF_PROTO_BANK_GROUP_B_COUNT     0x02
+#define DF_PROTO_BANK_PLAYLIST_COUNT    0x04
+#define DF_PROTO_BANK_PLAYLIST_ORDER    0x06
+#define DF_PROTO_BANK_CONTROL_SIZE      (DF_PROTO_BANK_PLAYLIST_ORDER + DF_PROTO_PLAYLIST_MAX * 0x02)
+
 /* Revision-4 .snd control payload. Unlike the shared .mov/.sfx/.trk layout,
  * the loop block is referenced by container id instead of fixed at id 1. */
 #define DF_SND_REVISION              0x02
@@ -63,10 +70,13 @@
 
 /* .snd "container-0" variant (HELP.SND/KID.SND): unlike the trk/sfx/mov container-1 loop block, the
  * order list, track name and per-chunk names live in container 0. Offsets are relative to container 0.
- * The order list holds 1-based container ids; the chunk-name table has one Pascal entry per chunk
- * (entry k -> container k+1). */
-#define DF_SND_ORDER_COUNT  0x22   /* u16 */
-#define DF_SND_ORDER        0x26   /* u16[], 1-based container ids */
+ * The order list holds 1-based selectors into a contiguous background range; the chunk-name table
+ * has one Pascal entry per chunk (entry k -> container k+1). */
+#define DF_SND_GROUP_A_BOUNDARY  0x20   /* u16, last one-shot container id */
+#define DF_SND_GROUP_B_COUNT     0x22   /* u16, unique background chunks */
+#define DF_SND_ORDER_COUNT       0x24   /* u16, authored playlist entries */
+#define DF_SND_ORDER             0x26   /* u16[64], relative Group-B selectors */
+#define DF_SND_ORDER_MAX         64
 #define DF_SND_TRACK_NAME   0xa6   /* Pascal string */
 #define DF_SND_CHUNK_NAMES  0xc2   /* Pascal entries, stride 0x18, one per chunk */
 #define DF_SND_NAME_STRIDE  0x18
@@ -524,8 +534,58 @@ static bool get_proto_config(STREAMFILE* sf, int* out_containers, bool* out_big_
     return true;
 }
 
+/* Proto standalone music banks use the same Group-A/Group-B model as early
+ * .snd, but place the compact control block at the start of container 0. */
+static int get_proto_bank_playlist(STREAMFILE* sf, int containers,
+        read_u16_t read_u16, read_u32_t read_u32, df_chunk_t* chunks,
+        df_early_playlist_t* playlist) {
+    off_t file_size = get_streamfile_size(sf);
+    off_t control = read_u32(DF_HEADER_SIZE, sf);
+
+    if (control <= 0 || control + 0x08 > file_size || read_u32(control, sf) != 0)
+        return 0;
+
+    uint32_t payload_size = read_u32(control + 0x04, sf);
+    off_t p = control + 0x08;
+    if (payload_size < DF_PROTO_BANK_CONTROL_SIZE || payload_size > file_size - p)
+        return 0;
+
+    int group_a_boundary = read_u16(p + DF_PROTO_BANK_GROUP_A_BOUNDARY, sf);
+    int group_b_count = read_u16(p + DF_PROTO_BANK_GROUP_B_COUNT, sf);
+    int order_count = read_u16(p + DF_PROTO_BANK_PLAYLIST_COUNT, sf);
+    if (group_a_boundary <= 0 || group_b_count <= 0 ||
+        order_count <= 0 || order_count > DF_PROTO_PLAYLIST_MAX ||
+        group_a_boundary + group_b_count >= containers)
+        return 0;
+
+    for (int selector = 1; selector <= group_b_count; selector++) {
+        int id = group_a_boundary + selector;
+        if (!chunks[id].valid)
+            return 0;
+    }
+
+    for (int i = 0; i < order_count; i++) {
+        int selector = read_u16(p + DF_PROTO_BANK_PLAYLIST_ORDER + (off_t)i * 0x02, sf);
+        if (selector < 1 || selector > group_b_count)
+            return 0;
+    }
+
+    playlist->sequence = malloc((size_t)order_count * sizeof(*playlist->sequence));
+    if (!playlist->sequence)
+        return -1;
+
+    for (int i = 0; i < order_count; i++) {
+        int selector = read_u16(p + DF_PROTO_BANK_PLAYLIST_ORDER + (off_t)i * 0x02, sf);
+        playlist->sequence[i] = group_a_boundary + selector;
+    }
+    playlist->count = order_count;
+    return 1;
+}
+
 /* Proto containers intersperse sound with non-sound resources.
- * MOV resources may additionally carry a complete Group-B playlist in control 0; */
+ * Discover only self-validating audio throughout the file. MOV resources may
+ * additionally carry a complete Group-B playlist in control 0. Non-MOV files
+ * are independently checked for the compact standalone music-bank form. */
 static VGMSTREAM* build_proto_resource(STREAMFILE* sf, int containers,
         bool big_endian, bool parse_movie_playlist) {
     VGMSTREAM* vgmstream = NULL;
@@ -602,6 +662,13 @@ static VGMSTREAM* build_proto_resource(STREAMFILE* sf, int containers,
                 }
             }
         }
+    }
+    else {
+        int playlist_result = get_proto_bank_playlist(sf, containers,
+                read_u16, read_u32, chunks, &playlist);
+        if (playlist_result < 0)
+            goto fail;
+        has_playlist = playlist_result > 0;
     }
 
     int subsongs = audio_count + (has_playlist ? 1 : 0);
@@ -730,7 +797,8 @@ static VGMSTREAM* build_snd_c0(STREAMFILE* sf, int containers, int* handled) {
     int* listed = NULL;
     df_name_t* names = NULL;
     char track_name[STREAM_NAME_SIZE];
-    int order_count, listed_count = 0, subsongs, target;
+    int group_a_boundary, group_b_count, order_count;
+    int listed_count = 0, subsongs, target;
     bool has_track;
     off_t fsize, c0;
 
@@ -741,8 +809,12 @@ static VGMSTREAM* build_snd_c0(STREAMFILE* sf, int containers, int* handled) {
     c0 = read_u32le(DF_HEADER_SIZE + 0x00 * 0x04, sf);
     if (c0 <= 0 || c0 + DF_SND_CHUNK_NAMES > fsize)
         return NULL;
+    group_a_boundary = read_u16le(c0 + DF_SND_GROUP_A_BOUNDARY, sf);
+    group_b_count = read_u16le(c0 + DF_SND_GROUP_B_COUNT, sf);
     order_count = read_u16le(c0 + DF_SND_ORDER_COUNT, sf);
-    if (order_count <= 0 || order_count > DF_MAX_CHUNKS)
+    if (group_a_boundary <= 0 || group_b_count <= 0 ||
+        group_a_boundary + group_b_count >= containers ||
+        order_count <= 0 || order_count > DF_SND_ORDER_MAX)
         return NULL; /* no container-0 order -> not this variant; caller falls through */
     if (c0 + DF_SND_ORDER + (off_t)order_count * 0x02 > fsize)
         return NULL;
@@ -759,10 +831,11 @@ static VGMSTREAM* build_snd_c0(STREAMFILE* sf, int containers, int* handled) {
     for (int i = 0; i < containers; i++)
         is_valid_chunk(sf, containers, i, &chunks[i]); /* fills chunks[i], sets .valid */
 
-    /* order list -> seq (1-based container ids); bail if any reference isn't a real audio chunk */
+    /* order list -> seq (1-based selectors into the contiguous Group-B range) */
     for (int i = 0; i < order_count; i++) {
-        int id = read_u16le(c0 + DF_SND_ORDER + (off_t)i * 0x02, sf);
-        if (id < 1 || id >= containers || !chunks[id].valid)
+        int selector = read_u16le(c0 + DF_SND_ORDER + (off_t)i * 0x02, sf);
+        int id = group_a_boundary + selector;
+        if (selector < 1 || selector > group_b_count || !chunks[id].valid)
             goto fail;
         seq[i] = id;
     }
@@ -795,7 +868,7 @@ static VGMSTREAM* build_snd_c0(STREAMFILE* sf, int containers, int* handled) {
         if (chunks[i].valid)
             listed[listed_count++] = i;
 
-    has_track = (order_count > 1); /* a single-step order is not a real assembled track */
+    has_track = true;
     subsongs = (has_track ? 1 : 0) + listed_count;
     if (subsongs == 0)
         goto fail;
@@ -859,15 +932,18 @@ VGMSTREAM* init_vgmstream_cf_df(STREAMFILE* sf) {
     uint8_t* in_loop = NULL;
     char track_name[STREAM_NAME_SIZE];
 
-    if (!check_extensions(sf, "snd,sfx,trk,mov,move"))
+    if (!check_extensions(sf, "snd,sfx,trk,mov,move,"))
         return NULL;
 
     int is_mov = check_extensions(sf, "mov,move");
-    if (is_mov) {
+    int is_extensionless = check_extensions(sf, "");
+    if (is_mov || is_extensionless) {
         int proto_containers;
         bool proto_big_endian;
         if (get_proto_config(sf, &proto_containers, &proto_big_endian))
             return build_proto_resource(sf, proto_containers, proto_big_endian, is_mov);
+        if (is_extensionless)
+            return NULL;
     }
 
     if (read_u32le(0x04, sf) != get_streamfile_size(sf))

--- a/src/meta/cf_df.c
+++ b/src/meta/cf_df.c
@@ -1,24 +1,28 @@
 #include "meta.h"
 #include "../coding/coding.h"
 #include "../layout/layout.h"
+#include "../util/endianness.h"
 #include "../util/layout_utils.h"
 
 /*
  * CF_DF - CyberFlix DreamFactory Engine
  *
  * Structure:
- * - 0x400-byte header: file size @0x04, container count @0x14, "LPPALPPA" @0x20.
+ * - 0x400-byte header: file size @0x04, container count @0x14; later files use
+ *   "LPPALPPA" @0x20.
  * - u32 offset table @0x400 pointing to each container (u32 id, u32 size, then payload).
- * - Audio chunks live in containers whose payload holds: u16 codec @0x1A (1=v4.0 / 2=v4.1),
- *   u32 rate @0x1C, u32 uncompressed size @0x24, u32 data offset @0x2C.
+ * - Later audio chunks hold: u16 codec @0x1A (1=v4.0 / 2=v4.1), u32 rate @0x1C,
+ *   u32 uncompressed size @0x24, u32 data offset @0x2C.
+ * - Proto audio resources hold a native-endian u16 duration followed by v4.0 ADPCM.
  *
  * Container 1 holds a "loop block" describing a playback track: a chunkOrder sequence plus a
  * list of audio chunks. A second "single block" (pointed at from container 0) lists named
  * one-shot chunks. subsong 1 = the assembled track, subsongs 2..N = every audio
  * chunk individually.
  *
- * Titles: Dust 1996 3.1/95, Titanic: Adventure Out of Time
+ * Titles: Lunicus, Jump Raven, Dust 1996 3.1/95, Titanic: Adventure Out of Time
  * Disney's Math/Reading Quest with Aladdin
+ *
  */
 
 #define DF_HEADER_SIZE  0x400
@@ -29,6 +33,27 @@
 #define DF_SHORT_NAME_MAX (DF_LOOP_ENTRY - DF_NAME_OFFSET - 1)
 #define DF_MOV_NAME_MAX   (DF_MOV_ENTRY - DF_NAME_OFFSET - 1)
 #define DF_MAX_CHUNKS   0x4000  /* sanity cap for table sizes */
+
+/* Early MOV control layouts. Revision 1 keeps the later audio chunk header. */
+#define DF_MOV_CONTROL_REVISION      0x02
+#define DF_MOV_CONTROL_REVISION_1    0x0001
+
+#define DF_REV1_AUDIO_A_COUNT        0x1A
+#define DF_REV1_AUDIO_B_COUNT        0x1C
+#define DF_REV1_PLAYLIST_COUNT       0x34
+#define DF_REV1_NEXT_CONTROL         0x36
+#define DF_REV1_PLAYLIST_ORDER       0x83E
+#define DF_REV1_PLAYLIST_LOOP        0x8BE
+
+#define DF_PROTO_AUDIO_HEADER        0x02
+#define DF_PROTO_DURATION_SAMPLES    370
+#define DF_PROTO_WINDOWS_RATE        22050
+#define DF_PROTO_MACINTOSH_RATE      22255  /* nearest integer to 0x56EE8BA3 (16.16) */
+#define DF_PROTO_AUDIO_A_COUNT       0x02
+#define DF_PROTO_AUDIO_B_COUNT       0x04
+#define DF_PROTO_PLAYLIST_COUNT      0x1C
+#define DF_PROTO_PLAYLIST_ORDER      0x822
+#define DF_PROTO_PLAYLIST_MAX        64
 
 /* .snd "container-0" variant (HELP.SND/KID.SND): unlike the trk/sfx/mov container-1 loop block, the
  * order list, track name and per-chunk names live in container 0. Offsets are relative to container 0.
@@ -54,6 +79,15 @@ typedef struct {
 typedef struct {
     char name[DF_MOV_NAME_MAX + 1];
 } df_name_t;
+
+typedef struct {
+    int* sequence;              /* container ids in authored playback order */
+    int count;
+    int loop;
+    int loop_start;             /* sequence index */
+} df_early_playlist_t;
+
+static VGMSTREAM* build_segmented(STREAMFILE* sf, df_chunk_t* chunks, int* seq, int count, int loop, int loop_start);
 
 /* Read the audio fields of a container; returns 1 if it looks like a valid audio chunk. */
 static bool is_valid_chunk(STREAMFILE* sf, int containers, int id, df_chunk_t* c) {
@@ -82,6 +116,76 @@ static bool is_valid_chunk(STREAMFILE* sf, int containers, int id, df_chunk_t* c
     c->offset            = hp + data_offset;
     c->size              = read_u32le(pos + 0x04, sf) - data_offset;
     c->valid             = 1;
+    return true;
+}
+
+static int32_t count_v40_samples(STREAMFILE* sf, off_t offset, int32_t size) {
+    if (size <= 0)
+        return 0;
+
+    off_t pos = offset + 1;
+    off_t end = offset + size;
+    int64_t samples = 1;
+
+    while (pos < end) {
+        uint8_t control = read_u8(pos++, sf);
+
+        if ((control & 0x80) == 0) {
+            samples++;
+        }
+        else if ((control & 0x40) == 0) {
+            int count = (control & 0x3f) + 1;
+            if (pos + count > end)
+                return 0;
+            pos += count;
+            samples += count * 2;
+        }
+        else {
+            samples += (control & 0x3f) + 1;
+        }
+
+        if (samples > INT32_MAX)
+            return 0;
+    }
+
+    return (int32_t)samples;
+}
+
+/* Proto audio stores a native-endian u16 duration followed by raw v4.0 ADPCM. */
+static bool is_valid_proto_chunk(STREAMFILE* sf, int containers, int id,
+        read_u16_t read_u16, read_u32_t read_u32, int sample_rate, df_chunk_t* c) {
+    off_t file_size = get_streamfile_size(sf);
+    if (id <= 0 || id >= containers)
+        return false;
+
+    off_t pos = read_u32(DF_HEADER_SIZE + id * 0x04, sf);
+    if (pos <= 0 || pos + 0x08 > file_size)
+        return false;
+    if (read_u32(pos, sf) != (uint32_t)id)
+        return false;
+
+    uint32_t payload_size = read_u32(pos + 0x04, sf);
+    off_t hp = pos + 0x08;
+    if (payload_size <= DF_PROTO_AUDIO_HEADER || payload_size > INT32_MAX || hp + payload_size > file_size)
+        return false;
+
+    off_t data_offset = hp + DF_PROTO_AUDIO_HEADER;
+    int32_t data_size = payload_size - DF_PROTO_AUDIO_HEADER;
+    int32_t samples = count_v40_samples(sf, data_offset, data_size);
+    if (samples <= 0 || samples % DF_PROTO_DURATION_SAMPLES != 0)
+        return false;
+
+    int duration = samples / DF_PROTO_DURATION_SAMPLES;
+    if (duration != read_u16(hp, sf))
+        return false;
+
+    c->container_id = id;
+    c->codec_flag = 1;
+    c->sample_rate = sample_rate;
+    c->uncompressed_size = samples;
+    c->offset = data_offset;
+    c->size = data_size;
+    c->valid = 1;
     return true;
 }
 
@@ -145,9 +249,351 @@ static void read_name(STREAMFILE* sf, off_t entry, int name_max, df_name_t* dst)
     dst->name[len] = '\0';
 }
 
+static int get_mov_control_revision(STREAMFILE* sf) {
+    off_t file_size = get_streamfile_size(sf);
+    off_t pos = read_u32le(DF_HEADER_SIZE, sf);
+    if (pos <= 0 || pos + 0x08 + DF_MOV_CONTROL_REVISION + 0x02 > file_size)
+        return 0;
+    return read_u16le(pos + 0x08 + DF_MOV_CONTROL_REVISION, sf);
+}
+
+static void trim_early_playlist(STREAMFILE* sf, df_chunk_t* chunks,
+        const df_early_playlist_t* playlist, int* out_lo, int* out_hi,
+        int* out_loop, int* out_loop_start) {
+    int lo = 0, hi = playlist->count - 1;
+    int loop = playlist->loop;
+    int loop_start = playlist->loop_start;
+
+    /* Trim non-interspaced silence */
+    while (lo <= hi && is_silent_chunk(sf, &chunks[playlist->sequence[lo]]))
+        lo++;
+    while (hi >= lo && is_silent_chunk(sf, &chunks[playlist->sequence[hi]]))
+        hi--;
+    if (lo > hi) {
+        lo = 0;
+        hi = playlist->count - 1;
+    }
+
+    if (loop) {
+        if (loop_start > hi) {
+            loop = 0;
+            loop_start = 0;
+        }
+        else {
+            if (loop_start < lo)
+                loop_start = lo;
+            loop_start -= lo;
+        }
+    }
+
+    *out_lo = lo;
+    *out_hi = hi;
+    *out_loop = loop;
+    *out_loop_start = loop_start;
+}
+
+/* Revision-1 MOVs keep Group-A one-shots and
+ * Group-B background sources immediately after each control. */
+static VGMSTREAM* build_revision1_mov(STREAMFILE* sf, int containers) {
+    VGMSTREAM* vgmstream = NULL;
+    df_chunk_t* chunks = NULL;
+    int* audio_ids = NULL;
+    df_early_playlist_t playlist = {0};
+    int audio_count = 0;
+    int control = 0;
+    bool has_playlist = false;
+
+    chunks = calloc((size_t)containers, sizeof(*chunks));
+    audio_ids = malloc((size_t)containers * sizeof(*audio_ids));
+    if (!chunks || !audio_ids)
+        goto fail;
+
+    off_t file_size = get_streamfile_size(sf);
+    while (control < containers) {
+        off_t pos = read_u32le(DF_HEADER_SIZE + (off_t)control * 0x04, sf);
+        if (pos <= 0 || pos + 0x08 > file_size)
+            goto fail;
+        off_t p = pos + 0x08;
+
+        int audio_a, audio_b, next;
+        int order_count;
+        off_t order_pos;
+        int loop = 0, loop_start = 0;
+
+        if (p + DF_REV1_PLAYLIST_LOOP + 0x04 > file_size)
+            goto fail;
+        if (read_u16le(p + DF_MOV_CONTROL_REVISION, sf) != DF_MOV_CONTROL_REVISION_1)
+            goto fail;
+        audio_a = read_u16le(p + DF_REV1_AUDIO_A_COUNT, sf);
+        audio_b = read_u16le(p + DF_REV1_AUDIO_B_COUNT, sf);
+        order_count = read_u16le(p + DF_REV1_PLAYLIST_COUNT, sf);
+        order_pos = p + DF_REV1_PLAYLIST_ORDER;
+        uint32_t authored_loop = read_u32le(p + DF_REV1_PLAYLIST_LOOP, sf);
+        if (authored_loop < (uint32_t)order_count) {
+            loop = 1;
+            loop_start = authored_loop;
+        }
+        uint32_t authored_next = read_u32le(p + DF_REV1_NEXT_CONTROL, sf);
+        if (authored_next > (uint32_t)containers)
+            goto fail;
+        next = authored_next ? (int)authored_next : containers;
+
+        int audio_base = control + 1;
+        int group_b_base = audio_base + audio_a;
+        if (audio_a + audio_b > containers || audio_base + audio_a + audio_b > containers)
+            goto fail;
+        if (next <= control || next > containers)
+            goto fail;
+        if (order_count > DF_MAX_CHUNKS)
+            goto fail;
+        if (order_pos + (off_t)order_count * 0x02 > file_size)
+            goto fail;
+
+        for (int i = 0; i < audio_a + audio_b; i++) {
+            int id = audio_base + i;
+            if (!is_valid_chunk(sf, containers, id, &chunks[id]))
+                goto fail;
+            if (audio_count >= containers)
+                goto fail;
+            audio_ids[audio_count++] = id;
+        }
+
+        if (audio_b > 0 && order_count > 0) {
+            int old_count = playlist.count;
+
+            for (int i = 0; i < order_count; i++) {
+                int selector = read_u16le(order_pos + (off_t)i * 0x02, sf);
+                if (selector < 1 || selector > audio_b)
+                    goto fail;
+            }
+
+            int* sequence = realloc(playlist.sequence,
+                    (size_t)(old_count + order_count) * sizeof(*sequence));
+            if (!sequence)
+                goto fail;
+            playlist.sequence = sequence;
+
+            for (int i = 0; i < order_count; i++) {
+                int selector = read_u16le(order_pos + (off_t)i * 0x02, sf);
+                playlist.sequence[old_count + i] = group_b_base + selector - 1;
+            }
+            playlist.count = old_count + order_count;
+
+            /* One output track has one loop point. Keep the first authored
+             * point when a MOV contributes more than one control sequence. */
+            if (loop && !playlist.loop) {
+                playlist.loop = 1;
+                playlist.loop_start = old_count + loop_start;
+            }
+            has_playlist = true;
+        }
+
+        if (next == containers)
+            break;
+        control = next;
+    }
+
+    int subsongs = (has_playlist ? 1 : 0) + audio_count;
+    if (subsongs <= 0)
+        goto fail;
+
+    int target = sf->stream_index;
+    if (target == 0)
+        target = 1;
+    if (target < 1 || target > subsongs)
+        goto fail;
+
+    if (has_playlist && target == 1) {
+        int lo = 0, hi = playlist.count - 1;
+        int loop = playlist.loop;
+        int loop_start = playlist.loop_start;
+
+        trim_early_playlist(sf, chunks, &playlist, &lo, &hi, &loop, &loop_start);
+
+        vgmstream = build_segmented(sf, chunks, playlist.sequence + lo,
+                hi - lo + 1, loop, loop_start);
+        if (!vgmstream)
+            goto fail;
+    }
+    else {
+        int piece = target - (has_playlist ? 1 : 0);
+        int id = audio_ids[piece - 1];
+        vgmstream = allocate_vgmstream(1, 0);
+        if (!vgmstream)
+            goto fail;
+        config_chunk(vgmstream, &chunks[id]);
+        if (!vgmstream_open_stream(vgmstream, sf, chunks[id].offset))
+            goto fail;
+    }
+
+    vgmstream->num_streams = subsongs;
+    free(chunks);
+    free(audio_ids);
+    free(playlist.sequence);
+    return vgmstream;
+
+fail:
+    free(chunks);
+    free(audio_ids);
+    free(playlist.sequence);
+    close_vgmstream(vgmstream);
+    return NULL;
+}
+
+/* Proto resources serialize the complete container in the platform's native byte order. */
+static bool get_proto_config(STREAMFILE* sf, int* out_containers, bool* out_big_endian) {
+    off_t file_size = get_streamfile_size(sf);
+    if (file_size <= 0 || file_size > UINT32_MAX)
+        return false;
+    if (is_id32be(0x20, sf, "LPPA") && is_id32be(0x24, sf, "LPPA"))
+        return false;
+
+    bool valid_le = read_u32le(0x00, sf) == 0x00010000 &&
+                    read_u32le(0x04, sf) == (uint32_t)file_size;
+    bool valid_be = read_u32be(0x00, sf) == 0x00010000 &&
+                    read_u32be(0x04, sf) == (uint32_t)file_size;
+    if (valid_le == valid_be)
+        return false;
+
+    bool big_endian = valid_be;
+    read_u32_t read_u32 = get_read_u32(big_endian);
+    uint32_t containers = read_u32(0x14, sf);
+    if (containers <= 1 || containers > INT16_MAX)
+        return false;
+    if (DF_HEADER_SIZE + (off_t)containers * 0x04 > file_size)
+        return false;
+
+    *out_containers = containers;
+    *out_big_endian = big_endian;
+    return true;
+}
+
+/* Proto containers intersperse sound with non-sound resources.
+ * MOV resources may additionally carry a complete Group-B playlist in control 0; */
+static VGMSTREAM* build_proto_resource(STREAMFILE* sf, int containers,
+        bool big_endian, bool parse_movie_playlist) {
+    VGMSTREAM* vgmstream = NULL;
+    df_chunk_t* chunks = NULL;
+    int* audio_ids = NULL;
+    df_early_playlist_t playlist = {0};
+    read_u16_t read_u16 = get_read_u16(big_endian);
+    read_u32_t read_u32 = get_read_u32(big_endian);
+    int sample_rate = big_endian ? DF_PROTO_MACINTOSH_RATE : DF_PROTO_WINDOWS_RATE;
+    int audio_count = 0;
+    bool has_playlist = false;
+
+    chunks = calloc((size_t)containers, sizeof(*chunks));
+    audio_ids = malloc((size_t)containers * sizeof(*audio_ids));
+    if (!chunks || !audio_ids)
+        goto fail;
+
+    for (int id = 1; id < containers; id++) {
+        if (is_valid_proto_chunk(sf, containers, id, read_u16, read_u32,
+                sample_rate, &chunks[id])) {
+            audio_ids[audio_count++] = id;
+        }
+    }
+    if (audio_count <= 0)
+        goto fail;
+
+    if (parse_movie_playlist) {
+        /* Proto MOV has one control record. Group-B selectors are 1-based and
+         * loop from entry zero. */
+        off_t file_size = get_streamfile_size(sf);
+        off_t control = read_u32(DF_HEADER_SIZE, sf);
+        if (control > 0 && control + 0x08 <= file_size &&
+            read_u32(control, sf) == 0) {
+            uint32_t payload_size = read_u32(control + 0x04, sf);
+            off_t p = control + 0x08;
+
+            if (payload_size <= file_size - p &&
+                payload_size >= DF_PROTO_PLAYLIST_COUNT + 0x02) {
+                int audio_a = read_u16(p + DF_PROTO_AUDIO_A_COUNT, sf);
+                int audio_b = read_u16(p + DF_PROTO_AUDIO_B_COUNT, sf);
+                int order_count = read_u16(p + DF_PROTO_PLAYLIST_COUNT, sf);
+
+                if (audio_b > 0 && order_count > 0 &&
+                    order_count <= DF_PROTO_PLAYLIST_MAX &&
+                    audio_a + audio_b < containers &&
+                    DF_PROTO_PLAYLIST_ORDER + (off_t)order_count * 0x02 <= payload_size) {
+                    bool valid = true;
+
+                    playlist.sequence = malloc((size_t)order_count * sizeof(*playlist.sequence));
+                    if (!playlist.sequence)
+                        goto fail;
+
+                    for (int i = 0; i < order_count; i++) {
+                        int selector = read_u16(p + DF_PROTO_PLAYLIST_ORDER + (off_t)i * 0x02, sf);
+                        int id = audio_a + selector;
+
+                        if (selector < 1 || selector > audio_b || !chunks[id].valid) {
+                            valid = false;
+                            break;
+                        }
+                        playlist.sequence[i] = id;
+                    }
+
+                    if (valid) {
+                        playlist.count = order_count;
+                        playlist.loop = 1;
+                        playlist.loop_start = 0;
+                        has_playlist = true;
+                    }
+                    else {
+                        free(playlist.sequence);
+                        playlist.sequence = NULL;
+                    }
+                }
+            }
+        }
+    }
+
+    int subsongs = audio_count + (has_playlist ? 1 : 0);
+    int target = sf->stream_index;
+    if (target == 0)
+        target = 1;
+    if (target < 1 || target > subsongs)
+        goto fail;
+
+    if (has_playlist && target == 1) {
+        int lo, hi, loop, loop_start;
+
+        trim_early_playlist(sf, chunks, &playlist, &lo, &hi, &loop, &loop_start);
+        vgmstream = build_segmented(sf, chunks, playlist.sequence + lo,
+                hi - lo + 1, loop, loop_start);
+        if (!vgmstream)
+            goto fail;
+    }
+    else {
+        int piece = target - (has_playlist ? 1 : 0);
+        int id = audio_ids[piece - 1];
+
+        vgmstream = allocate_vgmstream(1, 0);
+        if (!vgmstream)
+            goto fail;
+
+        config_chunk(vgmstream, &chunks[id]);
+        if (!vgmstream_open_stream(vgmstream, sf, chunks[id].offset))
+            goto fail;
+    }
+
+    vgmstream->num_streams = subsongs;
+    free(chunks);
+    free(audio_ids);
+    free(playlist.sequence);
+    return vgmstream;
+
+fail:
+    free(chunks);
+    free(audio_ids);
+    free(playlist.sequence);
+    close_vgmstream(vgmstream);
+    return NULL;
+}
+
 /* Assembled track via segmented layout: play the given sequence of loop chunks once.
  * loop=1 marks the whole assembled track as an end-to-end loop (.snd/.sfx/.trk only; .mov excluded). */
-static VGMSTREAM* build_segmented(STREAMFILE* sf, df_chunk_t* chunks, int* seq, int count, int loop) {
+static VGMSTREAM* build_segmented(STREAMFILE* sf, df_chunk_t* chunks, int* seq, int count, int loop, int loop_start) {
     VGMSTREAM* v = NULL;
     segmented_layout_data* data = init_layout_segmented(count);
     if (!data) goto fail;
@@ -165,7 +611,7 @@ static VGMSTREAM* build_segmented(STREAMFILE* sf, df_chunk_t* chunks, int* seq, 
     if (!setup_layout_segmented(data))
         goto fail;
 
-    v = allocate_segmented_vgmstream(data, loop, 0, count - 1);
+    v = allocate_segmented_vgmstream(data, loop, loop_start, count - 1);
     if (!v) goto fail;
     return v;
 
@@ -314,7 +760,7 @@ static VGMSTREAM* build_snd_c0(STREAMFILE* sf, int containers, int* handled) {
             hi--;
         if (lo > hi) { lo = 0; hi = order_count - 1; } /* all silent: keep so it isn't empty */
 
-        vgmstream = build_segmented(sf, chunks, seq + lo, hi - lo + 1, 1);
+        vgmstream = build_segmented(sf, chunks, seq + lo, hi - lo + 1, 1, 0);
         if (!vgmstream)
             goto fail;
         snprintf(vgmstream->stream_name, STREAM_NAME_SIZE, "%s", track_name[0] ? track_name : basename);
@@ -362,15 +808,29 @@ VGMSTREAM* init_vgmstream_cf_df(STREAMFILE* sf) {
     char track_name[STREAM_NAME_SIZE];
     char basename[STREAM_NAME_SIZE];
 
-    if (!is_id32be(0x20, sf, "LPPA") || !is_id32be(0x24, sf, "LPPA"))
-        return NULL;
-    if (read_u32le(0x04, sf) != get_streamfile_size(sf))
-        return NULL;
-    if (!check_extensions(sf, "snd,sfx,trk,mov"))
+    if (!check_extensions(sf, "snd,sfx,trk,mov,move"))
         return NULL;
 
+    int is_mov = check_extensions(sf, "mov,move");
+    if (is_mov) {
+        int proto_containers;
+        bool proto_big_endian;
+        if (get_proto_config(sf, &proto_containers, &proto_big_endian))
+            return build_proto_resource(sf, proto_containers, proto_big_endian, is_mov);
+    }
+
+    if (read_u32le(0x04, sf) != get_streamfile_size(sf))
+        return NULL;
     int containers = read_u32le(0x14, sf);
     if (containers <= 0 || containers > INT16_MAX)
+        return NULL;
+    if (DF_HEADER_SIZE + (off_t)containers * 0x04 > get_streamfile_size(sf))
+        return NULL;
+
+    int has_lppa = is_id32be(0x20, sf, "LPPA") && is_id32be(0x24, sf, "LPPA");
+    if (is_mov && get_mov_control_revision(sf) == DF_MOV_CONTROL_REVISION_1)
+        return build_revision1_mov(sf, containers);
+    if (!has_lppa)
         return NULL;
 
     /* Most .snd files store the theme in container 0.
@@ -383,7 +843,6 @@ VGMSTREAM* init_vgmstream_cf_df(STREAMFILE* sf) {
             return vgmstream;
     }
 
-    int is_mov = check_extensions(sf, "mov");
     int loop_track = check_extensions(sf, "sfx,snd,trk");
     int target = sf->stream_index;
     if (target == 0)
@@ -535,7 +994,7 @@ VGMSTREAM* init_vgmstream_cf_df(STREAMFILE* sf) {
                 lo = 0;
                 hi = count - 1;
             }
-            vgmstream = build_segmented(sf, loop, seq + lo, hi - lo + 1, loop_track);
+            vgmstream = build_segmented(sf, loop, seq + lo, hi - lo + 1, loop_track, 0);
         }
         if (!vgmstream)
             goto fail;

--- a/src/meta/cf_df.c
+++ b/src/meta/cf_df.c
@@ -292,8 +292,21 @@ static void trim_early_playlist(STREAMFILE* sf, df_chunk_t* chunks,
     *out_loop_start = loop_start;
 }
 
-/* Revision-1 MOVs keep Group-A one-shots and
- * Group-B background sources immediately after each control. */
+static void set_stream_name(STREAMFILE* sf, VGMSTREAM* vgmstream,
+        const char* authored_name, int stream_index) {
+    if (authored_name && authored_name[0]) {
+        snprintf(vgmstream->stream_name, STREAM_NAME_SIZE, "%s", authored_name);
+    }
+    else {
+        char basename[STREAM_NAME_SIZE];
+        get_streamfile_filename(sf, basename, sizeof(basename));
+        snprintf(vgmstream->stream_name, STREAM_NAME_SIZE, "%.*s#%d",
+                STREAM_NAME_SIZE - (11 + 1 + 1), basename, stream_index);
+    }
+}
+
+/* Revision-1 MOVs keep Group-A one-shots and Group-B background sources
+ * immediately after each control. */
 static VGMSTREAM* build_revision1_mov(STREAMFILE* sf, int containers) {
     VGMSTREAM* vgmstream = NULL;
     df_chunk_t* chunks = NULL;
@@ -426,6 +439,7 @@ static VGMSTREAM* build_revision1_mov(STREAMFILE* sf, int containers) {
             goto fail;
     }
 
+    set_stream_name(sf, vgmstream, NULL, target);
     vgmstream->num_streams = subsongs;
     free(chunks);
     free(audio_ids);
@@ -577,6 +591,7 @@ static VGMSTREAM* build_proto_resource(STREAMFILE* sf, int containers,
             goto fail;
     }
 
+    set_stream_name(sf, vgmstream, NULL, target);
     vgmstream->num_streams = subsongs;
     free(chunks);
     free(audio_ids);
@@ -673,14 +688,12 @@ static VGMSTREAM* build_snd_c0(STREAMFILE* sf, int containers, int* handled) {
     int* listed = NULL;
     df_name_t* names = NULL;
     char track_name[STREAM_NAME_SIZE];
-    char basename[STREAM_NAME_SIZE];
     int order_count, listed_count = 0, subsongs, target;
     bool has_track;
     off_t fsize, c0;
 
     *handled = 0;
     track_name[0] = '\0';
-    get_streamfile_filename(sf, basename, sizeof(basename));
     fsize = get_streamfile_size(sf);
 
     c0 = read_u32le(DF_HEADER_SIZE + 0x00 * 0x04, sf);
@@ -763,7 +776,7 @@ static VGMSTREAM* build_snd_c0(STREAMFILE* sf, int containers, int* handled) {
         vgmstream = build_segmented(sf, chunks, seq + lo, hi - lo + 1, 1, 0);
         if (!vgmstream)
             goto fail;
-        snprintf(vgmstream->stream_name, STREAM_NAME_SIZE, "%s", track_name[0] ? track_name : basename);
+        set_stream_name(sf, vgmstream, track_name, target);
     }
     else {
         int piece = target - (has_track ? 1 : 0); /* 1-based index into listed[] */
@@ -773,10 +786,7 @@ static VGMSTREAM* build_snd_c0(STREAMFILE* sf, int containers, int* handled) {
         if (!vgmstream)
             goto fail;
         config_chunk(vgmstream, &chunks[id]);
-        if (names[id].name[0])
-            snprintf(vgmstream->stream_name, STREAM_NAME_SIZE, "%s", names[id].name);
-        else
-            snprintf(vgmstream->stream_name, STREAM_NAME_SIZE, "%.*s#%d", STREAM_NAME_SIZE - (11 + 1 + 1), basename, piece);
+        set_stream_name(sf, vgmstream, names[id].name, target);
         if (!vgmstream_open_stream(vgmstream, sf, chunks[id].offset))
             goto fail;
     }
@@ -806,7 +816,6 @@ VGMSTREAM* init_vgmstream_cf_df(STREAMFILE* sf) {
     int* seq = NULL;
     uint8_t* in_loop = NULL;
     char track_name[STREAM_NAME_SIZE];
-    char basename[STREAM_NAME_SIZE];
 
     if (!check_extensions(sf, "snd,sfx,trk,mov,move"))
         return NULL;
@@ -847,7 +856,6 @@ VGMSTREAM* init_vgmstream_cf_df(STREAMFILE* sf) {
     int target = sf->stream_index;
     if (target == 0)
         target = 1;
-    get_streamfile_filename(sf, basename, sizeof(basename));
     track_name[0] = '\0';
 
     // definitions before 'goto fail'
@@ -999,8 +1007,8 @@ VGMSTREAM* init_vgmstream_cf_df(STREAMFILE* sf) {
         if (!vgmstream)
             goto fail;
 
-        snprintf(vgmstream->stream_name, STREAM_NAME_SIZE, "%s",
-                (!is_mov && track_name[0]) ? track_name : basename);
+        set_stream_name(sf, vgmstream,
+                !is_mov ? track_name : NULL, target);
     } else {
         /* subsongs 2..N (or 1..N when no loop block): individual audio pieces */
         int piece = target - (has_loop ? 1 : 0);
@@ -1015,10 +1023,7 @@ VGMSTREAM* init_vgmstream_cf_df(STREAMFILE* sf) {
             goto fail;
 
         config_chunk(vgmstream, &c);
-        if (names[id].name[0])
-            snprintf(vgmstream->stream_name, STREAM_NAME_SIZE, "%s", names[id].name);
-        else
-            snprintf(vgmstream->stream_name, STREAM_NAME_SIZE, "%.*s#%d", STREAM_NAME_SIZE - (11 + 1 + 1), basename, piece); /* reserve '#' + 11-digit int + NUL */
+        set_stream_name(sf, vgmstream, names[id].name, target);
 
         if (!vgmstream_open_stream(vgmstream, sf, c.offset))
             goto fail;

--- a/src/meta/cf_df.c
+++ b/src/meta/cf_df.c
@@ -41,8 +41,7 @@
 #define DF_CODEC_V41    0x02
 
 /* Early MOV control layouts. Revision 1 keeps the later audio chunk header. */
-#define DF_MOV_CONTROL_REVISION      0x02
-#define DF_MOV_CONTROL_REVISION_1    0x0001
+#define DF_MOV_CONTROL_REVISION_1    (1u << 16)
 
 #define DF_PROTO_AUDIO_HEADER        0x02
 #define DF_PROTO_DURATION_SAMPLES    370
@@ -126,11 +125,12 @@ typedef struct {
 static VGMSTREAM* build_segmented(STREAMFILE* sf, df_chunk_t* chunks, const int* seq, int count, int loop, int loop_start);
 
 /* Read the audio fields of a container; returns 1 if it looks like a valid audio chunk. */
-static bool is_valid_chunk(STREAMFILE* sf, int containers, int id, df_chunk_t* c) {
+static bool is_valid_chunk(STREAMFILE* sf, int containers, int id,
+        read_u16_t read_u16, read_u32_t read_u32, df_chunk_t* c) {
     if (id < 0 || id >= containers)
         return false;
 
-    off_t pos = read_u32le(DF_HEADER_SIZE + id * 0x04, sf);
+    off_t pos = read_u32(DF_HEADER_SIZE + id * 0x04, sf);
     if (pos <= 0 || pos >= get_streamfile_size(sf))
         return false;
 
@@ -138,20 +138,20 @@ static bool is_valid_chunk(STREAMFILE* sf, int containers, int id, df_chunk_t* c
     if (hp + 0x30 > get_streamfile_size(sf))
         return false;
 
-    uint16_t codec = read_u16le(hp + 0x1A, sf);
-    uint32_t rate  = read_u32le(hp + 0x1C, sf);
+    uint16_t codec = read_u16(hp + 0x1A, sf);
+    uint32_t rate  = read_u32(hp + 0x1C, sf);
     if ((codec != DF_CODEC_V40 && codec != DF_CODEC_V41) ||
             (rate != 11025 && rate != 22050 && rate != 44100))
         return false;
 
-    uint32_t data_offset = read_u32le(hp + 0x2C, sf);
+    uint32_t data_offset = read_u32(hp + 0x2C, sf);
 
     c->container_id      = id;
     c->codec_flag        = codec;
     c->sample_rate       = rate;
-    c->uncompressed_size = read_u32le(hp + 0x24, sf);
+    c->uncompressed_size = read_u32(hp + 0x24, sf);
     c->offset            = hp + data_offset;
-    c->size              = read_u32le(pos + 0x04, sf) - data_offset;
+    c->size              = read_u32(pos + 0x04, sf) - data_offset;
     c->valid             = 1;
     return true;
 }
@@ -286,12 +286,12 @@ static void read_name(STREAMFILE* sf, off_t entry, int name_max, df_name_t* dst)
     dst->name[len] = '\0';
 }
 
-static int get_mov_control_revision(STREAMFILE* sf) {
+static bool has_v1_mov_control(STREAMFILE* sf, read_u32_t read_u32) {
     off_t file_size = get_streamfile_size(sf);
-    off_t pos = read_u32le(DF_HEADER_SIZE, sf);
-    if (pos <= 0 || pos + 0x08 + DF_MOV_CONTROL_REVISION + 0x02 > file_size)
-        return 0;
-    return read_u16le(pos + 0x08 + DF_MOV_CONTROL_REVISION, sf);
+    off_t pos = read_u32(DF_HEADER_SIZE, sf);
+    if (pos <= 0 || pos + 0x08 + 0x04 > file_size)
+        return false;
+    return read_u32(pos + 0x08, sf) == DF_MOV_CONTROL_REVISION_1;
 }
 
 /* Revision-4 .snd stores the normal loop block's container id in control 0.
@@ -491,7 +491,8 @@ static VGMSTREAM* build_bank_subsong(STREAMFILE* sf, df_bank_t* bank) {
 
 /* Revision-1 MOVs keep Group-A one-shots and Group-B background sources
  * immediately after each control. */
-static VGMSTREAM* build_cf_df_v1_mov(STREAMFILE* sf, int containers) {
+static VGMSTREAM* build_cf_df_v1_mov(STREAMFILE* sf, int containers,
+        read_u16_t read_u16, read_u32_t read_u32) {
     VGMSTREAM* vgmstream = NULL;
     df_bank_t bank = {0};
     int control = 0;
@@ -501,7 +502,7 @@ static VGMSTREAM* build_cf_df_v1_mov(STREAMFILE* sf, int containers) {
 
     off_t file_size = get_streamfile_size(sf);
     while (control < containers) {
-        off_t pos = read_u32le(DF_HEADER_SIZE + (off_t)control * 0x04, sf);
+        off_t pos = read_u32(DF_HEADER_SIZE + (off_t)control * 0x04, sf);
         if (pos <= 0 || pos + 0x08 > file_size)
             goto fail;
         off_t p = pos + 0x08;
@@ -510,18 +511,18 @@ static VGMSTREAM* build_cf_df_v1_mov(STREAMFILE* sf, int containers) {
 
         if (p + 0x8be + 0x04 > file_size)
             goto fail;
-        if (read_u16le(p + DF_MOV_CONTROL_REVISION, sf) != DF_MOV_CONTROL_REVISION_1)
+        if (read_u32(p + 0x00, sf) != DF_MOV_CONTROL_REVISION_1)
             goto fail;
-        cfg.audio_a_count = read_u16le(p + 0x1a, sf);
-        cfg.audio_b_count = read_u16le(p + 0x1c, sf);
-        cfg.order_count = read_u16le(p + 0x34, sf);
+        cfg.audio_a_count = read_u16(p + 0x1a, sf);
+        cfg.audio_b_count = read_u16(p + 0x1c, sf);
+        cfg.order_count = read_u16(p + 0x34, sf);
         cfg.order = p + 0x83e;
-        uint32_t authored_loop = read_u32le(p + 0x8be, sf);
+        uint32_t authored_loop = read_u32(p + 0x8be, sf);
         if (authored_loop < (uint32_t)cfg.order_count) {
             cfg.loop = 1;
             cfg.loop_start = authored_loop;
         }
-        uint32_t authored_next = read_u32le(p + 0x36, sf);
+        uint32_t authored_next = read_u32(p + 0x36, sf);
         if (authored_next > (uint32_t)containers)
             goto fail;
         cfg.next_control = authored_next ? (int)authored_next : containers;
@@ -540,7 +541,8 @@ static VGMSTREAM* build_cf_df_v1_mov(STREAMFILE* sf, int containers) {
 
         for (int i = 0; i < cfg.audio_a_count + cfg.audio_b_count; i++) {
             int id = audio_base + i;
-            if (!is_valid_chunk(sf, containers, id, &bank.chunks[id]))
+            if (!is_valid_chunk(sf, containers, id, read_u16, read_u32,
+                    &bank.chunks[id]))
                 goto fail;
             if (bank.audio_count >= containers)
                 goto fail;
@@ -548,7 +550,7 @@ static VGMSTREAM* build_cf_df_v1_mov(STREAMFILE* sf, int containers) {
         }
 
         if (cfg.audio_b_count > 0 && cfg.order_count > 0) {
-            if (append_contiguous_playlist(sf, read_u16le, bank.chunks, containers,
+            if (append_contiguous_playlist(sf, read_u16, bank.chunks, containers,
                     group_b_base - 1, cfg.audio_b_count, cfg.order, cfg.order_count,
                     cfg.loop, cfg.loop_start, &bank.playlist) != 1)
                 goto fail;
@@ -570,23 +572,15 @@ fail:
     return NULL;
 }
 
-/* Proto resources serialize the complete container in the platform's native byte order. */
-static bool get_proto_config(STREAMFILE* sf, int* out_containers, bool* out_big_endian) {
+/* Early resources serialize the complete container in the platform's native byte order. */
+static bool get_native_config(STREAMFILE* sf, read_u32_t read_u32, int* out_containers) {
     off_t file_size = get_streamfile_size(sf);
     if (file_size <= 0 || file_size > UINT32_MAX)
         return false;
-    if (is_id32be(0x20, sf, "LPPA") && is_id32be(0x24, sf, "LPPA"))
+    if (read_u32(0x00, sf) != (1u << 16) ||
+            read_u32(0x04, sf) != (uint32_t)file_size)
         return false;
 
-    bool valid_le = read_u32le(0x00, sf) == 0x00010000 &&
-                    read_u32le(0x04, sf) == (uint32_t)file_size;
-    bool valid_be = read_u32be(0x00, sf) == 0x00010000 &&
-                    read_u32be(0x04, sf) == (uint32_t)file_size;
-    if (valid_le == valid_be)
-        return false;
-
-    bool big_endian = valid_be;
-    read_u32_t read_u32 = get_read_u32(big_endian);
     uint32_t containers = read_u32(0x14, sf);
     if (containers <= 1 || containers > INT16_MAX)
         return false;
@@ -594,7 +588,23 @@ static bool get_proto_config(STREAMFILE* sf, int* out_containers, bool* out_big_
         return false;
 
     *out_containers = containers;
-    *out_big_endian = big_endian;
+    return true;
+}
+
+/* Proto resources may use either native byte order and have no family tag. */
+static bool get_proto_config(STREAMFILE* sf, int* out_containers, bool* out_big_endian) {
+    if (is_id32be(0x20, sf, "LPPA") && is_id32be(0x24, sf, "LPPA"))
+        return false;
+
+    int containers_le = 0;
+    int containers_be = 0;
+    bool valid_le = get_native_config(sf, read_u32le, &containers_le);
+    bool valid_be = get_native_config(sf, read_u32be, &containers_be);
+    if (valid_le == valid_be)
+        return false;
+
+    *out_containers = valid_be ? containers_be : containers_le;
+    *out_big_endian = valid_be;
     return true;
 }
 
@@ -782,16 +792,17 @@ static VGMSTREAM* build_blocked(STREAMFILE* sf, df_chunk_t* loop, int loop_count
     return v;
 }
 
-static bool get_v1_snd_config(STREAMFILE* sf, int containers, df_v1_snd_config_t* cfg) {
+static bool get_v1_snd_config(STREAMFILE* sf, int containers,
+        read_u16_t read_u16, read_u32_t read_u32, df_v1_snd_config_t* cfg) {
     off_t file_size = get_streamfile_size(sf);
-    off_t control = read_u32le(DF_HEADER_SIZE, sf);
+    off_t control = read_u32(DF_HEADER_SIZE, sf);
 
     if (control <= 0 || control + 0xc2 > file_size)
         return false;
 
-    cfg->bank.group_a_boundary = read_u16le(control + 0x20, sf);
-    cfg->bank.group_b_count = read_u16le(control + 0x22, sf);
-    cfg->bank.order_count = read_u16le(control + 0x24, sf);
+    cfg->bank.group_a_boundary = read_u16(control + 0x20, sf);
+    cfg->bank.group_b_count = read_u16(control + 0x22, sf);
+    cfg->bank.order_count = read_u16(control + 0x24, sf);
     cfg->bank.order = control + 0x26;
     cfg->track_name = control + 0xa6;
     cfg->chunk_names = control + 0xc2;
@@ -809,7 +820,8 @@ static bool get_v1_snd_config(STREAMFILE* sf, int containers, df_v1_snd_config_t
  * per-chunk names live in container 0, unlike the container 1 found in trk/sfx/mov.
  * Builds the theme (subsong 1: order assembled in order, leading/trailing silence trimmed,
  * end-to-end loop) plus every chunk as a named subsong. */
-static VGMSTREAM* build_cf_df_v1_snd(STREAMFILE* sf, int containers, const df_v1_snd_config_t* cfg) {
+static VGMSTREAM* build_cf_df_v1_snd(STREAMFILE* sf, int containers,
+        read_u16_t read_u16, read_u32_t read_u32, const df_v1_snd_config_t* cfg) {
     VGMSTREAM* vgmstream = NULL;
     df_bank_t bank = {0};
     off_t file_size = get_streamfile_size(sf);
@@ -818,10 +830,11 @@ static VGMSTREAM* build_cf_df_v1_snd(STREAMFILE* sf, int containers, const df_v1
         goto fail;
 
     for (int i = 0; i < containers; i++)
-        is_valid_chunk(sf, containers, i, &bank.chunks[i]); /* fills chunks[i], sets .valid */
+        is_valid_chunk(sf, containers, i, read_u16, read_u32,
+                &bank.chunks[i]); /* fills chunks[i], sets .valid */
 
     /* order list -> seq (1-based selectors into the contiguous Group-B range) */
-    if (append_contiguous_playlist(sf, read_u16le, bank.chunks, containers,
+    if (append_contiguous_playlist(sf, read_u16, bank.chunks, containers,
             cfg->bank.group_a_boundary, cfg->bank.group_b_count,
             cfg->bank.order, cfg->bank.order_count,
             1, 0, &bank.playlist) != 1)
@@ -867,11 +880,14 @@ fail:
 }
 
 static VGMSTREAM* build_cf_df_v1(STREAMFILE* sf, int containers, bool is_mov,
-        const df_v1_snd_config_t* snd_config) {
-    if (is_mov)
-        return build_cf_df_v1_mov(sf, containers);
+        bool big_endian, const df_v1_snd_config_t* snd_config) {
+    read_u16_t read_u16 = get_read_u16(big_endian);
+    read_u32_t read_u32 = get_read_u32(big_endian);
 
-    return build_cf_df_v1_snd(sf, containers, snd_config);
+    if (is_mov)
+        return build_cf_df_v1_mov(sf, containers, read_u16, read_u32);
+
+    return build_cf_df_v1_snd(sf, containers, read_u16, read_u32, snd_config);
 }
 
 static VGMSTREAM* build_cf_df_v4(STREAMFILE* sf, int containers, bool is_mov) {
@@ -926,7 +942,8 @@ static VGMSTREAM* build_cf_df_v4(STREAMFILE* sf, int containers, bool is_mov) {
                 int id = read_u16le(e + 0x04, sf);
                 if (id >= 0 && id < containers)
                     read_name(sf, e, DF_SHORT_NAME_MAX, &bank.names[id]);
-                if (!is_valid_chunk(sf, containers, id, &loop[i])) {
+                if (!is_valid_chunk(sf, containers, id, read_u16le, read_u32le,
+                        &loop[i])) {
                     all_valid = 0;
                 }
                 else {
@@ -989,7 +1006,8 @@ static VGMSTREAM* build_cf_df_v4(STREAMFILE* sf, int containers, bool is_mov) {
     for (int i = 0; i < containers; i++) {
         if (in_loop && in_loop[i])
             continue;
-        if (is_valid_chunk(sf, containers, i, &bank.chunks[i]))
+        if (is_valid_chunk(sf, containers, i, read_u16le, read_u32le,
+                &bank.chunks[i]))
             bank.audio_ids[bank.audio_count++] = i;
     }
 
@@ -1056,6 +1074,7 @@ VGMSTREAM* init_vgmstream_cf_df(STREAMFILE* sf) {
     int containers = 0;
     bool is_mov;
     bool proto_big_endian = false;
+    bool v1_big_endian = false;
     bool is_extensionless;
 
     if (!check_extensions(sf, "snd,sfx,trk,mov,move,"))
@@ -1064,9 +1083,31 @@ VGMSTREAM* init_vgmstream_cf_df(STREAMFILE* sf) {
     is_mov = check_extensions(sf, "mov,move");
     is_extensionless = check_extensions(sf, ""); //Proto has banked music!
 
+    /* Macintosh Dust V1 uses native big-endian fields and family tags in
+     * place of the later LPPALPPA marker. */
+    bool is_mac_v1_mov = is_mov && is_id64be(0x20, sf, "MOVEDFME");
+    bool is_mac_v1_snd = check_extensions(sf, "snd") &&
+            is_id64be(0x20, sf, "SONGDFST");
+    if (is_mac_v1_mov || is_mac_v1_snd) {
+        if (!get_native_config(sf, read_u32be, &containers))
+            return NULL;
+
+        if (is_mac_v1_mov) {
+            if (!has_v1_mov_control(sf, read_u32be))
+                return NULL;
+        }
+        else if (!get_v1_snd_config(sf, containers,
+                read_u16be, read_u32be, &snd_config)) {
+            return NULL;
+        }
+
+        version = DF_VERSION_1;
+        v1_big_endian = true;
+    }
+
     /* Proto has no LPPALPPA marker and may be native little- or big-endian.
      * Extensionless files are admitted only after this complete header check. */
-    if (is_mov || is_extensionless) {
+    if (version == DF_VERSION_NONE && (is_mov || is_extensionless)) {
         if (get_proto_config(sf, &containers, &proto_big_endian)) {
             version = DF_VERSION_PROTO;
         }
@@ -1085,7 +1126,7 @@ VGMSTREAM* init_vgmstream_cf_df(STREAMFILE* sf) {
         if (DF_HEADER_SIZE + (off_t)containers * 0x04 > get_streamfile_size(sf))
             return NULL;
 
-        if (is_mov && get_mov_control_revision(sf) == DF_MOV_CONTROL_REVISION_1) {
+        if (is_mov && has_v1_mov_control(sf, read_u32le)) {
             version = DF_VERSION_1;
         }
         else {
@@ -1094,7 +1135,8 @@ VGMSTREAM* init_vgmstream_cf_df(STREAMFILE* sf) {
 
             /* V1 .snd and V4 share the later envelope. Prefer the structural
              * V1 container-0 playlist, then use the V4 loop-block model. */
-            if (check_extensions(sf, "snd") && get_v1_snd_config(sf, containers, &snd_config))
+            if (check_extensions(sf, "snd") && get_v1_snd_config(sf, containers,
+                    read_u16le, read_u32le, &snd_config))
                 version = DF_VERSION_1;
             else
                 version = DF_VERSION_4;
@@ -1105,7 +1147,7 @@ VGMSTREAM* init_vgmstream_cf_df(STREAMFILE* sf) {
         case DF_VERSION_PROTO:
             return build_cf_df_proto(sf, containers, proto_big_endian, is_mov);
         case DF_VERSION_1:
-            return build_cf_df_v1(sf, containers, is_mov, &snd_config);
+            return build_cf_df_v1(sf, containers, is_mov, v1_big_endian, &snd_config);
         case DF_VERSION_4:
             return build_cf_df_v4(sf, containers, is_mov);
         default:

--- a/src/meta/cf_df.c
+++ b/src/meta/cf_df.c
@@ -7,14 +7,19 @@
 /*
  * CF_DF - CyberFlix DreamFactory Engine
  *
- * Structure:
+ * Generations:
+ * - Proto (Luncius/Jump Raven): Native-endian containers store a duration followed by raw v4.0 ADPCM.
+ * - V1 (Dust 1996): Control records divide sounds into one-shot and reusable
+ *   background groups selected by authored playlists.
+ * - V4 (TAOOT - DMQwA/DRQwA): LPPALPPA containers use explicit loop and
+ *   one-shot blocks; some .snd files reference their loop block from control 0.
+ *
+ * Shared structure:
  * - 0x400-byte header: file size @0x04, container count @0x14; later files use
  *   "LPPALPPA" @0x20.
  * - u32 offset table @0x400 pointing to each container (u32 id, u32 size, then payload).
  * - Later audio chunks hold: u16 codec @0x1A (1=v4.0 / 2=v4.1), u32 rate @0x1C,
  *   u32 uncompressed size @0x24, u32 data offset @0x2C.
- * - Proto audio resources hold a native-endian u16 duration followed by v4.0 ADPCM.
- *
  * Format-specific control data describes a playback track plus stored one-shot
  * and reusable background chunks. subsong 1 = the assembled background track,
  * subsongs 2..N = every stored audio chunk individually.
@@ -32,35 +37,18 @@
 #define DF_SHORT_NAME_MAX (DF_LOOP_ENTRY - DF_NAME_OFFSET - 1)
 #define DF_MOV_NAME_MAX   (DF_MOV_ENTRY - DF_NAME_OFFSET - 1)
 #define DF_MAX_CHUNKS   0x4000  /* sanity cap for table sizes */
+#define DF_CODEC_V40    0x01
+#define DF_CODEC_V41    0x02
 
 /* Early MOV control layouts. Revision 1 keeps the later audio chunk header. */
 #define DF_MOV_CONTROL_REVISION      0x02
 #define DF_MOV_CONTROL_REVISION_1    0x0001
 
-#define DF_REV1_AUDIO_A_COUNT        0x1A
-#define DF_REV1_AUDIO_B_COUNT        0x1C
-#define DF_REV1_PLAYLIST_COUNT       0x34
-#define DF_REV1_NEXT_CONTROL         0x36
-#define DF_REV1_PLAYLIST_ORDER       0x83E
-#define DF_REV1_PLAYLIST_LOOP        0x8BE
-
 #define DF_PROTO_AUDIO_HEADER        0x02
 #define DF_PROTO_DURATION_SAMPLES    370
 #define DF_PROTO_WINDOWS_RATE        22050
 #define DF_PROTO_MACINTOSH_RATE      22255  /* nearest integer to 0x56EE8BA3 (16.16) */
-#define DF_PROTO_AUDIO_A_COUNT       0x02
-#define DF_PROTO_AUDIO_B_COUNT       0x04
-#define DF_PROTO_PLAYLIST_COUNT      0x1C
-#define DF_PROTO_PLAYLIST_ORDER      0x822
 #define DF_PROTO_PLAYLIST_MAX        64
-
-/* Compact Proto music-bank control payload. Group-B background sources are a
- * contiguous range selected by a fixed 64-entry order table. */
-#define DF_PROTO_BANK_GROUP_A_BOUNDARY  0x00
-#define DF_PROTO_BANK_GROUP_B_COUNT     0x02
-#define DF_PROTO_BANK_PLAYLIST_COUNT    0x04
-#define DF_PROTO_BANK_PLAYLIST_ORDER    0x06
-#define DF_PROTO_BANK_CONTROL_SIZE      (DF_PROTO_BANK_PLAYLIST_ORDER + DF_PROTO_PLAYLIST_MAX * 0x02)
 
 /* Revision-4 .snd control payload. Unlike the shared .mov/.sfx/.trk layout,
  * the loop block is referenced by container id instead of fixed at id 1. */
@@ -68,17 +56,7 @@
 #define DF_SND_REVISION_4            0x0004
 #define DF_SND_LOOP_BLOCK_PTR        0x1C
 
-/* .snd "container-0" variant (HELP.SND/KID.SND): unlike the trk/sfx/mov container-1 loop block, the
- * order list, track name and per-chunk names live in container 0. Offsets are relative to container 0.
- * The order list holds 1-based selectors into a contiguous background range; the chunk-name table
- * has one Pascal entry per chunk (entry k -> container k+1). */
-#define DF_SND_GROUP_A_BOUNDARY  0x20   /* u16, last one-shot container id */
-#define DF_SND_GROUP_B_COUNT     0x22   /* u16, unique background chunks */
-#define DF_SND_ORDER_COUNT       0x24   /* u16, authored playlist entries */
-#define DF_SND_ORDER             0x26   /* u16[64], relative Group-B selectors */
 #define DF_SND_ORDER_MAX         64
-#define DF_SND_TRACK_NAME   0xa6   /* Pascal string */
-#define DF_SND_CHUNK_NAMES  0xc2   /* Pascal entries, stride 0x18, one per chunk */
 #define DF_SND_NAME_STRIDE  0x18
 
 typedef struct {
@@ -88,22 +66,64 @@ typedef struct {
     int32_t size;               /* compressed size */
     int32_t sample_rate;
     int32_t uncompressed_size;
-    int valid;
-    char name[DF_MOV_NAME_MAX + 1];
+    bool valid;
 } df_chunk_t;
 
 typedef struct {
     char name[DF_MOV_NAME_MAX + 1];
 } df_name_t;
 
+typedef enum {
+    DF_VERSION_NONE = 0,
+    DF_VERSION_PROTO,
+    DF_VERSION_1,
+    DF_VERSION_4,
+} df_version_t;
+
 typedef struct {
     int* sequence;              /* container ids in authored playback order */
     int count;
     int loop;
     int loop_start;             /* sequence index */
-} df_early_playlist_t;
+} df_playlist_t;
 
-static VGMSTREAM* build_segmented(STREAMFILE* sf, df_chunk_t* chunks, int* seq, int count, int loop, int loop_start);
+typedef struct {
+    df_chunk_t* chunks;         /* indexed by container id */
+    int* audio_ids;             /* individual subsongs in presentation order */
+    int audio_count;
+    df_playlist_t playlist;     /* single assembled background subsong */
+    bool has_playlist;
+    df_name_t* names;           /* optional names indexed by container id */
+    char track_name[STREAM_NAME_SIZE];
+    int containers;
+} df_bank_t;
+
+typedef struct {
+    int audio_a_count;
+    int audio_b_count;
+    int order_count;
+    off_t order;
+    int next_control;
+    int loop;
+    int loop_start;
+} df_mov_control_t;
+
+typedef struct {
+    int group_a_boundary;
+    int group_b_count;
+    int order_count;
+    off_t order;
+} df_bank_control_t;
+
+/* .snd "container-0" variant: unlike the trk/sfx/mov
+ * container-1 loop block, the order list and names live in container 0. */
+typedef struct {
+    df_bank_control_t bank;
+    off_t track_name;
+    off_t chunk_names;
+} df_v1_snd_config_t;
+
+static VGMSTREAM* build_segmented(STREAMFILE* sf, df_chunk_t* chunks, const int* seq, int count, int loop, int loop_start);
 
 /* Read the audio fields of a container; returns 1 if it looks like a valid audio chunk. */
 static bool is_valid_chunk(STREAMFILE* sf, int containers, int id, df_chunk_t* c) {
@@ -120,7 +140,8 @@ static bool is_valid_chunk(STREAMFILE* sf, int containers, int id, df_chunk_t* c
 
     uint16_t codec = read_u16le(hp + 0x1A, sf);
     uint32_t rate  = read_u32le(hp + 0x1C, sf);
-    if ((codec != 1 && codec != 2) || (rate != 11025 && rate != 22050 && rate != 44100))
+    if ((codec != DF_CODEC_V40 && codec != DF_CODEC_V41) ||
+            (rate != 11025 && rate != 22050 && rate != 44100))
         return false;
 
     uint32_t data_offset = read_u32le(hp + 0x2C, sf);
@@ -196,7 +217,7 @@ static bool is_valid_proto_chunk(STREAMFILE* sf, int containers, int id,
         return false;
 
     c->container_id = id;
-    c->codec_flag = 1;
+    c->codec_flag = DF_CODEC_V40;
     c->sample_rate = sample_rate;
     c->uncompressed_size = samples;
     c->offset = data_offset;
@@ -205,15 +226,15 @@ static bool is_valid_proto_chunk(STREAMFILE* sf, int containers, int id,
     return true;
 }
 
-static int32_t chunk_samples(df_chunk_t* c) {
-    return (c->codec_flag == 1) ? c->uncompressed_size : c->uncompressed_size / 2;
+static int32_t chunk_samples(const df_chunk_t* c) {
+    return (c->codec_flag == DF_CODEC_V40) ? c->uncompressed_size : c->uncompressed_size / 2;
 }
 
-static void config_chunk(VGMSTREAM* v, df_chunk_t* c) {
+static void config_chunk(VGMSTREAM* v, const df_chunk_t* c) {
     v->meta_type   = meta_CF_DF;
     v->sample_rate = c->sample_rate;
     v->stream_size = c->size;
-    if (c->codec_flag == 1) {
+    if (c->codec_flag == DF_CODEC_V40) {
         v->coding_type = coding_CF_DF_ADPCM_V40;
         v->num_samples = c->uncompressed_size;
     } else {
@@ -238,7 +259,7 @@ static bool is_silent_chunk(STREAMFILE* sf, const df_chunk_t* c) {
 
         for (int i = 0; i < got; i++) {
             uint8_t b = buf[i];
-            if (c->codec_flag == 2) {
+            if (c->codec_flag == DF_CODEC_V41) {
                 if (b != 0x00 && b != 0x80)
                     return false;
             } else {
@@ -309,8 +330,8 @@ static int get_snd_loop_block_id(STREAMFILE* sf, int containers) {
     return id;
 }
 
-static void trim_early_playlist(STREAMFILE* sf, df_chunk_t* chunks,
-        const df_early_playlist_t* playlist, int* out_lo, int* out_hi,
+static void trim_playlist(STREAMFILE* sf, df_chunk_t* chunks,
+        const df_playlist_t* playlist, int* out_lo, int* out_hi,
         int* out_loop, int* out_loop_start) {
     int lo = 0, hi = playlist->count - 1;
     int loop = playlist->loop;
@@ -344,6 +365,70 @@ static void trim_early_playlist(STREAMFILE* sf, df_chunk_t* chunks,
     *out_loop_start = loop_start;
 }
 
+/* Older generations select a contiguous Group-B range with one-based values.
+ * Returns 1 when populated, 0 for invalid control data and -1 on allocation failure. */
+static int append_contiguous_playlist(STREAMFILE* sf, read_u16_t read_u16,
+        df_chunk_t* chunks, int containers, int group_boundary, int group_count,
+        off_t order_offset, int order_count, int loop, int loop_start,
+        df_playlist_t* playlist) {
+    int old_count = playlist->count;
+
+    if (group_boundary < 0 || group_count <= 0 || order_count <= 0 ||
+            group_boundary + group_count >= containers)
+        return 0;
+
+    for (int i = 0; i < order_count; i++) {
+        int selector = read_u16(order_offset + (off_t)i * 0x02, sf);
+        int id = group_boundary + selector;
+        if (selector < 1 || selector > group_count || !chunks[id].valid)
+            return 0;
+    }
+
+    int* sequence = realloc(playlist->sequence,
+            (size_t)(old_count + order_count) * sizeof(*sequence));
+    if (!sequence)
+        return -1;
+    playlist->sequence = sequence;
+
+    for (int i = 0; i < order_count; i++) {
+        int selector = read_u16(order_offset + (off_t)i * 0x02, sf);
+        playlist->sequence[old_count + i] = group_boundary + selector;
+    }
+    playlist->count = old_count + order_count;
+
+    /* One output track has one loop point. Keep the first authored point when
+     * a V1 MOV contributes more than one control playlist. */
+    if (loop && !playlist->loop) {
+        playlist->loop = 1;
+        playlist->loop_start = old_count + loop_start;
+    }
+    return 1;
+}
+
+static bool init_bank(df_bank_t* bank, int containers, bool use_names) {
+    bank->chunks = calloc((size_t)containers, sizeof(*bank->chunks));
+    bank->audio_ids = malloc((size_t)containers * sizeof(*bank->audio_ids));
+    if (use_names)
+        bank->names = calloc((size_t)containers, sizeof(*bank->names));
+
+    if (!bank->chunks || !bank->audio_ids ||
+            (use_names && !bank->names))
+        return false;
+
+    bank->containers = containers;
+    return true;
+}
+
+static void free_bank(df_bank_t* bank) {
+    if (!bank)
+        return;
+
+    free(bank->chunks);
+    free(bank->audio_ids);
+    free(bank->playlist.sequence);
+    free(bank->names);
+}
+
 static void set_stream_name(STREAMFILE* sf, VGMSTREAM* vgmstream,
         const char* authored_name, int stream_index) {
     if (authored_name && authored_name[0]) {
@@ -357,20 +442,61 @@ static void set_stream_name(STREAMFILE* sf, VGMSTREAM* vgmstream,
     }
 }
 
+/* Present every generation consistently: one authored background track first,
+ * followed by each stored audio chunk in the same subsong number space.
+ * stream_index 0 selects the background track. */
+static VGMSTREAM* build_bank_subsong(STREAMFILE* sf, df_bank_t* bank) {
+    VGMSTREAM* vgmstream = NULL;
+    int subsongs = (bank->has_playlist ? 1 : 0) + bank->audio_count;
+    int target = sf->stream_index;
+
+    if (target == 0)
+        target = 1;
+    if (subsongs <= 0 || target < 1 || target > subsongs)
+        return NULL;
+
+    if (bank->has_playlist && target == 1) {
+        df_playlist_t* playlist = &bank->playlist;
+        int lo, hi, loop, loop_start;
+
+        trim_playlist(sf, bank->chunks, playlist, &lo, &hi, &loop, &loop_start);
+        vgmstream = build_segmented(sf, bank->chunks, playlist->sequence + lo,
+                hi - lo + 1, loop, loop_start);
+        if (!vgmstream)
+            return NULL;
+
+        set_stream_name(sf, vgmstream, bank->track_name, target);
+    }
+    else {
+        int piece = target - (bank->has_playlist ? 1 : 0);
+        int id = bank->audio_ids[piece - 1];
+
+        vgmstream = allocate_vgmstream(1, 0);
+        if (!vgmstream)
+            return NULL;
+
+        config_chunk(vgmstream, &bank->chunks[id]);
+        set_stream_name(sf, vgmstream,
+                bank->names ? bank->names[id].name : NULL, target);
+
+        if (!vgmstream_open_stream(vgmstream, sf, bank->chunks[id].offset)) {
+            close_vgmstream(vgmstream);
+            return NULL;
+        }
+    }
+
+    vgmstream->num_streams = subsongs;
+    return vgmstream;
+}
+
 /* Revision-1 MOVs keep Group-A one-shots and Group-B background sources
  * immediately after each control. */
-static VGMSTREAM* build_revision1_mov(STREAMFILE* sf, int containers) {
+static VGMSTREAM* build_cf_df_v1_mov(STREAMFILE* sf, int containers) {
     VGMSTREAM* vgmstream = NULL;
-    df_chunk_t* chunks = NULL;
-    int* audio_ids = NULL;
-    df_early_playlist_t playlist = {0};
-    int audio_count = 0;
+    df_bank_t bank = {0};
     int control = 0;
-    bool has_playlist = false;
 
-    chunks = calloc((size_t)containers, sizeof(*chunks));
-    audio_ids = malloc((size_t)containers * sizeof(*audio_ids));
-    if (!chunks || !audio_ids)
+    if (!init_bank(&bank, containers, false))
         goto fail;
 
     off_t file_size = get_streamfile_size(sf);
@@ -380,128 +506,66 @@ static VGMSTREAM* build_revision1_mov(STREAMFILE* sf, int containers) {
             goto fail;
         off_t p = pos + 0x08;
 
-        int audio_a, audio_b, next;
-        int order_count;
-        off_t order_pos;
-        int loop = 0, loop_start = 0;
+        df_mov_control_t cfg = {0};
 
-        if (p + DF_REV1_PLAYLIST_LOOP + 0x04 > file_size)
+        if (p + 0x8be + 0x04 > file_size)
             goto fail;
         if (read_u16le(p + DF_MOV_CONTROL_REVISION, sf) != DF_MOV_CONTROL_REVISION_1)
             goto fail;
-        audio_a = read_u16le(p + DF_REV1_AUDIO_A_COUNT, sf);
-        audio_b = read_u16le(p + DF_REV1_AUDIO_B_COUNT, sf);
-        order_count = read_u16le(p + DF_REV1_PLAYLIST_COUNT, sf);
-        order_pos = p + DF_REV1_PLAYLIST_ORDER;
-        uint32_t authored_loop = read_u32le(p + DF_REV1_PLAYLIST_LOOP, sf);
-        if (authored_loop < (uint32_t)order_count) {
-            loop = 1;
-            loop_start = authored_loop;
+        cfg.audio_a_count = read_u16le(p + 0x1a, sf);
+        cfg.audio_b_count = read_u16le(p + 0x1c, sf);
+        cfg.order_count = read_u16le(p + 0x34, sf);
+        cfg.order = p + 0x83e;
+        uint32_t authored_loop = read_u32le(p + 0x8be, sf);
+        if (authored_loop < (uint32_t)cfg.order_count) {
+            cfg.loop = 1;
+            cfg.loop_start = authored_loop;
         }
-        uint32_t authored_next = read_u32le(p + DF_REV1_NEXT_CONTROL, sf);
+        uint32_t authored_next = read_u32le(p + 0x36, sf);
         if (authored_next > (uint32_t)containers)
             goto fail;
-        next = authored_next ? (int)authored_next : containers;
+        cfg.next_control = authored_next ? (int)authored_next : containers;
 
         int audio_base = control + 1;
-        int group_b_base = audio_base + audio_a;
-        if (audio_a + audio_b > containers || audio_base + audio_a + audio_b > containers)
+        int group_b_base = audio_base + cfg.audio_a_count;
+        if (cfg.audio_a_count + cfg.audio_b_count > containers ||
+                audio_base + cfg.audio_a_count + cfg.audio_b_count > containers)
             goto fail;
-        if (next <= control || next > containers)
+        if (cfg.next_control <= control || cfg.next_control > containers)
             goto fail;
-        if (order_count > DF_MAX_CHUNKS)
+        if (cfg.order_count > DF_MAX_CHUNKS)
             goto fail;
-        if (order_pos + (off_t)order_count * 0x02 > file_size)
+        if (cfg.order + (off_t)cfg.order_count * 0x02 > file_size)
             goto fail;
 
-        for (int i = 0; i < audio_a + audio_b; i++) {
+        for (int i = 0; i < cfg.audio_a_count + cfg.audio_b_count; i++) {
             int id = audio_base + i;
-            if (!is_valid_chunk(sf, containers, id, &chunks[id]))
+            if (!is_valid_chunk(sf, containers, id, &bank.chunks[id]))
                 goto fail;
-            if (audio_count >= containers)
+            if (bank.audio_count >= containers)
                 goto fail;
-            audio_ids[audio_count++] = id;
+            bank.audio_ids[bank.audio_count++] = id;
         }
 
-        if (audio_b > 0 && order_count > 0) {
-            int old_count = playlist.count;
-
-            for (int i = 0; i < order_count; i++) {
-                int selector = read_u16le(order_pos + (off_t)i * 0x02, sf);
-                if (selector < 1 || selector > audio_b)
-                    goto fail;
-            }
-
-            int* sequence = realloc(playlist.sequence,
-                    (size_t)(old_count + order_count) * sizeof(*sequence));
-            if (!sequence)
+        if (cfg.audio_b_count > 0 && cfg.order_count > 0) {
+            if (append_contiguous_playlist(sf, read_u16le, bank.chunks, containers,
+                    group_b_base - 1, cfg.audio_b_count, cfg.order, cfg.order_count,
+                    cfg.loop, cfg.loop_start, &bank.playlist) != 1)
                 goto fail;
-            playlist.sequence = sequence;
-
-            for (int i = 0; i < order_count; i++) {
-                int selector = read_u16le(order_pos + (off_t)i * 0x02, sf);
-                playlist.sequence[old_count + i] = group_b_base + selector - 1;
-            }
-            playlist.count = old_count + order_count;
-
-            /* One output track has one loop point. Keep the first authored
-             * point when a MOV contributes more than one control sequence. */
-            if (loop && !playlist.loop) {
-                playlist.loop = 1;
-                playlist.loop_start = old_count + loop_start;
-            }
-            has_playlist = true;
+            bank.has_playlist = true;
         }
 
-        if (next == containers)
+        if (cfg.next_control == containers)
             break;
-        control = next;
+        control = cfg.next_control;
     }
 
-    int subsongs = (has_playlist ? 1 : 0) + audio_count;
-    if (subsongs <= 0)
-        goto fail;
-
-    int target = sf->stream_index;
-    if (target == 0)
-        target = 1;
-    if (target < 1 || target > subsongs)
-        goto fail;
-
-    if (has_playlist && target == 1) {
-        int lo = 0, hi = playlist.count - 1;
-        int loop = playlist.loop;
-        int loop_start = playlist.loop_start;
-
-        trim_early_playlist(sf, chunks, &playlist, &lo, &hi, &loop, &loop_start);
-
-        vgmstream = build_segmented(sf, chunks, playlist.sequence + lo,
-                hi - lo + 1, loop, loop_start);
-        if (!vgmstream)
-            goto fail;
-    }
-    else {
-        int piece = target - (has_playlist ? 1 : 0);
-        int id = audio_ids[piece - 1];
-        vgmstream = allocate_vgmstream(1, 0);
-        if (!vgmstream)
-            goto fail;
-        config_chunk(vgmstream, &chunks[id]);
-        if (!vgmstream_open_stream(vgmstream, sf, chunks[id].offset))
-            goto fail;
-    }
-
-    set_stream_name(sf, vgmstream, NULL, target);
-    vgmstream->num_streams = subsongs;
-    free(chunks);
-    free(audio_ids);
-    free(playlist.sequence);
+    vgmstream = build_bank_subsong(sf, &bank);
+    free_bank(&bank);
     return vgmstream;
 
 fail:
-    free(chunks);
-    free(audio_ids);
-    free(playlist.sequence);
+    free_bank(&bank);
     close_vgmstream(vgmstream);
     return NULL;
 }
@@ -538,7 +602,7 @@ static bool get_proto_config(STREAMFILE* sf, int* out_containers, bool* out_big_
  * .snd, but place the compact control block at the start of container 0. */
 static int get_proto_bank_playlist(STREAMFILE* sf, int containers,
         read_u16_t read_u16, read_u32_t read_u32, df_chunk_t* chunks,
-        df_early_playlist_t* playlist) {
+        df_playlist_t* playlist) {
     off_t file_size = get_streamfile_size(sf);
     off_t control = read_u32(DF_HEADER_SIZE, sf);
 
@@ -547,69 +611,53 @@ static int get_proto_bank_playlist(STREAMFILE* sf, int containers,
 
     uint32_t payload_size = read_u32(control + 0x04, sf);
     off_t p = control + 0x08;
-    if (payload_size < DF_PROTO_BANK_CONTROL_SIZE || payload_size > file_size - p)
+    if (payload_size < 0x06 + DF_PROTO_PLAYLIST_MAX * 0x02 || payload_size > file_size - p)
         return 0;
 
-    int group_a_boundary = read_u16(p + DF_PROTO_BANK_GROUP_A_BOUNDARY, sf);
-    int group_b_count = read_u16(p + DF_PROTO_BANK_GROUP_B_COUNT, sf);
-    int order_count = read_u16(p + DF_PROTO_BANK_PLAYLIST_COUNT, sf);
-    if (group_a_boundary <= 0 || group_b_count <= 0 ||
-        order_count <= 0 || order_count > DF_PROTO_PLAYLIST_MAX ||
-        group_a_boundary + group_b_count >= containers)
+    df_bank_control_t cfg = {
+        .group_a_boundary = read_u16(p + 0x00, sf),
+        .group_b_count = read_u16(p + 0x02, sf),
+        .order_count = read_u16(p + 0x04, sf),
+        .order = p + 0x06,
+    };
+    if (cfg.group_a_boundary <= 0 || cfg.group_b_count <= 0 ||
+        cfg.order_count <= 0 || cfg.order_count > DF_PROTO_PLAYLIST_MAX ||
+        cfg.group_a_boundary + cfg.group_b_count >= containers)
         return 0;
 
-    for (int selector = 1; selector <= group_b_count; selector++) {
-        int id = group_a_boundary + selector;
+    for (int selector = 1; selector <= cfg.group_b_count; selector++) {
+        int id = cfg.group_a_boundary + selector;
         if (!chunks[id].valid)
             return 0;
     }
 
-    for (int i = 0; i < order_count; i++) {
-        int selector = read_u16(p + DF_PROTO_BANK_PLAYLIST_ORDER + (off_t)i * 0x02, sf);
-        if (selector < 1 || selector > group_b_count)
-            return 0;
-    }
-
-    playlist->sequence = malloc((size_t)order_count * sizeof(*playlist->sequence));
-    if (!playlist->sequence)
-        return -1;
-
-    for (int i = 0; i < order_count; i++) {
-        int selector = read_u16(p + DF_PROTO_BANK_PLAYLIST_ORDER + (off_t)i * 0x02, sf);
-        playlist->sequence[i] = group_a_boundary + selector;
-    }
-    playlist->count = order_count;
-    return 1;
+    return append_contiguous_playlist(sf, read_u16, chunks, containers,
+            cfg.group_a_boundary, cfg.group_b_count, cfg.order,
+            cfg.order_count, 0, 0, playlist);
 }
 
 /* Proto containers intersperse sound with non-sound resources.
  * Discover only self-validating audio throughout the file. MOV resources may
  * additionally carry a complete Group-B playlist in control 0. Non-MOV files
  * are independently checked for the compact standalone music-bank form. */
-static VGMSTREAM* build_proto_resource(STREAMFILE* sf, int containers,
+static VGMSTREAM* build_cf_df_proto(STREAMFILE* sf, int containers,
         bool big_endian, bool parse_movie_playlist) {
     VGMSTREAM* vgmstream = NULL;
-    df_chunk_t* chunks = NULL;
-    int* audio_ids = NULL;
-    df_early_playlist_t playlist = {0};
+    df_bank_t bank = {0};
     read_u16_t read_u16 = get_read_u16(big_endian);
     read_u32_t read_u32 = get_read_u32(big_endian);
     int sample_rate = big_endian ? DF_PROTO_MACINTOSH_RATE : DF_PROTO_WINDOWS_RATE;
-    int audio_count = 0;
-    bool has_playlist = false;
 
-    chunks = calloc((size_t)containers, sizeof(*chunks));
-    audio_ids = malloc((size_t)containers * sizeof(*audio_ids));
-    if (!chunks || !audio_ids)
+    if (!init_bank(&bank, containers, false))
         goto fail;
 
     for (int id = 1; id < containers; id++) {
         if (is_valid_proto_chunk(sf, containers, id, read_u16, read_u32,
-                sample_rate, &chunks[id])) {
-            audio_ids[audio_count++] = id;
+                sample_rate, &bank.chunks[id])) {
+            bank.audio_ids[bank.audio_count++] = id;
         }
     }
-    if (audio_count <= 0)
+    if (bank.audio_count <= 0)
         goto fail;
 
     if (parse_movie_playlist) {
@@ -622,102 +670,51 @@ static VGMSTREAM* build_proto_resource(STREAMFILE* sf, int containers,
             uint32_t payload_size = read_u32(control + 0x04, sf);
             off_t p = control + 0x08;
 
-            if (payload_size <= file_size - p &&
-                payload_size >= DF_PROTO_PLAYLIST_COUNT + 0x02) {
-                int audio_a = read_u16(p + DF_PROTO_AUDIO_A_COUNT, sf);
-                int audio_b = read_u16(p + DF_PROTO_AUDIO_B_COUNT, sf);
-                int order_count = read_u16(p + DF_PROTO_PLAYLIST_COUNT, sf);
+            if (payload_size <= file_size - p && payload_size >= 0x1c + 0x02) {
+                df_bank_control_t cfg = {
+                    .group_a_boundary = read_u16(p + 0x02, sf),
+                    .group_b_count = read_u16(p + 0x04, sf),
+                    .order_count = read_u16(p + 0x1c, sf),
+                    .order = p + 0x822,
+                };
 
-                if (audio_b > 0 && order_count > 0 &&
-                    order_count <= DF_PROTO_PLAYLIST_MAX &&
-                    audio_a + audio_b < containers &&
-                    DF_PROTO_PLAYLIST_ORDER + (off_t)order_count * 0x02 <= payload_size) {
-                    bool valid = true;
-
-                    playlist.sequence = malloc((size_t)order_count * sizeof(*playlist.sequence));
-                    if (!playlist.sequence)
+                if (cfg.group_b_count > 0 && cfg.order_count > 0 &&
+                    cfg.order_count <= DF_PROTO_PLAYLIST_MAX &&
+                    cfg.group_a_boundary + cfg.group_b_count < containers &&
+                    0x822 + (off_t)cfg.order_count * 0x02 <= payload_size) {
+                    int result = append_contiguous_playlist(sf, read_u16,
+                            bank.chunks, containers, cfg.group_a_boundary, cfg.group_b_count,
+                            cfg.order, cfg.order_count,
+                            1, 0, &bank.playlist);
+                    if (result < 0)
                         goto fail;
-
-                    for (int i = 0; i < order_count; i++) {
-                        int selector = read_u16(p + DF_PROTO_PLAYLIST_ORDER + (off_t)i * 0x02, sf);
-                        int id = audio_a + selector;
-
-                        if (selector < 1 || selector > audio_b || !chunks[id].valid) {
-                            valid = false;
-                            break;
-                        }
-                        playlist.sequence[i] = id;
-                    }
-
-                    if (valid) {
-                        playlist.count = order_count;
-                        playlist.loop = 1;
-                        playlist.loop_start = 0;
-                        has_playlist = true;
-                    }
-                    else {
-                        free(playlist.sequence);
-                        playlist.sequence = NULL;
-                    }
+                    if (result > 0)
+                        bank.has_playlist = true;
                 }
             }
         }
     }
     else {
         int playlist_result = get_proto_bank_playlist(sf, containers,
-                read_u16, read_u32, chunks, &playlist);
+                read_u16, read_u32, bank.chunks, &bank.playlist);
         if (playlist_result < 0)
             goto fail;
-        has_playlist = playlist_result > 0;
+        bank.has_playlist = playlist_result > 0;
     }
 
-    int subsongs = audio_count + (has_playlist ? 1 : 0);
-    int target = sf->stream_index;
-    if (target == 0)
-        target = 1;
-    if (target < 1 || target > subsongs)
-        goto fail;
-
-    if (has_playlist && target == 1) {
-        int lo, hi, loop, loop_start;
-
-        trim_early_playlist(sf, chunks, &playlist, &lo, &hi, &loop, &loop_start);
-        vgmstream = build_segmented(sf, chunks, playlist.sequence + lo,
-                hi - lo + 1, loop, loop_start);
-        if (!vgmstream)
-            goto fail;
-    }
-    else {
-        int piece = target - (has_playlist ? 1 : 0);
-        int id = audio_ids[piece - 1];
-
-        vgmstream = allocate_vgmstream(1, 0);
-        if (!vgmstream)
-            goto fail;
-
-        config_chunk(vgmstream, &chunks[id]);
-        if (!vgmstream_open_stream(vgmstream, sf, chunks[id].offset))
-            goto fail;
-    }
-
-    set_stream_name(sf, vgmstream, NULL, target);
-    vgmstream->num_streams = subsongs;
-    free(chunks);
-    free(audio_ids);
-    free(playlist.sequence);
+    vgmstream = build_bank_subsong(sf, &bank);
+    free_bank(&bank);
     return vgmstream;
 
 fail:
-    free(chunks);
-    free(audio_ids);
-    free(playlist.sequence);
+    free_bank(&bank);
     close_vgmstream(vgmstream);
     return NULL;
 }
 
 /* Assembled track via segmented layout: play the given sequence of loop chunks once.
  * loop=1 marks the whole assembled track as an end-to-end loop (.snd/.sfx/.trk only; .mov excluded). */
-static VGMSTREAM* build_segmented(STREAMFILE* sf, df_chunk_t* chunks, int* seq, int count, int loop, int loop_start) {
+static VGMSTREAM* build_segmented(STREAMFILE* sf, df_chunk_t* chunks, const int* seq, int count, int loop, int loop_start) {
     VGMSTREAM* v = NULL;
     segmented_layout_data* data = init_layout_segmented(count);
     if (!data) goto fail;
@@ -772,7 +769,7 @@ static VGMSTREAM* build_blocked(STREAMFILE* sf, df_chunk_t* loop, int loop_count
     }
 
     v->meta_type    = meta_CF_DF;
-    v->coding_type  = (loop[lo].codec_flag == 1) ? coding_CF_DF_ADPCM_V40 : coding_CF_DF_DPCM_V41;
+    v->coding_type  = (loop[lo].codec_flag == DF_CODEC_V40) ? coding_CF_DF_ADPCM_V40 : coding_CF_DF_DPCM_V41;
     v->sample_rate  = max_rate;
     v->num_samples  = total;
     v->layout_type  = layout_blocked_cf_df;
@@ -785,206 +782,116 @@ static VGMSTREAM* build_blocked(STREAMFILE* sf, df_chunk_t* loop, int loop_count
     return v;
 }
 
-/* DreamFactory revision-1 .snd "container-0" variant: the assembled theme's order list, track name and
+static bool get_v1_snd_config(STREAMFILE* sf, int containers, df_v1_snd_config_t* cfg) {
+    off_t file_size = get_streamfile_size(sf);
+    off_t control = read_u32le(DF_HEADER_SIZE, sf);
+
+    if (control <= 0 || control + 0xc2 > file_size)
+        return false;
+
+    cfg->bank.group_a_boundary = read_u16le(control + 0x20, sf);
+    cfg->bank.group_b_count = read_u16le(control + 0x22, sf);
+    cfg->bank.order_count = read_u16le(control + 0x24, sf);
+    cfg->bank.order = control + 0x26;
+    cfg->track_name = control + 0xa6;
+    cfg->chunk_names = control + 0xc2;
+    if (cfg->bank.group_a_boundary <= 0 || cfg->bank.group_b_count <= 0 ||
+            cfg->bank.group_a_boundary + cfg->bank.group_b_count >= containers ||
+            cfg->bank.order_count <= 0 || cfg->bank.order_count > DF_SND_ORDER_MAX)
+        return false;
+    if (cfg->bank.order + (off_t)cfg->bank.order_count * 0x02 > file_size)
+        return false;
+
+    return true;
+}
+
+/* DreamFactory V1 .snd "container-0" variant: the assembled theme's order list, track name and
  * per-chunk names live in container 0, unlike the container 1 found in trk/sfx/mov.
  * Builds the theme (subsong 1: order assembled in order, leading/trailing silence trimmed,
- * end-to-end loop) plus every chunk as a named subsong. *handled is set once a valid container-0
- * order is recognized, so the caller stops instead of falling through to the container-1 path. */
-static VGMSTREAM* build_snd_c0(STREAMFILE* sf, int containers, int* handled) {
+ * end-to-end loop) plus every chunk as a named subsong. */
+static VGMSTREAM* build_cf_df_v1_snd(STREAMFILE* sf, int containers, const df_v1_snd_config_t* cfg) {
     VGMSTREAM* vgmstream = NULL;
-    df_chunk_t* chunks = NULL;
-    int* seq = NULL;
-    int* listed = NULL;
-    df_name_t* names = NULL;
-    char track_name[STREAM_NAME_SIZE];
-    int group_a_boundary, group_b_count, order_count;
-    int listed_count = 0, subsongs, target;
-    bool has_track;
-    off_t fsize, c0;
+    df_bank_t bank = {0};
+    off_t file_size = get_streamfile_size(sf);
 
-    *handled = 0;
-    track_name[0] = '\0';
-    fsize = get_streamfile_size(sf);
-
-    c0 = read_u32le(DF_HEADER_SIZE + 0x00 * 0x04, sf);
-    if (c0 <= 0 || c0 + DF_SND_CHUNK_NAMES > fsize)
-        return NULL;
-    group_a_boundary = read_u16le(c0 + DF_SND_GROUP_A_BOUNDARY, sf);
-    group_b_count = read_u16le(c0 + DF_SND_GROUP_B_COUNT, sf);
-    order_count = read_u16le(c0 + DF_SND_ORDER_COUNT, sf);
-    if (group_a_boundary <= 0 || group_b_count <= 0 ||
-        group_a_boundary + group_b_count >= containers ||
-        order_count <= 0 || order_count > DF_SND_ORDER_MAX)
-        return NULL; /* no container-0 order -> not this variant; caller falls through */
-    if (c0 + DF_SND_ORDER + (off_t)order_count * 0x02 > fsize)
-        return NULL;
-
-    *handled = 1; /* a valid container-0 .snd from here -> NULL means parse failure, do not fall through */
-
-    chunks = calloc((size_t)containers, sizeof(df_chunk_t));
-    names  = calloc((size_t)containers, sizeof(df_name_t));
-    seq    = malloc((size_t)order_count * sizeof(int));
-    listed = malloc((size_t)containers * sizeof(int));
-    if (!chunks || !names || !seq || !listed)
+    if (!init_bank(&bank, containers, true))
         goto fail;
 
     for (int i = 0; i < containers; i++)
-        is_valid_chunk(sf, containers, i, &chunks[i]); /* fills chunks[i], sets .valid */
+        is_valid_chunk(sf, containers, i, &bank.chunks[i]); /* fills chunks[i], sets .valid */
 
     /* order list -> seq (1-based selectors into the contiguous Group-B range) */
-    for (int i = 0; i < order_count; i++) {
-        int selector = read_u16le(c0 + DF_SND_ORDER + (off_t)i * 0x02, sf);
-        int id = group_a_boundary + selector;
-        if (selector < 1 || selector > group_b_count || !chunks[id].valid)
-            goto fail;
-        seq[i] = id;
-    }
+    if (append_contiguous_playlist(sf, read_u16le, bank.chunks, containers,
+            cfg->bank.group_a_boundary, cfg->bank.group_b_count,
+            cfg->bank.order, cfg->bank.order_count,
+            1, 0, &bank.playlist) != 1)
+        goto fail;
+    bank.has_playlist = true;
 
     /* per-chunk names: entry k (0-based) -> container k+1 */
     for (int id = 1; id < containers; id++) {
-        off_t e = c0 + DF_SND_CHUNK_NAMES + (off_t)(id - 1) * DF_SND_NAME_STRIDE;
-        if (e + 1 > fsize)
+        off_t e = cfg->chunk_names + (off_t)(id - 1) * DF_SND_NAME_STRIDE;
+        if (e + 1 > file_size)
             break;
         int ln = read_u8(e, sf);
-        if (ln <= 0 || ln > DF_SHORT_NAME_MAX || e + 1 + ln > fsize)
+        if (ln <= 0 || ln > DF_SHORT_NAME_MAX || e + 1 + ln > file_size)
             continue;
         for (int k = 0; k < ln; k++)
-            names[id].name[k] = read_u8(e + 1 + k, sf);
-        names[id].name[ln] = '\0';
+            bank.names[id].name[k] = read_u8(e + 1 + k, sf);
+        bank.names[id].name[ln] = '\0';
     }
 
     /* track name */
     {
-        int tl = read_u8(c0 + DF_SND_TRACK_NAME, sf);
-        if (tl > 0 && tl <= DF_MOV_NAME_MAX && c0 + DF_SND_TRACK_NAME + 1 + tl <= fsize) {
+        int tl = read_u8(cfg->track_name, sf);
+        if (tl > 0 && tl <= DF_MOV_NAME_MAX && cfg->track_name + 1 + tl <= file_size) {
             for (int k = 0; k < tl; k++)
-                track_name[k] = read_u8(c0 + DF_SND_TRACK_NAME + 1 + k, sf);
-            track_name[tl] = '\0';
+                bank.track_name[k] = read_u8(cfg->track_name + 1 + k, sf);
+            bank.track_name[tl] = '\0';
         }
     }
 
     /* individual list: every valid audio chunk, kept (not folded) so each stays its own named subsong */
     for (int i = 0; i < containers; i++)
-        if (chunks[i].valid)
-            listed[listed_count++] = i;
+        if (bank.chunks[i].valid)
+            bank.audio_ids[bank.audio_count++] = i;
 
-    has_track = true;
-    subsongs = (has_track ? 1 : 0) + listed_count;
-    if (subsongs == 0)
-        goto fail;
-
-    target = sf->stream_index;
-    if (target == 0)
-        target = 1;
-    if (target < 0 || target > subsongs)
-        goto fail;
-
-    if (has_track && target == 1) {
-        /* subsong 1: assembled theme, leading/trailing silence trimmed, looped end-to-end */
-        int lo = 0, hi = order_count - 1;
-        while (lo <= hi && is_silent_chunk(sf, &chunks[seq[lo]]))
-            lo++;
-        while (hi >= lo && is_silent_chunk(sf, &chunks[seq[hi]]))
-            hi--;
-        if (lo > hi) { lo = 0; hi = order_count - 1; } /* all silent: keep so it isn't empty */
-
-        vgmstream = build_segmented(sf, chunks, seq + lo, hi - lo + 1, 1, 0);
-        if (!vgmstream)
-            goto fail;
-        set_stream_name(sf, vgmstream, track_name, target);
-    }
-    else {
-        int piece = target - (has_track ? 1 : 0); /* 1-based index into listed[] */
-        int id = listed[piece - 1];
-
-        vgmstream = allocate_vgmstream(1, 0);
-        if (!vgmstream)
-            goto fail;
-        config_chunk(vgmstream, &chunks[id]);
-        set_stream_name(sf, vgmstream, names[id].name, target);
-        if (!vgmstream_open_stream(vgmstream, sf, chunks[id].offset))
-            goto fail;
-    }
-
-    vgmstream->num_streams = subsongs;
-    free(chunks);
-    free(names);
-    free(seq);
-    free(listed);
+    vgmstream = build_bank_subsong(sf, &bank);
+    free_bank(&bank);
     return vgmstream;
 
 fail:
-    free(chunks);
-    free(names);
-    free(seq);
-    free(listed);
+    free_bank(&bank);
     close_vgmstream(vgmstream);
     return NULL;
 }
 
-VGMSTREAM* init_vgmstream_cf_df(STREAMFILE* sf) {
+static VGMSTREAM* build_cf_df_v1(STREAMFILE* sf, int containers, bool is_mov,
+        const df_v1_snd_config_t* snd_config) {
+    if (is_mov)
+        return build_cf_df_v1_mov(sf, containers);
+
+    return build_cf_df_v1_snd(sf, containers, snd_config);
+}
+
+static VGMSTREAM* build_cf_df_v4(STREAMFILE* sf, int containers, bool is_mov) {
     VGMSTREAM* vgmstream = NULL;
-    df_name_t* names = NULL;
-    int* audio_ids = NULL;
+    df_bank_t bank = {0};
     df_chunk_t* loop = NULL;
     int16_t* order = NULL;
-    int* seq = NULL;
     uint8_t* in_loop = NULL;
-    char track_name[STREAM_NAME_SIZE];
-
-    if (!check_extensions(sf, "snd,sfx,trk,mov,move,"))
-        return NULL;
-
-    int is_mov = check_extensions(sf, "mov,move");
-    int is_extensionless = check_extensions(sf, "");
-    if (is_mov || is_extensionless) {
-        int proto_containers;
-        bool proto_big_endian;
-        if (get_proto_config(sf, &proto_containers, &proto_big_endian))
-            return build_proto_resource(sf, proto_containers, proto_big_endian, is_mov);
-        if (is_extensionless)
-            return NULL;
-    }
-
-    if (read_u32le(0x04, sf) != get_streamfile_size(sf))
-        return NULL;
-    int containers = read_u32le(0x14, sf);
-    if (containers <= 0 || containers > INT16_MAX)
-        return NULL;
-    if (DF_HEADER_SIZE + (off_t)containers * 0x04 > get_streamfile_size(sf))
-        return NULL;
-
-    int has_lppa = is_id32be(0x20, sf, "LPPA") && is_id32be(0x24, sf, "LPPA");
-    if (is_mov && get_mov_control_revision(sf) == DF_MOV_CONTROL_REVISION_1)
-        return build_revision1_mov(sf, containers);
-    if (!has_lppa)
-        return NULL;
-
-    /* Most .snd files store the theme in container 0.
-     * A few rare .snd files may instead use a container 1 loop block
-     * and instead fall through to the shared path below. */
-    if (check_extensions(sf, "snd")) {
-        int handled = 0;
-        vgmstream = build_snd_c0(sf, containers, &handled);
-        if (handled)
-            return vgmstream;
-    }
 
     int loop_track = check_extensions(sf, "sfx,snd,trk");
     int target = sf->stream_index;
     if (target == 0)
         target = 1;
-    track_name[0] = '\0';
 
     // definitions before 'goto fail'
     int loop_count, order_count, loop_block_id;
     off_t first_entry, c1, c0;
-    int audio_count, disk_stream;
-    int has_loop, subsongs;
+    int disk_stream;
 
-    names = calloc(containers, sizeof(*names));
-    audio_ids = malloc(containers * sizeof(int));
-    if (!names || !audio_ids)
+    if (!init_bank(&bank, containers, true))
         goto fail;
 
     /* --- loop block (container 1): chunkOrder + loop chunk list --- */
@@ -1018,9 +925,13 @@ VGMSTREAM* init_vgmstream_cf_df(STREAMFILE* sf) {
             for (int i = 0; i < lc; i++) {
                 int id = read_u16le(e + 0x04, sf);
                 if (id >= 0 && id < containers)
-                    read_name(sf, e, DF_SHORT_NAME_MAX, &names[id]);
-                if (!is_valid_chunk(sf, containers, id, &loop[i]))
+                    read_name(sf, e, DF_SHORT_NAME_MAX, &bank.names[id]);
+                if (!is_valid_chunk(sf, containers, id, &loop[i])) {
                     all_valid = 0;
+                }
+                else {
+                    bank.chunks[id] = loop[i];
+                }
                 e += DF_LOOP_ENTRY;
             }
             if (all_valid)
@@ -1049,8 +960,8 @@ VGMSTREAM* init_vgmstream_cf_df(STREAMFILE* sf) {
             int tl = read_u8(p0 + 0x24, sf);
             if (tl > 0 && tl <= DF_MOV_NAME_MAX) {
                 for (int k = 0; k < tl; k++)
-                    track_name[k] = read_u8(p0 + 0x25 + k, sf);
-                track_name[tl] = '\0';
+                    bank.track_name[k] = read_u8(p0 + 0x25 + k, sf);
+                bank.track_name[tl] = '\0';
             }
         }
 
@@ -1067,7 +978,7 @@ VGMSTREAM* init_vgmstream_cf_df(STREAMFILE* sf) {
                     for (int i = 0; i < count; i++) {
                         int id = read_u32le(e + 0x04, sf);
                         if (id >= 0 && id < containers)
-                            read_name(sf, e, name_max, &names[id]);
+                            read_name(sf, e, name_max, &bank.names[id]);
                         e += stride;
                     }
                 }
@@ -1075,96 +986,129 @@ VGMSTREAM* init_vgmstream_cf_df(STREAMFILE* sf) {
         }
     }
 
-    audio_count = 0;
     for (int i = 0; i < containers; i++) {
         if (in_loop && in_loop[i])
             continue;
-        df_chunk_t tmp;
-        if (is_valid_chunk(sf, containers, i, &tmp))
-            audio_ids[audio_count++] = i;
+        if (is_valid_chunk(sf, containers, i, &bank.chunks[i]))
+            bank.audio_ids[bank.audio_count++] = i;
     }
 
-    has_loop = (loop_count > 0);
-    subsongs = (has_loop ? 1 : 0) + audio_count;
-    if (subsongs == 0)
-        goto fail;
-    if (target < 0 || target > subsongs)
-        goto fail;
+    if (loop_count > 0) {
+        bool blocked_stream = disk_stream && loop[0].codec_flag == DF_CODEC_V41;
+        int use_order = order_count > 0;
+        int sequence_count;
 
-    if (has_loop && target == 1) {
-        /* subsong 1: the assembled track */
-        if (disk_stream && loop[0].codec_flag == 2) {
-            /* scattered stream of v4.1 blocks -> blocked layout */
-            vgmstream = build_blocked(sf, loop, loop_count, first_entry);
-        } else {
-            /* follow chunkOrder if usable, else play loop chunks in list order */
-            int use_order = (order_count > 0);
-            for (int i = 0; use_order && i < order_count; i++) {
-                int idx = order[i] - 1;
-                if (idx < 0 || idx >= loop_count)
-                    use_order = 0;
-            }
-            int count = use_order ? order_count : loop_count;
-            seq = malloc(count * sizeof(int));
-            if (!seq) goto fail;
-            for (int i = 0; i < count; i++)
-                seq[i] = use_order ? (order[i] - 1) : i;
-            /* CF_DF silence trim: drop leading/trailing fully-silent steps (the LOGO/OCREDITS
-             * cascades are silent chunks repeated at the ends) but keep interspersed silence.
-             * Force lo=0 / hi=count-1 to disable. */
-            int lo = 0, hi = count - 1;
-            while (lo <= hi && is_silent_chunk(sf, &loop[seq[lo]]))
-                lo++;
-            while (hi >= lo && is_silent_chunk(sf, &loop[seq[hi]]))
-                hi--;
-            if (lo > hi) { /* degenerate all-silent track: keep unfiltered so subsong 1 isn't empty */
-                lo = 0;
-                hi = count - 1;
-            }
-            vgmstream = build_segmented(sf, loop, seq + lo, hi - lo + 1, loop_track, 0);
+        for (int i = 0; use_order && i < order_count; i++) {
+            int index = order[i] - 1;
+            if (index < 0 || index >= loop_count)
+                use_order = false;
         }
-        if (!vgmstream)
-            goto fail;
 
-        set_stream_name(sf, vgmstream,
-                !is_mov ? track_name : NULL, target);
-    } else {
-        /* subsongs 2..N (or 1..N when no loop block): individual audio pieces */
-        int piece = target - (has_loop ? 1 : 0);
-        int id = audio_ids[piece - 1];
-        df_chunk_t c;
+        sequence_count = use_order ? order_count : loop_count;
+        if (!blocked_stream) {
+            bank.playlist.sequence = malloc((size_t)sequence_count * sizeof(*bank.playlist.sequence));
+            if (!bank.playlist.sequence)
+                goto fail;
 
-        if (!is_valid_chunk(sf, containers, id, &c))
-            goto fail;
+            for (int i = 0; i < sequence_count; i++) {
+                int index = use_order ? order[i] - 1 : i;
+                bank.playlist.sequence[i] = loop[index].container_id;
+            }
+            bank.playlist.count = sequence_count;
+            bank.playlist.loop = loop_track;
+        }
+        bank.has_playlist = true;
 
-        vgmstream = allocate_vgmstream(1, 0);
-        if (!vgmstream)
-            goto fail;
-
-        config_chunk(vgmstream, &c);
-        set_stream_name(sf, vgmstream, names[id].name, target);
-
-        if (!vgmstream_open_stream(vgmstream, sf, c.offset))
-            goto fail;
+        if (blocked_stream && target == 1) {
+            vgmstream = build_blocked(sf, loop, loop_count, first_entry);
+            if (!vgmstream)
+                goto fail;
+            set_stream_name(sf, vgmstream,
+                    !is_mov ? bank.track_name : NULL, target);
+            vgmstream->num_streams = 1 + bank.audio_count;
+        }
+        else {
+            vgmstream = build_bank_subsong(sf, &bank);
+        }
+    }
+    else {
+        vgmstream = build_bank_subsong(sf, &bank);
     }
 
-    vgmstream->num_streams = subsongs;
-
-    free(names);
-    free(audio_ids);
+    free_bank(&bank);
     free(loop);
     free(order);
-    free(seq);
     free(in_loop);
     return vgmstream;
 
 fail:
-    free(names);
-    free(audio_ids);
+    free_bank(&bank);
     free(loop);
     free(order);
-    free(seq);
     free(in_loop);
     close_vgmstream(vgmstream);
     return NULL;
+}
+
+VGMSTREAM* init_vgmstream_cf_df(STREAMFILE* sf) {
+    df_version_t version = DF_VERSION_NONE;
+    df_v1_snd_config_t snd_config = {0};
+    int containers = 0;
+    bool is_mov;
+    bool proto_big_endian = false;
+    bool is_extensionless;
+
+    if (!check_extensions(sf, "snd,sfx,trk,mov,move,"))
+        return NULL;
+
+    is_mov = check_extensions(sf, "mov,move");
+    is_extensionless = check_extensions(sf, ""); //Proto has banked music!
+
+    /* Proto has no LPPALPPA marker and may be native little- or big-endian.
+     * Extensionless files are admitted only after this complete header check. */
+    if (is_mov || is_extensionless) {
+        if (get_proto_config(sf, &containers, &proto_big_endian)) {
+            version = DF_VERSION_PROTO;
+        }
+        else if (is_extensionless) {
+            return NULL;
+        }
+    }
+
+    if (version == DF_VERSION_NONE) {
+        if (read_u32le(0x04, sf) != get_streamfile_size(sf))
+            return NULL;
+
+        containers = read_u32le(0x14, sf);
+        if (containers <= 0 || containers > INT16_MAX)
+            return NULL;
+        if (DF_HEADER_SIZE + (off_t)containers * 0x04 > get_streamfile_size(sf))
+            return NULL;
+
+        if (is_mov && get_mov_control_revision(sf) == DF_MOV_CONTROL_REVISION_1) {
+            version = DF_VERSION_1;
+        }
+        else {
+            if (!(is_id32be(0x20, sf, "LPPA") && is_id32be(0x24, sf, "LPPA")))
+                return NULL;
+
+            /* V1 .snd and V4 share the later envelope. Prefer the structural
+             * V1 container-0 playlist, then use the V4 loop-block model. */
+            if (check_extensions(sf, "snd") && get_v1_snd_config(sf, containers, &snd_config))
+                version = DF_VERSION_1;
+            else
+                version = DF_VERSION_4;
+        }
+    }
+
+    switch (version) {
+        case DF_VERSION_PROTO:
+            return build_cf_df_proto(sf, containers, proto_big_endian, is_mov);
+        case DF_VERSION_1:
+            return build_cf_df_v1(sf, containers, is_mov, &snd_config);
+        case DF_VERSION_4:
+            return build_cf_df_v4(sf, containers, is_mov);
+        default:
+            return NULL;
+    }
 }


### PR DESCRIPTION
1. Fix df_decoder on some earlier versions
2. Add support for older DreamFactory titles

[Samples](https://files.catbox.moe/gi8g6v.zip)
[Logs](https://files.catbox.moe/21tt2r.zip)